### PR TITLE
fix strong text in example

### DIFF
--- a/src/lib-dev/typography/template.html
+++ b/src/lib-dev/typography/template.html
@@ -15,7 +15,7 @@
 
     <br>
 
-    <div class="mc-body_bold">Body bold</div>
+    <div class="mc-body_strong">Body strong</div>
     <div class="mc-body_caps">BODY CAPS</div>
     <div class="mc-body_mono">Body mono</div>
 


### PR DESCRIPTION
У нас был сломан жирный текст в примере, использовался класс, которого не было.

Вот.