### PR TITLE
fix(progress-spinner) add module export

### DIFF
--- a/src/lib/public-api.ts
+++ b/src/lib/public-api.ts
@@ -9,3 +9,4 @@ export * from '@ptsecurity/mosaic/radio';
 export * from '@ptsecurity/mosaic/list';
 export * from '@ptsecurity/mosaic/checkbox';
 export * from '@ptsecurity/mosaic/progress-bar';
+export * from '@ptsecurity/mosaic/progress-spinner';


### PR DESCRIPTION
Forget to add progress-spinner module to library export