### PR TITLE
chore: added plugin tslint-language-service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
             "integrity": "sha512-1Es9oNpabOukutBe+0txXUHyhI6ypuc7WrxTutZH7Lr3n3+CTG6oEv42rOcot1aXi1n97wNqcdY3lrENFu9vhQ==",
             "dev": true,
             "requires": {
-                "ajv": "6.4.0",
-                "chokidar": "2.0.4",
-                "rxjs": "6.0.0",
-                "source-map": "0.5.7"
+                "ajv": "~6.4.0",
+                "chokidar": "^2.0.3",
+                "rxjs": "^6.0.0",
+                "source-map": "^0.5.6"
             },
             "dependencies": {
                 "ajv": {
@@ -22,10 +22,10 @@
                     "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
                     "dev": true,
                     "requires": {
-                        "fast-deep-equal": "1.1.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1",
-                        "uri-js": "3.0.2"
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0",
+                        "uri-js": "^3.0.2"
                     }
                 },
                 "anymatch": {
@@ -34,8 +34,8 @@
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "3.1.10",
-                        "normalize-path": "2.1.1"
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
                     }
                 },
                 "arr-diff": {
@@ -56,16 +56,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -74,7 +74,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -85,19 +85,19 @@
                     "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "2.0.0",
-                        "async-each": "1.0.1",
-                        "braces": "2.3.2",
-                        "fsevents": "1.2.4",
-                        "glob-parent": "3.1.0",
-                        "inherits": "2.0.3",
-                        "is-binary-path": "1.0.1",
-                        "is-glob": "4.0.0",
-                        "lodash.debounce": "4.0.8",
-                        "normalize-path": "2.1.1",
-                        "path-is-absolute": "1.0.1",
-                        "readdirp": "2.1.0",
-                        "upath": "1.1.0"
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.0",
+                        "braces": "^2.3.0",
+                        "fsevents": "^1.2.2",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.1",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "lodash.debounce": "^4.0.8",
+                        "normalize-path": "^2.1.1",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.0.0",
+                        "upath": "^1.0.5"
                     }
                 },
                 "expand-brackets": {
@@ -106,13 +106,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -121,7 +121,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -130,7 +130,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -139,7 +139,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -148,7 +148,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -159,7 +159,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -168,7 +168,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -179,9 +179,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -198,14 +198,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -214,7 +214,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -223,7 +223,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -240,10 +240,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -252,7 +252,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -263,8 +263,8 @@
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
                     },
                     "dependencies": {
                         "is-glob": {
@@ -273,7 +273,7 @@
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "requires": {
-                                "is-extglob": "2.1.1"
+                                "is-extglob": "^2.1.0"
                             }
                         }
                     }
@@ -284,7 +284,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -293,7 +293,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -302,9 +302,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-extglob": {
@@ -319,7 +319,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 },
                 "is-number": {
@@ -328,7 +328,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -337,7 +337,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -366,19 +366,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 },
                 "source-map": {
@@ -393,7 +393,7 @@
                     "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
                     "dev": true,
                     "requires": {
-                        "punycode": "2.1.1"
+                        "punycode": "^2.1.0"
                     }
                 }
             }
@@ -403,7 +403,7 @@
             "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-6.0.0.tgz",
             "integrity": "sha512-jl3WZmM/csNeyzdb1cEEc5cUX7jLn3NvPYEiP/ZkKmib0XBGIGBBv7xiuoivTJFJsE4/N5sCFEHRFLnuBBE+OA==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "@angular/common": {
@@ -411,7 +411,7 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-6.0.0.tgz",
             "integrity": "sha512-oo/KESihAZo0FsZPHthO9PYhanN4Q+Lo7Lb2HNbWnD+xRIPa1yFC12JOWiD+SPPfFGWMI6aW3wAlcoej1+QKSw==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "@angular/compiler": {
@@ -419,7 +419,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-6.0.0.tgz",
             "integrity": "sha512-UsYfsvHf4VVtkhzM7tyabh8co7gqWZTm3p79hbLDeyCEojl0AkrwbSgh0DQnKRxp4Tu3DEeeDkg1ahA7n19I8A==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "@angular/compiler-cli": {
@@ -428,10 +428,10 @@
             "integrity": "sha512-RV0xTSTPT3yOnbS5Gx6lMAETQeTUr72Ifu0+JZh9AV07xGVislZ+SdQGSeNgXoqxise6e65lJp3Nrb5KE4Lv6g==",
             "dev": true,
             "requires": {
-                "chokidar": "1.7.0",
-                "minimist": "1.2.0",
-                "reflect-metadata": "0.1.12",
-                "tsickle": "0.27.5"
+                "chokidar": "^1.4.2",
+                "minimist": "^1.2.0",
+                "reflect-metadata": "^0.1.2",
+                "tsickle": "^0.27.2"
             }
         },
         "@angular/core": {
@@ -439,7 +439,7 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-6.0.0.tgz",
             "integrity": "sha512-52X2ZKXOoaMRYaC/ycHePTkXuwku8qJFxoEXAFBItAkk9rebLU4CD8Fx1Z9vUd8aWu1uFfLTxqkgE0mUyBANZw==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "@angular/elements": {
@@ -447,7 +447,7 @@
             "resolved": "https://registry.npmjs.org/@angular/elements/-/elements-6.0.0.tgz",
             "integrity": "sha512-Jp26Suu7XRrS25qS1CMDo0IFmIJQIl/ahvOE+vY7Xv9/OEGGaRvkF2aUaWyrhuFdXir+xMQGnhTCd6NeJM9VRg==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "@angular/forms": {
@@ -455,7 +455,7 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-6.0.0.tgz",
             "integrity": "sha512-4eVfCcSyPRhml7Xa6ia/DgDl3JhOnEdBdHo+jads1YL5AF6D08Tthngjf3KjuctGqZDACPyxNt6ciX4g8IbGCA==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "@angular/http": {
@@ -464,7 +464,7 @@
             "integrity": "sha512-nBZ4KmXx0KR+cIPOMBsJpPhcec5wSCbVtTYRH0zTxmzTmqM3g6+i0PECpqbVgcQEGiOxBLcmXNWfXZl5czpiqw==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "@angular/platform-browser": {
@@ -472,7 +472,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-6.0.0.tgz",
             "integrity": "sha512-ExI1o40BJIbJKFz1p1ivGSgLA1+T0uUo8rjheOZhcGDwCNx54/RapCFLdcHCNiW8NzAIzx+kt4DdXnCSKitnDA==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "@angular/platform-browser-dynamic": {
@@ -481,7 +481,7 @@
             "integrity": "sha512-yk4wZYn2bosuvDaYaEq6UuEeI966/28uCljm5iBfo3l8Vuv2IChk5664M68O6C+KwWzCCWDHvIqm0q178YUYug==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "@angular/platform-server": {
@@ -490,9 +490,9 @@
             "integrity": "sha512-1dmaM3xpayBdZrkpmhPfpJ1CDNntxlizL1td2DMRUfFqMNyE7acbc7vRuV9BOgniPGsMKphYQXczERNfoVeuSw==",
             "dev": true,
             "requires": {
-                "domino": "2.0.3",
-                "tslib": "1.9.3",
-                "xhr2": "0.1.4"
+                "domino": "^2.0.1",
+                "tslib": "^1.9.0",
+                "xhr2": "^0.1.4"
             }
         },
         "@angular/router": {
@@ -501,25 +501,25 @@
             "integrity": "sha512-ONrfgfYmFGz0Ht2MvymMvBMxPI9w5037ZfJWpTu1/Xo1XmVOawzj2SvYfEzTqexznWcTAALggq/A23k8r9ArKA==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "@commitlint/cli": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/cli/-/cli-7.0.0.tgz",
             "integrity": "sha1-O/htirL71QdMMRS3uj9LQbd189w=",
             "dev": true,
             "requires": {
-                "@commitlint/format": "7.0.0",
-                "@commitlint/lint": "7.0.0",
-                "@commitlint/load": "7.0.0",
-                "@commitlint/read": "7.0.0",
+                "@commitlint/format": "^7.0.0",
+                "@commitlint/lint": "^7.0.0",
+                "@commitlint/load": "^7.0.0",
+                "@commitlint/read": "^7.0.0",
                 "babel-polyfill": "6.26.0",
                 "chalk": "2.3.1",
                 "get-stdin": "5.0.1",
                 "lodash.merge": "4.6.1",
                 "lodash.pick": "4.4.0",
-                "meow": "5.0.0"
+                "meow": "^5.0.0"
             },
             "dependencies": {
                 "chalk": {
@@ -528,22 +528,22 @@
                     "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "3.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "supports-color": "5.4.0"
+                        "ansi-styles": "^3.2.0",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.2.0"
                     }
                 }
             }
         },
         "@commitlint/config-conventional": {
             "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-7.0.1.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/config-conventional/-/config-conventional-7.0.1.tgz",
             "integrity": "sha1-J2l3+O5g2MVtf91DKWr3bf7ptfc=",
             "dev": true
         },
         "@commitlint/ensure": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/ensure/-/ensure-7.0.0.tgz",
             "integrity": "sha1-PVIQu5iEFoRJJolaeCpVgVcxd50=",
             "dev": true,
             "requires": {
@@ -556,7 +556,7 @@
         },
         "@commitlint/execute-rule": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/execute-rule/-/execute-rule-7.0.0.tgz",
             "integrity": "sha1-y8ZTFPqeu5zSxbjN1NymGFs6ykw=",
             "dev": true,
             "requires": {
@@ -565,17 +565,17 @@
         },
         "@commitlint/format": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/format/-/format-7.0.0.tgz",
             "integrity": "sha1-O+H98MPEH+uY4nW09gXFmMUJuSA=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "chalk": "2.4.1"
+                "babel-runtime": "^6.23.0",
+                "chalk": "^2.0.1"
             }
         },
         "@commitlint/is-ignored": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/is-ignored/-/is-ignored-7.0.0.tgz",
             "integrity": "sha1-0yiil2J0yfEG4xmxysdd2Eg2D8k=",
             "dev": true,
             "requires": {
@@ -584,27 +584,27 @@
         },
         "@commitlint/lint": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/lint/-/lint-7.0.0.tgz",
             "integrity": "sha1-rt6eFfVRuCKvfZ2lXfSIGtODkNk=",
             "dev": true,
             "requires": {
-                "@commitlint/is-ignored": "7.0.0",
-                "@commitlint/parse": "7.0.0",
-                "@commitlint/rules": "7.0.0",
-                "babel-runtime": "6.26.0",
+                "@commitlint/is-ignored": "^7.0.0",
+                "@commitlint/parse": "^7.0.0",
+                "@commitlint/rules": "^7.0.0",
+                "babel-runtime": "^6.23.0",
                 "lodash.topairs": "4.3.0"
             }
         },
         "@commitlint/load": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/load/-/load-7.0.0.tgz",
             "integrity": "sha1-2ST0xcBtiEWxalC1Y4Kaf/+iMKg=",
             "dev": true,
             "requires": {
-                "@commitlint/execute-rule": "7.0.0",
-                "@commitlint/resolve-extends": "7.0.0",
-                "babel-runtime": "6.26.0",
-                "cosmiconfig": "4.0.0",
+                "@commitlint/execute-rule": "^7.0.0",
+                "@commitlint/resolve-extends": "^7.0.0",
+                "babel-runtime": "^6.23.0",
+                "cosmiconfig": "^4.0.0",
                 "lodash.merge": "4.6.1",
                 "lodash.mergewith": "4.6.1",
                 "lodash.pick": "4.4.0",
@@ -614,71 +614,71 @@
         },
         "@commitlint/message": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/message/-/message-7.0.0.tgz",
             "integrity": "sha1-b7IlY+MZAf9dpDkdsTRv2nEV+lM=",
             "dev": true
         },
         "@commitlint/parse": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/parse/-/parse-7.0.0.tgz",
             "integrity": "sha1-7QJMxNjwh0QhqN1tFmdCM7aFktQ=",
             "dev": true,
             "requires": {
-                "conventional-changelog-angular": "1.6.6",
-                "conventional-commits-parser": "2.1.7"
+                "conventional-changelog-angular": "^1.3.3",
+                "conventional-commits-parser": "^2.1.0"
             }
         },
         "@commitlint/read": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/read/-/read-7.0.0.tgz",
             "integrity": "sha1-yb8iLjfgTDPB4ltJhlf+9oN34sg=",
             "dev": true,
             "requires": {
-                "@commitlint/top-level": "7.0.0",
-                "@marionebl/sander": "0.6.1",
-                "babel-runtime": "6.26.0",
-                "git-raw-commits": "1.3.6"
+                "@commitlint/top-level": "^7.0.0",
+                "@marionebl/sander": "^0.6.0",
+                "babel-runtime": "^6.23.0",
+                "git-raw-commits": "^1.3.0"
             }
         },
         "@commitlint/resolve-extends": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/resolve-extends/-/resolve-extends-7.0.0.tgz",
             "integrity": "sha1-NJN1Jeo7wDc2XFMLzpscc+9Ot00=",
             "dev": true,
             "requires": {
                 "babel-runtime": "6.26.0",
                 "lodash.merge": "4.6.1",
                 "lodash.omit": "4.5.0",
-                "require-uncached": "1.0.3",
-                "resolve-from": "4.0.0",
-                "resolve-global": "0.1.0"
+                "require-uncached": "^1.0.3",
+                "resolve-from": "^4.0.0",
+                "resolve-global": "^0.1.0"
             }
         },
         "@commitlint/rules": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/rules/-/rules-7.0.0.tgz",
             "integrity": "sha1-mnEIkcNQwQ1vYt67gg/uT97x4CY=",
             "dev": true,
             "requires": {
-                "@commitlint/ensure": "7.0.0",
-                "@commitlint/message": "7.0.0",
-                "@commitlint/to-lines": "7.0.0",
-                "babel-runtime": "6.26.0"
+                "@commitlint/ensure": "^7.0.0",
+                "@commitlint/message": "^7.0.0",
+                "@commitlint/to-lines": "^7.0.0",
+                "babel-runtime": "^6.23.0"
             }
         },
         "@commitlint/to-lines": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/to-lines/-/to-lines-7.0.0.tgz",
             "integrity": "sha1-rbIpNo4rbHplfJCXVPtA7Ec2POI=",
             "dev": true
         },
         "@commitlint/top-level": {
             "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-7.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/top-level/-/top-level-7.0.0.tgz",
             "integrity": "sha1-/yhYCrjBQxKQ43sdUH4O83DDjZk=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
             }
         },
         "@marionebl/sander": {
@@ -687,9 +687,9 @@
             "integrity": "sha1-GViWWHTyS8Ub5Ih1/rUNZC/EH3s=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.3",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.2"
             }
         },
         "@mrmlnc/readdir-enhanced": {
@@ -698,8 +698,8 @@
             "integrity": "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==",
             "dev": true,
             "requires": {
-                "call-me-maybe": "1.0.1",
-                "glob-to-regexp": "0.3.0"
+                "call-me-maybe": "^1.0.1",
+                "glob-to-regexp": "^0.3.0"
             }
         },
         "@ngtools/webpack": {
@@ -709,9 +709,9 @@
             "dev": true,
             "requires": {
                 "@angular-devkit/core": "0.7.2",
-                "rxjs": "6.0.0",
-                "tree-kill": "1.2.0",
-                "webpack-sources": "1.1.0"
+                "rxjs": "^6.0.0",
+                "tree-kill": "^1.0.0",
+                "webpack-sources": "^1.1.0"
             }
         },
         "@nodelib/fs.stat": {
@@ -743,11 +743,11 @@
             "integrity": "sha512-GOo6hfoc3dmRXT+Rt0sEo8AWmNh6B8J4oLI5jRJ2z+Zr4fUPLtGufX85ol6PTIQcqpxdos+BdSiJPNoGUY+XrA==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.3",
-                "tslint": "5.11.0",
-                "tslint-eslint-rules": "5.3.1",
-                "tslint-microsoft-contrib": "5.2.0",
-                "tsutils": "2.29.0"
+                "tslib": "^1.9.3",
+                "tslint": "^5.11.0",
+                "tslint-eslint-rules": "^5.3.1",
+                "tslint-microsoft-contrib": "^5.1.0",
+                "tsutils": "^2.29.0"
             }
         },
         "@samverschueren/stream-to-observable": {
@@ -756,7 +756,7 @@
             "integrity": "sha512-MI4Xx6LHs4Webyvi6EbspgyAb4D2Q2VtnCQ1blOJcoLS6mVa8lNN2rkIy1CVxfTUpoyIbCTkXES1rLXztFD1lg==",
             "dev": true,
             "requires": {
-                "any-observable": "0.3.0"
+                "any-observable": "^0.3.0"
             }
         },
         "@types/chalk": {
@@ -765,7 +765,7 @@
             "integrity": "sha512-1zzPV9FDe1I/WHhRkf9SNgqtRJWZqrBWgu7JGveuHmmyR9CnAPCie2N/x+iHrgnpYBIcCJWHBoMRv2TRWktsvw==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1"
+                "chalk": "*"
             }
         },
         "@types/events": {
@@ -780,7 +780,7 @@
             "integrity": "sha512-DsknoBvD8s+RFfSGjmERJ7ZOP1HI0UZRA3FSI+Zakhrc/Gy26YQsLI+m5V5DHxroHRJqCDLKJp7Hixn8zyaF7g==",
             "dev": true,
             "requires": {
-                "@types/node": "8.9.5"
+                "@types/node": "*"
             }
         },
         "@types/glob": {
@@ -789,9 +789,9 @@
             "integrity": "sha512-wc+VveszMLyMWFvXLkloixT4n0harUIVZjnpzztaZ0nKLuul7Z32iMt2fUFGAaZ4y1XWjFRMtCI5ewvyh4aIeg==",
             "dev": true,
             "requires": {
-                "@types/events": "1.2.0",
-                "@types/minimatch": "3.0.3",
-                "@types/node": "8.9.5"
+                "@types/events": "*",
+                "@types/minimatch": "*",
+                "@types/node": "*"
             }
         },
         "@types/jasmine": {
@@ -824,18 +824,18 @@
             "integrity": "sha1-WY/JSla67ZdfGUV04PVy/Y5iekg=",
             "dev": true,
             "requires": {
-                "@types/rx-core": "4.0.3",
-                "@types/rx-core-binding": "4.0.4",
-                "@types/rx-lite": "4.0.5",
-                "@types/rx-lite-aggregates": "4.0.3",
-                "@types/rx-lite-async": "4.0.2",
-                "@types/rx-lite-backpressure": "4.0.3",
-                "@types/rx-lite-coincidence": "4.0.3",
-                "@types/rx-lite-experimental": "4.0.1",
-                "@types/rx-lite-joinpatterns": "4.0.1",
-                "@types/rx-lite-testing": "4.0.1",
-                "@types/rx-lite-time": "4.0.3",
-                "@types/rx-lite-virtualtime": "4.0.3"
+                "@types/rx-core": "*",
+                "@types/rx-core-binding": "*",
+                "@types/rx-lite": "*",
+                "@types/rx-lite-aggregates": "*",
+                "@types/rx-lite-async": "*",
+                "@types/rx-lite-backpressure": "*",
+                "@types/rx-lite-coincidence": "*",
+                "@types/rx-lite-experimental": "*",
+                "@types/rx-lite-joinpatterns": "*",
+                "@types/rx-lite-testing": "*",
+                "@types/rx-lite-time": "*",
+                "@types/rx-lite-virtualtime": "*"
             }
         },
         "@types/rx-core": {
@@ -850,7 +850,7 @@
             "integrity": "sha512-5pkfxnC4w810LqBPUwP5bg7SFR/USwhMSaAeZQQbEHeBp57pjKXRlXmqpMrLJB4y1oglR/c2502853uN0I+DAQ==",
             "dev": true,
             "requires": {
-                "@types/rx-core": "4.0.3"
+                "@types/rx-core": "*"
             }
         },
         "@types/rx-lite": {
@@ -859,8 +859,8 @@
             "integrity": "sha512-KZk5XTR1dm/kNgBx8iVpjno6fRYtAUQWBOmj+O8j724+nk097sz4fOoHJNpCkOJUtHUurZlJC7QvSFCZHbkC+w==",
             "dev": true,
             "requires": {
-                "@types/rx-core": "4.0.3",
-                "@types/rx-core-binding": "4.0.4"
+                "@types/rx-core": "*",
+                "@types/rx-core-binding": "*"
             }
         },
         "@types/rx-lite-aggregates": {
@@ -869,7 +869,7 @@
             "integrity": "sha512-MAGDAHy8cRatm94FDduhJF+iNS5//jrZ/PIfm+QYw9OCeDgbymFHChM8YVIvN2zArwsRftKgE33QfRWvQk4DPg==",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-async": {
@@ -878,7 +878,7 @@
             "integrity": "sha512-vTEv5o8l6702ZwfAM5aOeVDfUwBSDOs+ARoGmWAKQ6LOInQ8J4/zjM7ov12fuTpktUKdMQjkeCp07Vd73mPkxw==",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-backpressure": {
@@ -887,7 +887,7 @@
             "integrity": "sha512-Y6aIeQCtNban5XSAF4B8dffhIKu6aAy/TXFlScHzSxh6ivfQBQw6UjxyEJxIOt3IT49YkS+siuayM2H/Q0cmgA==",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-coincidence": {
@@ -896,7 +896,7 @@
             "integrity": "sha512-1VNJqzE9gALUyMGypDXZZXzR0Tt7LC9DdAZQ3Ou/Q0MubNU35agVUNXKGHKpNTba+fr8GdIdkC26bRDqtCQBeQ==",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-experimental": {
@@ -905,7 +905,7 @@
             "integrity": "sha1-xTL1y98/LBXaFt7Ykw0bKYQCPL0=",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-joinpatterns": {
@@ -914,7 +914,7 @@
             "integrity": "sha1-9w/jcFGKhDLykVjMkv+1a05K/D4=",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-testing": {
@@ -923,7 +923,7 @@
             "integrity": "sha1-IbGdEfTf1v/vWp0WSOnIh5v+Iek=",
             "dev": true,
             "requires": {
-                "@types/rx-lite-virtualtime": "4.0.3"
+                "@types/rx-lite-virtualtime": "*"
             }
         },
         "@types/rx-lite-time": {
@@ -932,7 +932,7 @@
             "integrity": "sha512-ukO5sPKDRwCGWRZRqPlaAU0SKVxmWwSjiOrLhoQDoWxZWg6vyB9XLEZViKOzIO6LnTIQBlk4UylYV0rnhJLxQw==",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/rx-lite-virtualtime": {
@@ -941,7 +941,7 @@
             "integrity": "sha512-3uC6sGmjpOKatZSVHI2xB1+dedgml669ZRvqxy+WqmGJDVusOdyxcKfyzjW0P3/GrCiN4nmRkLVMhPwHCc5QLg==",
             "dev": true,
             "requires": {
-                "@types/rx-lite": "4.0.5"
+                "@types/rx-lite": "*"
             }
         },
         "@types/source-map": {
@@ -950,7 +950,7 @@
             "integrity": "sha512-LrnsgZIfJaysFkv9rRJp4/uAyqw87oVed3s1hhF83nwbo9c7MG9g5DqR0seHP+lkX4ldmMrVolPjQSe2ZfD0yA==",
             "dev": true,
             "requires": {
-                "source-map": "0.6.1"
+                "source-map": "*"
             }
         },
         "@types/strip-bom": {
@@ -977,7 +977,7 @@
             "integrity": "sha512-MAT0BW2ruO0LhQKjvlipLGCF/Yx0y/cj+tT67tK3QIQDrM2+9R78HgJ54VlrE8AbfjYJJBCQCEPM5ZblPVTuww==",
             "dev": true,
             "requires": {
-                "source-map": "0.6.1"
+                "source-map": "^0.6.1"
             }
         },
         "@types/webpack": {
@@ -986,10 +986,10 @@
             "integrity": "sha512-LjZ4g7ONxDfpZ7Etf2S7DDw7CDvhZAst5q3eDGceTEfiWv1gq+CPozeeW+kDzYj1BXpfeHFvhoomzA3f4d1ftw==",
             "dev": true,
             "requires": {
-                "@types/node": "8.9.5",
-                "@types/tapable": "1.0.4",
-                "@types/uglify-js": "3.0.3",
-                "source-map": "0.6.1"
+                "@types/node": "*",
+                "@types/tapable": "*",
+                "@types/uglify-js": "*",
+                "source-map": "^0.6.0"
             }
         },
         "@webassemblyjs/ast": {
@@ -1001,8 +1001,8 @@
                 "@webassemblyjs/helper-module-context": "1.5.13",
                 "@webassemblyjs/helper-wasm-bytecode": "1.5.13",
                 "@webassemblyjs/wast-parser": "1.5.13",
-                "debug": "3.1.0",
-                "mamacro": "0.0.3"
+                "debug": "^3.1.0",
+                "mamacro": "^0.0.3"
             },
             "dependencies": {
                 "debug": {
@@ -1034,7 +1034,7 @@
             "integrity": "sha512-v7igWf1mHcpJNbn4m7e77XOAWXCDT76Xe7Is1VQFXc4K5jRcFrl9D0NrqM4XifQ0bXiuTSkTKMYqDxu5MhNljA==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0"
+                "debug": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -1069,8 +1069,8 @@
             "integrity": "sha512-zxJXULGPLB7r+k+wIlvGlXpT4CYppRz8fLUM/xobGHc9Z3T6qlmJD9ySJ2jknuktuuiR9AjnNpKYDECyaiX+QQ==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "mamacro": "0.0.3"
+                "debug": "^3.1.0",
+                "mamacro": "^0.0.3"
             },
             "dependencies": {
                 "debug": {
@@ -1100,7 +1100,7 @@
                 "@webassemblyjs/helper-buffer": "1.5.13",
                 "@webassemblyjs/helper-wasm-bytecode": "1.5.13",
                 "@webassemblyjs/wasm-gen": "1.5.13",
-                "debug": "3.1.0"
+                "debug": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -1120,7 +1120,7 @@
             "integrity": "sha512-TseswvXEPpG5TCBKoLx9tT7+/GMACjC1ruo09j46ULRZWYm8XHpDWaosOjTnI7kr4SRJFzA6MWoUkAB+YCGKKg==",
             "dev": true,
             "requires": {
-                "ieee754": "1.1.12"
+                "ieee754": "^1.1.11"
             }
         },
         "@webassemblyjs/leb128": {
@@ -1160,7 +1160,7 @@
                 "@webassemblyjs/wasm-opt": "1.5.13",
                 "@webassemblyjs/wasm-parser": "1.5.13",
                 "@webassemblyjs/wast-printer": "1.5.13",
-                "debug": "3.1.0"
+                "debug": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -1197,7 +1197,7 @@
                 "@webassemblyjs/helper-buffer": "1.5.13",
                 "@webassemblyjs/wasm-gen": "1.5.13",
                 "@webassemblyjs/wasm-parser": "1.5.13",
-                "debug": "3.1.0"
+                "debug": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -1236,8 +1236,8 @@
                 "@webassemblyjs/helper-api-error": "1.5.13",
                 "@webassemblyjs/helper-code-frame": "1.5.13",
                 "@webassemblyjs/helper-fsm": "1.5.13",
-                "long": "3.2.0",
-                "mamacro": "0.0.3"
+                "long": "^3.2.0",
+                "mamacro": "^0.0.3"
             }
         },
         "@webassemblyjs/wast-printer": {
@@ -1248,7 +1248,7 @@
             "requires": {
                 "@webassemblyjs/ast": "1.5.13",
                 "@webassemblyjs/wast-parser": "1.5.13",
-                "long": "3.2.0"
+                "long": "^3.2.0"
             }
         },
         "JSONStream": {
@@ -1257,8 +1257,8 @@
             "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
             "dev": true,
             "requires": {
-                "jsonparse": "1.3.1",
-                "through": "2.3.8"
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
             }
         },
         "a-sync-waterfall": {
@@ -1285,7 +1285,7 @@
             "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
             "dev": true,
             "requires": {
-                "mime-types": "2.1.19",
+                "mime-types": "~2.1.18",
                 "negotiator": "0.6.1"
             }
         },
@@ -1301,7 +1301,7 @@
             "integrity": "sha512-zVWV8Z8lislJoOKKqdNMOB+s6+XV5WERty8MnKBeFgwA+19XJjJHs2RP5dzM57FftIs+jQnRToLiWazKr6sSWg==",
             "dev": true,
             "requires": {
-                "acorn": "5.7.1"
+                "acorn": "^5.0.0"
             },
             "dependencies": {
                 "acorn": {
@@ -1318,7 +1318,7 @@
             "integrity": "sha1-VbtemGkVB7dFedBRNBMhfDgMVM8=",
             "dev": true,
             "requires": {
-                "acorn": "2.7.0"
+                "acorn": "^2.1.0"
             }
         },
         "add-asset-html-webpack-plugin": {
@@ -1327,9 +1327,9 @@
             "integrity": "sha512-lPdzWnwl96msr5Ix5WyU6ZqD5tQeSb6XD9j8yBKj7WswURRpZ4nZx/Gt+ocgbFdT7j48x7xw40g8wBykFbVptQ==",
             "dev": true,
             "requires": {
-                "globby": "8.0.1",
-                "micromatch": "3.1.10",
-                "p-each-series": "1.0.0"
+                "globby": "^8.0.0",
+                "micromatch": "^3.1.3",
+                "p-each-series": "^1.0.0"
             },
             "dependencies": {
                 "arr-diff": {
@@ -1350,16 +1350,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -1368,7 +1368,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -1379,13 +1379,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -1394,7 +1394,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -1403,7 +1403,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -1412,7 +1412,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -1421,7 +1421,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -1432,7 +1432,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -1441,7 +1441,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -1452,9 +1452,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -1471,14 +1471,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -1487,7 +1487,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -1496,7 +1496,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -1507,10 +1507,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -1519,7 +1519,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -1530,7 +1530,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -1539,7 +1539,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -1548,9 +1548,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-number": {
@@ -1559,7 +1559,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -1568,7 +1568,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -1591,26 +1591,26 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
         },
         "add-stream": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/add-stream/-/add-stream-1.0.0.tgz",
             "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
             "dev": true
         },
@@ -1627,13 +1627,13 @@
             "integrity": "sha512-958oaHHVEXMvsY7v7cC5gEkNIcoaAVIhZ4mBReYVZJOTP9IgKmzLjIOhTtzpLMu+qriXvLsVjJ155EeInp45IQ==",
             "dev": true,
             "requires": {
-                "assert": "1.4.1",
-                "camelcase": "1.2.1",
-                "loader-utils": "1.1.0",
-                "lodash.assign": "4.2.0",
-                "lodash.defaults": "3.1.2",
-                "object-path": "0.9.2",
-                "regex-parser": "2.2.9"
+                "assert": "^1.3.0",
+                "camelcase": "^1.2.1",
+                "loader-utils": "^1.1.0",
+                "lodash.assign": "^4.0.1",
+                "lodash.defaults": "^3.1.2",
+                "object-path": "^0.9.2",
+                "regex-parser": "^2.2.9"
             },
             "dependencies": {
                 "camelcase": {
@@ -1648,9 +1648,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 },
                 "lodash.defaults": {
@@ -1659,8 +1659,8 @@
                     "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
                     "dev": true,
                     "requires": {
-                        "lodash.assign": "3.2.0",
-                        "lodash.restparam": "3.6.1"
+                        "lodash.assign": "^3.0.0",
+                        "lodash.restparam": "^3.0.0"
                     },
                     "dependencies": {
                         "lodash.assign": {
@@ -1669,9 +1669,9 @@
                             "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
                             "dev": true,
                             "requires": {
-                                "lodash._baseassign": "3.2.0",
-                                "lodash._createassigner": "3.1.1",
-                                "lodash.keys": "3.1.2"
+                                "lodash._baseassign": "^3.0.0",
+                                "lodash._createassigner": "^3.0.0",
+                                "lodash.keys": "^3.0.0"
                             }
                         }
                     }
@@ -1696,7 +1696,7 @@
             "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
             "dev": true,
             "requires": {
-                "es6-promisify": "5.0.0"
+                "es6-promisify": "^5.0.0"
             }
         },
         "ajv": {
@@ -1705,10 +1705,10 @@
             "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
             "dev": true,
             "requires": {
-                "fast-deep-equal": "2.0.1",
-                "fast-json-stable-stringify": "2.0.0",
-                "json-schema-traverse": "0.4.1",
-                "uri-js": "4.2.2"
+                "fast-deep-equal": "^2.0.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.1"
             }
         },
         "ajv-keywords": {
@@ -1723,9 +1723,9 @@
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2",
-                "longest": "1.0.1",
-                "repeat-string": "1.6.1"
+                "kind-of": "^3.0.2",
+                "longest": "^1.0.1",
+                "repeat-string": "^1.5.2"
             }
         },
         "amdefine": {
@@ -1741,11 +1741,11 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "bitsyntax": "0.0.4",
-                "bluebird": "3.5.1",
+                "bitsyntax": "~0.0.4",
+                "bluebird": "^3.4.6",
                 "buffer-more-ints": "0.0.2",
-                "readable-stream": "1.1.14",
-                "safe-buffer": "5.1.2"
+                "readable-stream": "1.x >=1.1.9",
+                "safe-buffer": "^5.0.1"
             },
             "dependencies": {
                 "isarray": {
@@ -1762,10 +1762,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -1783,7 +1783,7 @@
             "integrity": "sha1-wNROkP/w+sleiyPwQ6zaf9HFHXw=",
             "dev": true,
             "requires": {
-                "loader-utils": "0.2.17"
+                "loader-utils": "^0.2.15"
             }
         },
         "ansi-colors": {
@@ -1792,7 +1792,7 @@
             "integrity": "sha512-SFKX67auSNoVR38N3L+nvsPjOE0bybKTYbkf5tRvushrAPQ9V75huw0ZxBkKVeRU9kqH3d6HA4xTckbwZ4ixmA==",
             "dev": true,
             "requires": {
-                "ansi-wrap": "0.1.0"
+                "ansi-wrap": "^0.1.0"
             }
         },
         "ansi-cyan": {
@@ -1846,7 +1846,7 @@
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
             "requires": {
-                "color-convert": "1.9.2"
+                "color-convert": "^1.9.0"
             }
         },
         "ansi-wrap": {
@@ -1867,8 +1867,8 @@
             "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
             "dev": true,
             "requires": {
-                "micromatch": "2.3.11",
-                "normalize-path": "2.1.1"
+                "micromatch": "^2.1.5",
+                "normalize-path": "^2.0.0"
             }
         },
         "app-module-path": {
@@ -1879,7 +1879,7 @@
         },
         "app-root-path": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.1.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/app-root-path/-/app-root-path-2.1.0.tgz",
             "integrity": "sha1-mL9lmTJ+zqGZMJhm6BQDaP0uZGo=",
             "dev": true
         },
@@ -1895,14 +1895,14 @@
             "integrity": "sha1-/2YrSnggFJSj7lRNOjP+dJZQnrw=",
             "dev": true,
             "requires": {
-                "archiver-utils": "1.3.0",
-                "async": "2.6.1",
-                "buffer-crc32": "0.2.13",
-                "glob": "7.1.2",
-                "lodash": "4.17.10",
-                "readable-stream": "2.3.6",
-                "tar-stream": "1.6.1",
-                "zip-stream": "1.2.0"
+                "archiver-utils": "^1.3.0",
+                "async": "^2.0.0",
+                "buffer-crc32": "^0.2.1",
+                "glob": "^7.0.0",
+                "lodash": "^4.8.0",
+                "readable-stream": "^2.0.0",
+                "tar-stream": "^1.5.0",
+                "zip-stream": "^1.2.0"
             },
             "dependencies": {
                 "async": {
@@ -1911,7 +1911,7 @@
                     "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.10"
+                        "lodash": "^4.17.10"
                     }
                 }
             }
@@ -1922,12 +1922,12 @@
             "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lazystream": "1.0.0",
-                "lodash": "4.17.10",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.6"
+                "glob": "^7.0.0",
+                "graceful-fs": "^4.1.0",
+                "lazystream": "^1.0.0",
+                "lodash": "^4.8.0",
+                "normalize-path": "^2.0.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "archy": {
@@ -1942,8 +1942,8 @@
             "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
             "dev": true,
             "requires": {
-                "delegates": "1.0.0",
-                "readable-stream": "2.3.6"
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
             }
         },
         "argparse": {
@@ -1952,7 +1952,7 @@
             "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
             "dev": true,
             "requires": {
-                "sprintf-js": "1.0.3"
+                "sprintf-js": "~1.0.2"
             }
         },
         "arr-diff": {
@@ -1961,7 +1961,7 @@
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0"
+                "arr-flatten": "^1.0.1"
             }
         },
         "arr-flatten": {
@@ -2018,8 +2018,8 @@
             "integrity": "sha1-GEtI9i2S10UrsxsyMWXH+L0CJm0=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.12.0"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.7.0"
             }
         },
         "array-iterate": {
@@ -2040,9 +2040,9 @@
             "integrity": "sha512-ihLeJkonmdiAsD7vpgN3CRcx2J2S0TiYW+IS/5zHBI7mKUq3ySvBdzzBfD236ubDBQFiiyG3SWCPc+msQ9KoYg==",
             "dev": true,
             "requires": {
-                "default-compare": "1.0.0",
-                "get-value": "2.0.6",
-                "kind-of": "5.1.0"
+                "default-compare": "^1.0.0",
+                "get-value": "^2.0.6",
+                "kind-of": "^5.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -2059,7 +2059,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -2098,7 +2098,7 @@
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
             "dev": true,
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": "~2.1.0"
             }
         },
         "asn1.js": {
@@ -2107,9 +2107,9 @@
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "assert": {
@@ -2188,12 +2188,12 @@
             "integrity": "sha512-BbAIdxNdptG/x4DiGGfpkDVYyqu4nUyNdBB0Utr49Gn3+0RERV1MdHik2FSbbWwhMAuk1KrfVJHe7nEMheGdBA==",
             "dev": true,
             "requires": {
-                "browserslist": "4.0.1",
-                "caniuse-lite": "1.0.30000874",
-                "normalize-range": "0.1.2",
-                "num2fraction": "1.2.2",
-                "postcss": "7.0.2",
-                "postcss-value-parser": "3.3.0"
+                "browserslist": "^4.0.1",
+                "caniuse-lite": "^1.0.30000872",
+                "normalize-range": "^0.1.2",
+                "num2fraction": "^1.2.2",
+                "postcss": "^7.0.2",
+                "postcss-value-parser": "^3.2.3"
             },
             "dependencies": {
                 "postcss": {
@@ -2202,9 +2202,9 @@
                     "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.1",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.4.0"
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
                     }
                 }
             }
@@ -2215,14 +2215,14 @@
             "integrity": "sha512-3v5MEUgRz1n90u61UGYbhFxiFq1tK/HBdoY/ScBX1srOiZVo4iF9b6hyP2ZsRp1ewHKYwlEo0OaHUXJVQHv6dw==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "enhanced-resolve": "4.1.0",
-                "loader-utils": "1.1.0",
-                "lodash": "4.17.10",
-                "micromatch": "3.1.10",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.5.6",
-                "webpack-log": "1.2.0"
+                "chalk": "^2.4.1",
+                "enhanced-resolve": "^4.0.0",
+                "loader-utils": "^1.1.0",
+                "lodash": "^4.17.5",
+                "micromatch": "^3.1.9",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.3",
+                "webpack-log": "^1.2.0"
             },
             "dependencies": {
                 "arr-diff": {
@@ -2243,16 +2243,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -2261,7 +2261,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -2272,13 +2272,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -2287,7 +2287,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -2296,7 +2296,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -2305,7 +2305,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -2314,7 +2314,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -2325,7 +2325,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -2334,7 +2334,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -2345,9 +2345,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -2364,14 +2364,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -2380,7 +2380,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -2389,7 +2389,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -2400,10 +2400,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -2412,7 +2412,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -2423,7 +2423,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -2432,7 +2432,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -2441,9 +2441,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-number": {
@@ -2452,7 +2452,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -2461,7 +2461,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -2484,9 +2484,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 },
                 "micromatch": {
@@ -2495,19 +2495,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -2541,7 +2541,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.9"
+                        "debug": "^2.2.0"
                     }
                 }
             }
@@ -2552,9 +2552,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -2569,11 +2569,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -2590,9 +2590,9 @@
             "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
             "dev": true,
             "requires": {
-                "babel-runtime": "6.26.0",
-                "core-js": "2.5.7",
-                "regenerator-runtime": "0.10.5"
+                "babel-runtime": "^6.26.0",
+                "core-js": "^2.5.0",
+                "regenerator-runtime": "^0.10.5"
             },
             "dependencies": {
                 "regenerator-runtime": {
@@ -2609,8 +2609,8 @@
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
             "dev": true,
             "requires": {
-                "core-js": "2.5.7",
-                "regenerator-runtime": "0.11.1"
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
             }
         },
         "babylon": {
@@ -2643,13 +2643,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -2658,7 +2658,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -2667,7 +2667,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -2676,7 +2676,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -2685,9 +2685,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
@@ -2735,7 +2735,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "beeper": {
@@ -2781,7 +2781,7 @@
             "integrity": "sha1-/cqHGplxOqANGeO7ukHER4emU5g=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.0.6"
+                "readable-stream": "~2.0.5"
             },
             "dependencies": {
                 "process-nextick-args": {
@@ -2796,12 +2796,12 @@
                     "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -2824,7 +2824,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "bluebird": {
@@ -2846,15 +2846,15 @@
             "dev": true,
             "requires": {
                 "bytes": "3.0.0",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "http-errors": "1.6.3",
+                "depd": "~1.1.2",
+                "http-errors": "~1.6.3",
                 "iconv-lite": "0.4.23",
-                "on-finished": "2.3.0",
+                "on-finished": "~2.3.0",
                 "qs": "6.5.2",
                 "raw-body": "2.3.3",
-                "type-is": "1.6.16"
+                "type-is": "~1.6.16"
             }
         },
         "bonjour": {
@@ -2863,12 +2863,12 @@
             "integrity": "sha1-jokKGD2O6aI5OzhExpGkK897yfU=",
             "dev": true,
             "requires": {
-                "array-flatten": "2.1.1",
-                "deep-equal": "1.0.1",
-                "dns-equal": "1.0.0",
-                "dns-txt": "2.0.2",
-                "multicast-dns": "6.2.3",
-                "multicast-dns-service-types": "1.1.0"
+                "array-flatten": "^2.1.0",
+                "deep-equal": "^1.0.1",
+                "dns-equal": "^1.0.0",
+                "dns-txt": "^2.0.2",
+                "multicast-dns": "^6.0.1",
+                "multicast-dns-service-types": "^1.1.0"
             }
         },
         "boolbase": {
@@ -2883,7 +2883,7 @@
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "brace-expansion": {
@@ -2892,7 +2892,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -2902,9 +2902,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "brorand": {
@@ -2919,12 +2919,12 @@
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
-                "buffer-xor": "1.0.3",
-                "cipher-base": "1.0.4",
-                "create-hash": "1.2.0",
-                "evp_bytestokey": "1.0.3",
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "browserify-cipher": {
@@ -2933,9 +2933,9 @@
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
             "dev": true,
             "requires": {
-                "browserify-aes": "1.2.0",
-                "browserify-des": "1.0.2",
-                "evp_bytestokey": "1.0.3"
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
             }
         },
         "browserify-des": {
@@ -2944,10 +2944,10 @@
             "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "des.js": "1.0.0",
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
             }
         },
         "browserify-rsa": {
@@ -2956,8 +2956,8 @@
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
             }
         },
         "browserify-sign": {
@@ -2966,13 +2966,13 @@
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "elliptic": "6.4.0",
-                "inherits": "2.0.3",
-                "parse-asn1": "5.1.1"
+                "bn.js": "^4.1.1",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.2",
+                "elliptic": "^6.0.0",
+                "inherits": "^2.0.1",
+                "parse-asn1": "^5.0.0"
             }
         },
         "browserify-zlib": {
@@ -2981,7 +2981,7 @@
             "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
             "dev": true,
             "requires": {
-                "pako": "1.0.6"
+                "pako": "~1.0.5"
             }
         },
         "browserslist": {
@@ -2990,9 +2990,9 @@
             "integrity": "sha512-QqiiIWchEIkney3wY53/huI7ZErouNAdvOkjorUALAwRcu3tEwOV3Sh6He0DnP38mz1JjBpCBb50jQBmaYuHPw==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "1.0.30000874",
-                "electron-to-chromium": "1.3.55",
-                "node-releases": "1.0.0-alpha.10"
+                "caniuse-lite": "^1.0.30000865",
+                "electron-to-chromium": "^1.3.52",
+                "node-releases": "^1.0.0-alpha.10"
             }
         },
         "buffer": {
@@ -3001,8 +3001,8 @@
             "integrity": "sha512-nUJyfChH7PMJy75eRDCCKtszSEFokUNXC1hNVSe+o+VdcgvDPLs20k3v8UXI8ruRYAJiYtyRea8mYyqPxoHWDw==",
             "dev": true,
             "requires": {
-                "base64-js": "1.3.0",
-                "ieee754": "1.1.12"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4"
             }
         },
         "buffer-alloc": {
@@ -3011,8 +3011,8 @@
             "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
             "dev": true,
             "requires": {
-                "buffer-alloc-unsafe": "1.1.0",
-                "buffer-fill": "1.0.0"
+                "buffer-alloc-unsafe": "^1.1.0",
+                "buffer-fill": "^1.0.0"
             }
         },
         "buffer-alloc-unsafe": {
@@ -3063,7 +3063,7 @@
             "integrity": "sha512-HaJnVuslRF4g2kSDeyl++AaVizoitCpL9PglzCYwy0uHHyvWerfvEb8jWmYbF1z4kiVFolGomnxSGl+GUQp2jg==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.2"
             }
         },
         "buildmail": {
@@ -3115,19 +3115,19 @@
             "integrity": "sha512-Dph0MzuH+rTQzGPNT9fAnrPmMmjKfST6trxJeK7NQuHRaVw24VzPRWTmg9MpcwOVQZO0E1FBICUlFeNaKPIfHA==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "chownr": "1.0.1",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "lru-cache": "4.1.3",
-                "mississippi": "2.0.0",
-                "mkdirp": "0.5.1",
-                "move-concurrently": "1.0.1",
-                "promise-inflight": "1.0.1",
-                "rimraf": "2.6.2",
-                "ssri": "5.3.0",
-                "unique-filename": "1.1.0",
-                "y18n": "4.0.0"
+                "bluebird": "^3.5.1",
+                "chownr": "^1.0.1",
+                "glob": "^7.1.2",
+                "graceful-fs": "^4.1.11",
+                "lru-cache": "^4.1.1",
+                "mississippi": "^2.0.0",
+                "mkdirp": "^0.5.1",
+                "move-concurrently": "^1.0.1",
+                "promise-inflight": "^1.0.1",
+                "rimraf": "^2.6.2",
+                "ssri": "^5.2.4",
+                "unique-filename": "^1.1.0",
+                "y18n": "^4.0.0"
             },
             "dependencies": {
                 "lru-cache": {
@@ -3136,8 +3136,8 @@
                     "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 },
                 "y18n": {
@@ -3154,15 +3154,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -3179,13 +3179,22 @@
             "integrity": "sha1-JtII6onje1y95gJQoV8DHBak1ms=",
             "dev": true
         },
+        "caller-id": {
+            "version": "0.1.0",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/caller-id/-/caller-id-0.1.0.tgz",
+            "integrity": "sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=",
+            "dev": true,
+            "requires": {
+                "stack-trace": "~0.0.7"
+            }
+        },
         "caller-path": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
             "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
             "dev": true,
             "requires": {
-                "callsites": "0.2.0"
+                "callsites": "^0.2.0"
             }
         },
         "callsite": {
@@ -3196,7 +3205,7 @@
         },
         "callsites": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/callsites/-/callsites-0.2.0.tgz",
             "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
             "dev": true
         },
@@ -3206,8 +3215,8 @@
             "integrity": "sha1-yjw2iKTpzzpM2nd9xNy8cTJJz3M=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2",
-                "upper-case": "1.1.3"
+                "no-case": "^2.2.0",
+                "upper-case": "^1.1.1"
             }
         },
         "camelcase": {
@@ -3222,9 +3231,9 @@
             "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
             "dev": true,
             "requires": {
-                "camelcase": "4.1.0",
-                "map-obj": "2.0.0",
-                "quick-lru": "1.1.0"
+                "camelcase": "^4.1.0",
+                "map-obj": "^2.0.0",
+                "quick-lru": "^1.0.0"
             }
         },
         "caniuse-lite": {
@@ -3251,7 +3260,7 @@
             "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
             "dev": true,
             "requires": {
-                "underscore-contrib": "0.3.0"
+                "underscore-contrib": "~0.3.0"
             }
         },
         "ccount": {
@@ -3266,8 +3275,8 @@
             "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
             "dev": true,
             "requires": {
-                "align-text": "0.1.4",
-                "lazy-cache": "1.0.4"
+                "align-text": "^0.1.3",
+                "lazy-cache": "^1.0.3"
             }
         },
         "chalk": {
@@ -3276,9 +3285,9 @@
             "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.4.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             }
         },
         "change-case": {
@@ -3287,24 +3296,24 @@
             "integrity": "sha1-bJyONfh5CHCoK2sHRb6MPL75sIE=",
             "dev": true,
             "requires": {
-                "camel-case": "3.0.0",
-                "constant-case": "2.0.0",
-                "dot-case": "2.1.1",
-                "header-case": "1.0.1",
-                "is-lower-case": "1.1.3",
-                "is-upper-case": "1.1.2",
-                "lower-case": "1.1.4",
-                "lower-case-first": "1.0.2",
-                "no-case": "2.3.2",
-                "param-case": "2.1.1",
-                "pascal-case": "2.0.1",
-                "path-case": "2.1.1",
-                "sentence-case": "2.1.1",
-                "snake-case": "2.1.0",
-                "swap-case": "1.1.2",
-                "title-case": "2.1.1",
-                "upper-case": "1.1.3",
-                "upper-case-first": "1.1.2"
+                "camel-case": "^3.0.0",
+                "constant-case": "^2.0.0",
+                "dot-case": "^2.1.0",
+                "header-case": "^1.0.0",
+                "is-lower-case": "^1.1.0",
+                "is-upper-case": "^1.1.0",
+                "lower-case": "^1.1.1",
+                "lower-case-first": "^1.0.0",
+                "no-case": "^2.2.0",
+                "param-case": "^2.1.0",
+                "pascal-case": "^2.0.0",
+                "path-case": "^2.1.0",
+                "sentence-case": "^2.1.0",
+                "snake-case": "^2.1.0",
+                "swap-case": "^1.1.0",
+                "title-case": "^2.1.0",
+                "upper-case": "^1.1.1",
+                "upper-case-first": "^1.1.0"
             }
         },
         "character-entities": {
@@ -3343,15 +3352,15 @@
             "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
             "dev": true,
             "requires": {
-                "anymatch": "1.3.2",
-                "async-each": "1.0.1",
-                "fsevents": "1.2.4",
-                "glob-parent": "2.0.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "2.0.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0"
+                "anymatch": "^1.3.0",
+                "async-each": "^1.0.0",
+                "fsevents": "^1.0.0",
+                "glob-parent": "^2.0.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^2.0.0",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0"
             }
         },
         "chownr": {
@@ -3366,7 +3375,7 @@
             "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "ci-info": {
@@ -3381,8 +3390,8 @@
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "circular-json": {
@@ -3397,10 +3406,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -3409,7 +3418,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "isobject": {
@@ -3426,7 +3435,7 @@
             "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "0.5.x"
             },
             "dependencies": {
                 "source-map": {
@@ -3443,7 +3452,7 @@
             "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
             "dev": true,
             "requires": {
-                "restore-cursor": "1.0.1"
+                "restore-cursor": "^1.0.1"
             }
         },
         "cli-spinners": {
@@ -3459,7 +3468,7 @@
             "dev": true,
             "requires": {
                 "slice-ansi": "0.0.4",
-                "string-width": "1.0.2"
+                "string-width": "^1.0.1"
             }
         },
         "cli-width": {
@@ -3474,8 +3483,8 @@
             "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
             "dev": true,
             "requires": {
-                "center-align": "0.1.3",
-                "right-align": "0.1.3",
+                "center-align": "^0.1.1",
+                "right-align": "^0.1.1",
                 "wordwrap": "0.0.2"
             },
             "dependencies": {
@@ -3505,10 +3514,10 @@
             "integrity": "sha512-SZegPTKjCgpQH63E+eN6mVEEPdQBOUzjyJm5Pora4lrwWRFS8I0QAxV/KD6vV/i0WuijHZWQC1fMsPEdxfdVCQ==",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "is-plain-object": "2.0.4",
-                "kind-of": "6.0.2",
-                "shallow-clone": "1.0.0"
+                "for-own": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "kind-of": "^6.0.0",
+                "shallow-clone": "^1.0.0"
             },
             "dependencies": {
                 "for-own": {
@@ -3517,7 +3526,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 },
                 "kind-of": {
@@ -3534,8 +3543,8 @@
             "integrity": "sha512-Fcij9IwRW27XedRIJnSOEupS7RVcXtObJXbcUOX93UCLqqOdRpkvzKywOOSizmEK/Is3S/RHX9dLdfo6R1Q1mw==",
             "dev": true,
             "requires": {
-                "is-regexp": "1.0.0",
-                "is-supported-regexp-flag": "1.0.1"
+                "is-regexp": "^1.0.0",
+                "is-supported-regexp-flag": "^1.0.0"
             }
         },
         "clone-stats": {
@@ -3550,9 +3559,9 @@
             "integrity": "sha512-Bq6+4t+lbM8vhTs/Bef5c5AdEMtapp/iFb6+s4/Hh9MVTt8OLKH7ZOOZSCT+Ys7hsHvqv0GuMPJ1lnQJVHvxpg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "2.0.0",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^2.0.0",
+                "readable-stream": "^2.3.5"
             }
         },
         "co": {
@@ -3579,8 +3588,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-convert": {
@@ -3616,7 +3625,7 @@
             "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
             "dev": true,
             "requires": {
-                "lodash": "4.17.10"
+                "lodash": "^4.5.0"
             }
         },
         "combined-stream": {
@@ -3625,7 +3634,7 @@
             "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -3646,8 +3655,8 @@
             "integrity": "sha1-md0LpFfh+bxyKxLAjsM+6rMfpkg=",
             "dev": true,
             "requires": {
-                "array-ify": "1.0.0",
-                "dot-prop": "3.0.0"
+                "array-ify": "^1.0.0",
+                "dot-prop": "^3.0.0"
             }
         },
         "component-bind": {
@@ -3674,10 +3683,10 @@
             "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "crc32-stream": "2.0.0",
-                "normalize-path": "2.1.1",
-                "readable-stream": "2.3.6"
+                "buffer-crc32": "^0.2.1",
+                "crc32-stream": "^2.0.0",
+                "normalize-path": "^2.0.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "compressible": {
@@ -3686,7 +3695,7 @@
             "integrity": "sha1-MmxfUH+7BV9UEWeCuWmoG2einac=",
             "dev": true,
             "requires": {
-                "mime-db": "1.35.0"
+                "mime-db": ">= 1.34.0 < 2"
             }
         },
         "compression": {
@@ -3695,13 +3704,13 @@
             "integrity": "sha512-HSjyBG5N1Nnz7tF2+O7A9XUhyjru71/fwgNb7oIsEVHR0WShfs2tIS/EySLgiTe98aOK18YDlMXpzjCXY/n9mg==",
             "dev": true,
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.5",
                 "bytes": "3.0.0",
-                "compressible": "2.0.14",
+                "compressible": "~2.0.14",
                 "debug": "2.6.9",
-                "on-headers": "1.0.1",
+                "on-headers": "~1.0.1",
                 "safe-buffer": "5.1.2",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             }
         },
         "concat-map": {
@@ -3716,10 +3725,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "connect": {
@@ -3730,7 +3739,7 @@
             "requires": {
                 "debug": "2.6.9",
                 "finalhandler": "1.1.0",
-                "parseurl": "1.3.2",
+                "parseurl": "~1.3.2",
                 "utils-merge": "1.0.1"
             }
         },
@@ -3746,7 +3755,7 @@
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "dev": true,
             "requires": {
-                "date-now": "0.1.4"
+                "date-now": "^0.1.4"
             }
         },
         "console-control-strings": {
@@ -3761,8 +3770,8 @@
             "integrity": "sha1-QXV2TTidP6nI7NKRhu1gBSQ7akY=",
             "dev": true,
             "requires": {
-                "snake-case": "2.1.0",
-                "upper-case": "1.1.3"
+                "snake-case": "^2.1.0",
+                "upper-case": "^1.1.1"
             }
         },
         "constants-browserify": {
@@ -3795,17 +3804,17 @@
             "integrity": "sha512-WeWcEcR7uBtRZ/uG6DRIlVqsm7UTnxrixaAPoPvfQP7FRPf1qIXL76nGKy4wXq+wO3zOpqYubWUqrYLIL3+xww==",
             "dev": true,
             "requires": {
-                "conventional-changelog-angular": "1.6.6",
-                "conventional-changelog-atom": "2.0.0",
-                "conventional-changelog-codemirror": "2.0.0",
-                "conventional-changelog-core": "3.0.0",
-                "conventional-changelog-ember": "2.0.0",
-                "conventional-changelog-eslint": "3.0.0",
-                "conventional-changelog-express": "2.0.0",
-                "conventional-changelog-jquery": "0.1.0",
-                "conventional-changelog-jscs": "0.1.0",
-                "conventional-changelog-jshint": "2.0.0",
-                "conventional-changelog-preset-loader": "2.0.0"
+                "conventional-changelog-angular": "^1.6.6",
+                "conventional-changelog-atom": "^2.0.0",
+                "conventional-changelog-codemirror": "^2.0.0",
+                "conventional-changelog-core": "^3.0.0",
+                "conventional-changelog-ember": "^2.0.0",
+                "conventional-changelog-eslint": "^3.0.0",
+                "conventional-changelog-express": "^2.0.0",
+                "conventional-changelog-jquery": "^0.1.0",
+                "conventional-changelog-jscs": "^0.1.0",
+                "conventional-changelog-jshint": "^2.0.0",
+                "conventional-changelog-preset-loader": "^2.0.0"
             }
         },
         "conventional-changelog-angular": {
@@ -3814,8 +3823,8 @@
             "integrity": "sha512-suQnFSqCxRwyBxY68pYTsFkG0taIdinHLNEAX5ivtw8bCRnIgnpvcHmlR/yjUyZIrNPYAoXlY1WiEKWgSE4BNg==",
             "dev": true,
             "requires": {
-                "compare-func": "1.3.2",
-                "q": "1.5.1"
+                "compare-func": "^1.3.1",
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-atom": {
@@ -3824,7 +3833,7 @@
             "integrity": "sha512-ygwkwyTQYAm4S0tsDt+1yg8tHhRrv7qu9SOWPhNQlVrInFLsfKc0FActCA3de2ChknxpVPY2B53yhKvCAtkBCg==",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-codemirror": {
@@ -3833,7 +3842,7 @@
             "integrity": "sha512-pZt/YynJ5m8C9MGV5wkBuhM1eX+8a84fmNrdOylxg/lJV+lgtAiNhnpskNuixtf71iKVWSlEqMQ6z6CH7/Uo5A==",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-core": {
@@ -3842,19 +3851,19 @@
             "integrity": "sha512-D2hApWWsdh4tkNgDjn1KtRapxUJ70Sd+V84btTVJJJ96S3cVRES8Ty3ih0TRkOZmDkw/uS0mxrHSskQ/P/Gvsg==",
             "dev": true,
             "requires": {
-                "conventional-changelog-writer": "4.0.0",
-                "conventional-commits-parser": "3.0.0",
-                "dateformat": "3.0.3",
-                "get-pkg-repo": "1.4.0",
-                "git-raw-commits": "2.0.0",
-                "git-remote-origin-url": "2.0.0",
-                "git-semver-tags": "2.0.0",
-                "lodash": "4.17.10",
-                "normalize-package-data": "2.4.0",
-                "q": "1.5.1",
-                "read-pkg": "1.1.0",
-                "read-pkg-up": "1.0.1",
-                "through2": "2.0.3"
+                "conventional-changelog-writer": "^4.0.0",
+                "conventional-commits-parser": "^3.0.0",
+                "dateformat": "^3.0.0",
+                "get-pkg-repo": "^1.0.0",
+                "git-raw-commits": "^2.0.0",
+                "git-remote-origin-url": "^2.0.0",
+                "git-semver-tags": "^2.0.0",
+                "lodash": "^4.2.1",
+                "normalize-package-data": "^2.3.5",
+                "q": "^1.5.1",
+                "read-pkg": "^1.1.0",
+                "read-pkg-up": "^1.0.1",
+                "through2": "^2.0.0"
             },
             "dependencies": {
                 "conventional-commits-parser": {
@@ -3863,13 +3872,13 @@
                     "integrity": "sha512-GWh71U26BLWgMykCp+VghZ4s64wVbtseECcKQ/PvcPZR2cUnz+FUc2J9KjxNl7/ZbCxST8R03c9fc+Vi0umS9Q==",
                     "dev": true,
                     "requires": {
-                        "JSONStream": "1.3.3",
-                        "is-text-path": "1.0.1",
-                        "lodash": "4.17.10",
-                        "meow": "4.0.1",
-                        "split2": "2.2.0",
-                        "through2": "2.0.3",
-                        "trim-off-newlines": "1.0.1"
+                        "JSONStream": "^1.0.4",
+                        "is-text-path": "^1.0.0",
+                        "lodash": "^4.2.1",
+                        "meow": "^4.0.0",
+                        "split2": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "trim-off-newlines": "^1.0.0"
                     }
                 },
                 "git-raw-commits": {
@@ -3878,11 +3887,11 @@
                     "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
                     "dev": true,
                     "requires": {
-                        "dargs": "4.1.0",
-                        "lodash.template": "4.4.0",
-                        "meow": "4.0.1",
-                        "split2": "2.2.0",
-                        "through2": "2.0.3"
+                        "dargs": "^4.0.1",
+                        "lodash.template": "^4.0.2",
+                        "meow": "^4.0.0",
+                        "split2": "^2.0.0",
+                        "through2": "^2.0.0"
                     }
                 },
                 "meow": {
@@ -3891,15 +3900,15 @@
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "4.2.0",
-                        "decamelize-keys": "1.1.0",
-                        "loud-rejection": "1.6.0",
-                        "minimist": "1.2.0",
-                        "minimist-options": "3.0.2",
-                        "normalize-package-data": "2.4.0",
-                        "read-pkg-up": "3.0.0",
-                        "redent": "2.0.0",
-                        "trim-newlines": "2.0.0"
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
                     },
                     "dependencies": {
                         "read-pkg": {
@@ -3908,9 +3917,9 @@
                             "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                             "dev": true,
                             "requires": {
-                                "load-json-file": "4.0.0",
-                                "normalize-package-data": "2.4.0",
-                                "path-type": "3.0.0"
+                                "load-json-file": "^4.0.0",
+                                "normalize-package-data": "^2.3.2",
+                                "path-type": "^3.0.0"
                             }
                         },
                         "read-pkg-up": {
@@ -3919,8 +3928,8 @@
                             "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
                             "dev": true,
                             "requires": {
-                                "find-up": "2.1.0",
-                                "read-pkg": "3.0.0"
+                                "find-up": "^2.0.0",
+                                "read-pkg": "^3.0.0"
                             }
                         }
                     }
@@ -3931,7 +3940,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -3940,7 +3949,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -3955,9 +3964,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     },
                     "dependencies": {
                         "load-json-file": {
@@ -3966,11 +3975,11 @@
                             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                             "dev": true,
                             "requires": {
-                                "graceful-fs": "4.1.11",
-                                "parse-json": "2.2.0",
-                                "pify": "2.3.0",
-                                "pinkie-promise": "2.0.1",
-                                "strip-bom": "2.0.0"
+                                "graceful-fs": "^4.1.2",
+                                "parse-json": "^2.2.0",
+                                "pify": "^2.0.0",
+                                "pinkie-promise": "^2.0.0",
+                                "strip-bom": "^2.0.0"
                             }
                         },
                         "path-type": {
@@ -3979,9 +3988,9 @@
                             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                             "dev": true,
                             "requires": {
-                                "graceful-fs": "4.1.11",
-                                "pify": "2.3.0",
-                                "pinkie-promise": "2.0.1"
+                                "graceful-fs": "^4.1.2",
+                                "pify": "^2.0.0",
+                                "pinkie-promise": "^2.0.0"
                             }
                         }
                     }
@@ -3992,8 +4001,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     },
                     "dependencies": {
                         "find-up": {
@@ -4002,8 +4011,8 @@
                             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                             "dev": true,
                             "requires": {
-                                "path-exists": "2.1.0",
-                                "pinkie-promise": "2.0.1"
+                                "path-exists": "^2.0.0",
+                                "pinkie-promise": "^2.0.0"
                             }
                         }
                     }
@@ -4014,7 +4023,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 }
             }
@@ -4025,7 +4034,7 @@
             "integrity": "sha512-s9ZYf3VMdYe8ca8bw1X+he050HZNy9Pm3dBpYA+BunDGFE4Fy7whOvYhWah2U9+j9l6y/whfa0+eHANvZytE9A==",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-eslint": {
@@ -4034,7 +4043,7 @@
             "integrity": "sha512-Acn20v+13c+o1OAWKvc9sCCl73Nj2vOMyn+G82euiMZwgYNE9CcBkTnw/GKdBi9KiZMK9uy+SCQ/QyAEE+8vZA==",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-express": {
@@ -4043,7 +4052,7 @@
             "integrity": "sha512-2svPjeXCrjwwqnzu/f3qU5LWoLO0jmUIEbtbbSRXAAP9Ag+137b484eJsiRt9DPYXSVzog0Eoek3rvCzfHcphQ==",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-jquery": {
@@ -4052,7 +4061,7 @@
             "integrity": "sha1-Agg5cWLjhGmG5xJztsecW1+A9RA=",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.4.1"
             }
         },
         "conventional-changelog-jscs": {
@@ -4061,7 +4070,7 @@
             "integrity": "sha1-BHnrRDzH1yxYvwvPDvHURKkvDlw=",
             "dev": true,
             "requires": {
-                "q": "1.5.1"
+                "q": "^1.4.1"
             }
         },
         "conventional-changelog-jshint": {
@@ -4070,8 +4079,8 @@
             "integrity": "sha512-+4fCln755N0ZzRUEdcDWR5Due71Dsqkbov6K/UmVCnljZvhVh0/wpT4YROoSsAnhfZO8shyWDPFKm6EP20pLQg==",
             "dev": true,
             "requires": {
-                "compare-func": "1.3.2",
-                "q": "1.5.1"
+                "compare-func": "^1.3.1",
+                "q": "^1.5.1"
             }
         },
         "conventional-changelog-preset-loader": {
@@ -4086,16 +4095,16 @@
             "integrity": "sha512-hMZPe0AQ6Bi05epeK/7hz80xxk59nPA5z/b63TOHq2wigM0/akreOc8N4Jam5b9nFgKWX1e9PdPv2ewgW6bcfg==",
             "dev": true,
             "requires": {
-                "compare-func": "1.3.2",
-                "conventional-commits-filter": "2.0.0",
-                "dateformat": "3.0.3",
-                "handlebars": "4.0.11",
-                "json-stringify-safe": "5.0.1",
-                "lodash": "4.17.10",
-                "meow": "4.0.1",
-                "semver": "5.5.0",
-                "split": "1.0.1",
-                "through2": "2.0.3"
+                "compare-func": "^1.3.1",
+                "conventional-commits-filter": "^2.0.0",
+                "dateformat": "^3.0.0",
+                "handlebars": "^4.0.2",
+                "json-stringify-safe": "^5.0.1",
+                "lodash": "^4.2.1",
+                "meow": "^4.0.0",
+                "semver": "^5.5.0",
+                "split": "^1.0.0",
+                "through2": "^2.0.0"
             },
             "dependencies": {
                 "meow": {
@@ -4104,15 +4113,15 @@
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "4.2.0",
-                        "decamelize-keys": "1.1.0",
-                        "loud-rejection": "1.6.0",
-                        "minimist": "1.2.0",
-                        "minimist-options": "3.0.2",
-                        "normalize-package-data": "2.4.0",
-                        "read-pkg-up": "3.0.0",
-                        "redent": "2.0.0",
-                        "trim-newlines": "2.0.0"
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
                     }
                 }
             }
@@ -4123,8 +4132,8 @@
             "integrity": "sha512-Cfl0j1/NquB/TMVx7Wrmyq7uRM+/rPQbtVVGwzfkhZ6/yH6fcMmP0Q/9044TBZPTNdGzm46vXFXL14wbET0/Mg==",
             "dev": true,
             "requires": {
-                "is-subset": "0.1.1",
-                "modify-values": "1.0.1"
+                "is-subset": "^0.1.1",
+                "modify-values": "^1.0.0"
             }
         },
         "conventional-commits-parser": {
@@ -4133,13 +4142,13 @@
             "integrity": "sha512-BoMaddIEJ6B4QVMSDu9IkVImlGOSGA1I2BQyOZHeLQ6qVOJLcLKn97+fL6dGbzWEiqDzfH4OkcveULmeq2MHFQ==",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.3",
-                "is-text-path": "1.0.1",
-                "lodash": "4.17.10",
-                "meow": "4.0.1",
-                "split2": "2.2.0",
-                "through2": "2.0.3",
-                "trim-off-newlines": "1.0.1"
+                "JSONStream": "^1.0.4",
+                "is-text-path": "^1.0.0",
+                "lodash": "^4.2.1",
+                "meow": "^4.0.0",
+                "split2": "^2.0.0",
+                "through2": "^2.0.0",
+                "trim-off-newlines": "^1.0.0"
             },
             "dependencies": {
                 "meow": {
@@ -4148,15 +4157,15 @@
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "4.2.0",
-                        "decamelize-keys": "1.1.0",
-                        "loud-rejection": "1.6.0",
-                        "minimist": "1.2.0",
-                        "minimist-options": "3.0.2",
-                        "normalize-package-data": "2.4.0",
-                        "read-pkg-up": "3.0.0",
-                        "redent": "2.0.0",
-                        "trim-newlines": "2.0.0"
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
                     }
                 }
             }
@@ -4185,12 +4194,12 @@
             "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0",
-                "fs-write-stream-atomic": "1.0.10",
-                "iferr": "0.1.5",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "fs-write-stream-atomic": "^1.0.8",
+                "iferr": "^0.1.5",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.0"
             }
         },
         "copy-descriptor": {
@@ -4205,8 +4214,8 @@
             "integrity": "sha512-7cjuUME+p+S3HZlbllgsn2CDwS+5eCCX16qBgNC4jgSTf49qR1VKy/Zhl400m0IQXl/bPGEVqncgUUMjrr4s8A==",
             "dev": true,
             "requires": {
-                "each-props": "1.3.2",
-                "is-plain-object": "2.0.4"
+                "each-props": "^1.3.0",
+                "is-plain-object": "^2.0.1"
             }
         },
         "core-js": {
@@ -4226,10 +4235,10 @@
             "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
             "dev": true,
             "requires": {
-                "is-directory": "0.3.1",
-                "js-yaml": "3.12.0",
-                "parse-json": "4.0.0",
-                "require-from-string": "2.0.2"
+                "is-directory": "^0.3.1",
+                "js-yaml": "^3.9.0",
+                "parse-json": "^4.0.0",
+                "require-from-string": "^2.0.1"
             }
         },
         "crc": {
@@ -4238,7 +4247,7 @@
             "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
             "dev": true,
             "requires": {
-                "buffer": "5.2.0"
+                "buffer": "^5.1.0"
             }
         },
         "crc32-stream": {
@@ -4247,8 +4256,8 @@
             "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
             "dev": true,
             "requires": {
-                "crc": "3.8.0",
-                "readable-stream": "2.3.6"
+                "crc": "^3.4.4",
+                "readable-stream": "^2.0.0"
             }
         },
         "create-ecdh": {
@@ -4257,8 +4266,8 @@
             "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "elliptic": "6.4.0"
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.0.0"
             }
         },
         "create-hash": {
@@ -4267,11 +4276,11 @@
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "inherits": "2.0.3",
-                "md5.js": "1.3.4",
-                "ripemd160": "2.0.2",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
             }
         },
         "create-hmac": {
@@ -4280,12 +4289,12 @@
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "create-hash": "1.2.0",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.2",
-                "safe-buffer": "5.1.2",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "cross-spawn": {
@@ -4294,8 +4303,8 @@
             "integrity": "sha1-ElYDfsufDF9549bvE14wdwGEuYI=",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.3",
-                "which": "1.3.1"
+                "lru-cache": "^4.0.1",
+                "which": "^1.2.9"
             },
             "dependencies": {
                 "lru-cache": {
@@ -4304,8 +4313,8 @@
                     "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 }
             }
@@ -4316,7 +4325,7 @@
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "crypto-browserify": {
@@ -4325,17 +4334,17 @@
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
-                "browserify-cipher": "1.0.1",
-                "browserify-sign": "4.0.4",
-                "create-ecdh": "4.0.3",
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "diffie-hellman": "5.0.3",
-                "inherits": "2.0.3",
-                "pbkdf2": "3.0.16",
-                "public-encrypt": "4.0.2",
-                "randombytes": "2.0.6",
-                "randomfill": "1.0.4"
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
             }
         },
         "css": {
@@ -4344,10 +4353,10 @@
             "integrity": "sha512-0W171WccAjQGGTKLhw4m2nnl0zPHUlTO/I8td4XzJgIB8Hg3ZZx71qT4G4eX8OVsSiaAKiUMy73E3nsbPlg2DQ==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "source-map": "0.1.43",
-                "source-map-resolve": "0.5.2",
-                "urix": "0.1.0"
+                "inherits": "^2.0.1",
+                "source-map": "^0.1.38",
+                "source-map-resolve": "^0.5.1",
+                "urix": "^0.1.0"
             },
             "dependencies": {
                 "source-map": {
@@ -4356,7 +4365,7 @@
                     "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -4367,10 +4376,10 @@
             "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0",
-                "css-what": "2.1.0",
+                "boolbase": "~1.0.0",
+                "css-what": "2.1",
                 "domutils": "1.5.1",
-                "nth-check": "1.0.1"
+                "nth-check": "~1.0.1"
             },
             "dependencies": {
                 "domutils": {
@@ -4379,8 +4388,8 @@
                     "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
                     "dev": true,
                     "requires": {
-                        "dom-serializer": "0.1.0",
-                        "domelementtype": "1.3.0"
+                        "dom-serializer": "0",
+                        "domelementtype": "1"
                     }
                 }
             }
@@ -4403,7 +4412,7 @@
             "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
             "dev": true,
             "requires": {
-                "cssom": "0.3.4"
+                "cssom": "0.3.x"
             }
         },
         "currently-unhandled": {
@@ -4412,7 +4421,7 @@
             "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
             "dev": true,
             "requires": {
-                "array-find-index": "1.0.2"
+                "array-find-index": "^1.0.1"
             }
         },
         "custom-event": {
@@ -4439,7 +4448,7 @@
             "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
             "dev": true,
             "requires": {
-                "es5-ext": "0.10.45"
+                "es5-ext": "^0.10.9"
             }
         },
         "dargs": {
@@ -4448,7 +4457,7 @@
             "integrity": "sha1-A6nbtLXC8Tm/FK5T8LiipqhvThc=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "dashdash": {
@@ -4457,7 +4466,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "data-uri-to-buffer": {
@@ -4518,8 +4527,8 @@
             "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
             "dev": true,
             "requires": {
-                "decamelize": "1.2.0",
-                "map-obj": "1.0.1"
+                "decamelize": "^1.1.0",
+                "map-obj": "^1.0.0"
             },
             "dependencies": {
                 "map-obj": {
@@ -4572,7 +4581,7 @@
             "integrity": "sha512-QWfXlM0EkAbqOCbD/6HjdwT19j7WCkMyiRhWilc4H9/5h/RzTF9gv5LYh1+CmDV5d1rki6KAWLtQale0xt20eQ==",
             "dev": true,
             "requires": {
-                "kind-of": "5.1.0"
+                "kind-of": "^5.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -4589,7 +4598,7 @@
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "dev": true,
             "requires": {
-                "clone": "1.0.4"
+                "clone": "^1.0.2"
             }
         },
         "define-properties": {
@@ -4598,8 +4607,8 @@
             "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
             "dev": true,
             "requires": {
-                "foreach": "2.0.5",
-                "object-keys": "1.0.12"
+                "foreach": "^2.0.5",
+                "object-keys": "^1.0.8"
             }
         },
         "define-property": {
@@ -4608,8 +4617,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -4618,7 +4627,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -4627,7 +4636,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -4636,9 +4645,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
@@ -4662,9 +4671,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "ast-types": "0.9.6",
-                "escodegen": "1.11.0",
-                "esprima": "3.1.3"
+                "ast-types": "0.x.x",
+                "escodegen": "1.x.x",
+                "esprima": "3.x.x"
             },
             "dependencies": {
                 "esprima": {
@@ -4682,13 +4691,13 @@
             "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
             "dev": true,
             "requires": {
-                "globby": "5.0.0",
-                "is-path-cwd": "1.0.0",
-                "is-path-in-cwd": "1.0.1",
-                "object-assign": "4.1.1",
-                "pify": "2.3.0",
-                "pinkie-promise": "2.0.1",
-                "rimraf": "2.6.2"
+                "globby": "^5.0.0",
+                "is-path-cwd": "^1.0.0",
+                "is-path-in-cwd": "^1.0.0",
+                "object-assign": "^4.0.1",
+                "pify": "^2.0.0",
+                "pinkie-promise": "^2.0.0",
+                "rimraf": "^2.2.8"
             },
             "dependencies": {
                 "globby": {
@@ -4697,12 +4706,12 @@
                     "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "arrify": "1.0.1",
-                        "glob": "7.1.2",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "arrify": "^1.0.0",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -4743,10 +4752,10 @@
             "integrity": "sha512-jnemt7VLwdZKlbzmw1HSevq3ybtTczduk/jvv4x4RWx3vStMZ2yeFL2GZ2KJT0ycJWll9N3ZmOIoKziMnvtC2Q==",
             "dev": true,
             "requires": {
-                "commander": "2.17.1",
-                "debug": "3.1.0",
-                "filing-cabinet": "1.14.3",
-                "precinct": "4.2.0"
+                "commander": "^2.16.0",
+                "debug": "^3.1.0",
+                "filing-cabinet": "^1.14.2",
+                "precinct": "^4.2.0"
             },
             "dependencies": {
                 "debug": {
@@ -4772,8 +4781,8 @@
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "destroy": {
@@ -4800,10 +4809,10 @@
             "integrity": "sha1-XrDfTvXBipQDOwfa8TbbzV/HXNU=",
             "dev": true,
             "requires": {
-                "ast-module-types": "2.3.2",
-                "escodegen": "1.11.0",
-                "get-amd-module-type": "2.0.5",
-                "node-source-walk": "3.3.0"
+                "ast-module-types": "^2.3.1",
+                "escodegen": "^1.8.0",
+                "get-amd-module-type": "^2.0.4",
+                "node-source-walk": "^3.0.0"
             }
         },
         "detective-cjs": {
@@ -4812,8 +4821,8 @@
             "integrity": "sha1-3OTJMCzcpS5ri/04d8qT9ixczAM=",
             "dev": true,
             "requires": {
-                "ast-module-types": "2.3.2",
-                "node-source-walk": "3.3.0"
+                "ast-module-types": "^2.3.2",
+                "node-source-walk": "^3.0.0"
             }
         },
         "detective-es6": {
@@ -4822,7 +4831,7 @@
             "integrity": "sha1-a5s71Uf9jyH4lQL2JuRe0qMnb9w=",
             "dev": true,
             "requires": {
-                "node-source-walk": "3.3.0"
+                "node-source-walk": "^3.3.0"
             }
         },
         "detective-less": {
@@ -4831,9 +4840,9 @@
             "integrity": "sha512-xeFzlSFHChKSvDGBg/gL5K7RHB4x/xXk5PmVuOek3tIYi4tZaVpUKIkCDTY1ndOt4FVcgGd51DSn7Y/DYvCqDw==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "gonzales-pe": "3.4.7",
-                "node-source-walk": "3.3.0"
+                "debug": "^3.1.0",
+                "gonzales-pe": "^3.4.4",
+                "node-source-walk": "^3.2.0"
             },
             "dependencies": {
                 "debug": {
@@ -4853,10 +4862,10 @@
             "integrity": "sha512-Ryf9mdjP4Lgrlkfy1bHkeUrCyS94kUzzrAXkXL/2JmTaG1COU4lkmWm6YG4u1P0SKSP179RVLhbUoJ6J788rRQ==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "is-url": "1.2.4",
-                "postcss": "6.0.23",
-                "postcss-values-parser": "1.5.0"
+                "debug": "^3.1.0",
+                "is-url": "^1.2.4",
+                "postcss": "^6.0.21",
+                "postcss-values-parser": "^1.5.0"
             },
             "dependencies": {
                 "debug": {
@@ -4874,9 +4883,9 @@
                     "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.1",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.4.0"
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
                     }
                 }
             }
@@ -4887,9 +4896,9 @@
             "integrity": "sha1-BWYKoblc/Yf1dGQ7+s4+iiaBEqE=",
             "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "gonzales-pe": "3.4.7",
-                "node-source-walk": "3.3.0"
+                "debug": "^3.1.0",
+                "gonzales-pe": "^3.4.4",
+                "node-source-walk": "^3.2.0"
             },
             "dependencies": {
                 "debug": {
@@ -4909,9 +4918,9 @@
             "integrity": "sha1-dDJGoN01jZ2R/0ElQX9qd/vPJw8=",
             "dev": true,
             "requires": {
-                "debug": "3.1.0",
-                "gonzales-pe": "3.4.7",
-                "node-source-walk": "3.3.0"
+                "debug": "^3.1.0",
+                "gonzales-pe": "^3.4.4",
+                "node-source-walk": "^3.2.0"
             },
             "dependencies": {
                 "debug": {
@@ -4938,8 +4947,8 @@
             "dev": true,
             "requires": {
                 "node-source-walk": "3.2.0",
-                "typescript": "2.7.2",
-                "typescript-eslint-parser": "9.0.1"
+                "typescript": "^2.6.1",
+                "typescript-eslint-parser": "^9.0.0"
             },
             "dependencies": {
                 "babylon": {
@@ -4948,7 +4957,7 @@
                     "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
                     "dev": true,
                     "requires": {
-                        "babel-runtime": "6.26.0"
+                        "babel-runtime": "^6.0.0"
                     }
                 },
                 "node-source-walk": {
@@ -4957,7 +4966,7 @@
                     "integrity": "sha1-PGBcxTq97ktFq2XpR9+x23yQ8OM=",
                     "dev": true,
                     "requires": {
-                        "babylon": "6.8.4"
+                        "babylon": "~6.8.1"
                     }
                 }
             }
@@ -4968,8 +4977,8 @@
             "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
             "dev": true,
             "requires": {
-                "asap": "2.0.6",
-                "wrappy": "1.0.2"
+                "asap": "^2.0.0",
+                "wrappy": "1"
             }
         },
         "dgeni": {
@@ -4978,15 +4987,15 @@
             "integrity": "sha1-nkJ3WxOGyl64JHU6ws0WnY9hztE=",
             "dev": true,
             "requires": {
-                "canonical-path": "0.0.2",
-                "dependency-graph": "0.4.1",
+                "canonical-path": "~0.0.2",
+                "dependency-graph": "~0.4.1",
                 "di": "0.0.1",
-                "lodash": "3.10.1",
-                "objectdiff": "1.1.0",
-                "optimist": "0.6.1",
-                "q": "1.4.1",
-                "validate.js": "0.9.0",
-                "winston": "2.4.3"
+                "lodash": "^3.10.1",
+                "objectdiff": "^1.1.0",
+                "optimist": "~0.6.1",
+                "q": "~1.4.1",
+                "validate.js": "^0.9.0",
+                "winston": "^2.1.1"
             },
             "dependencies": {
                 "lodash": {
@@ -5010,27 +5019,27 @@
             "dev": true,
             "requires": {
                 "canonical-path": "0.0.2",
-                "catharsis": "0.8.9",
+                "catharsis": "^0.8.1",
                 "change-case": "3.0.0",
-                "dgeni": "0.4.9",
-                "espree": "2.2.5",
-                "estraverse": "4.2.0",
-                "glob": "7.1.2",
-                "htmlparser2": "3.9.2",
-                "lodash": "4.17.10",
-                "marked": "0.3.19",
-                "minimatch": "3.0.4",
-                "mkdirp": "0.5.1",
-                "mkdirp-promise": "5.0.1",
+                "dgeni": "^0.4.9",
+                "espree": "^2.2.3",
+                "estraverse": "^4.1.0",
+                "glob": "^7.0.5",
+                "htmlparser2": "^3.7.3",
+                "lodash": "^4.13.1",
+                "marked": "^0.3.2",
+                "minimatch": "^3.0.2",
+                "mkdirp": "^0.5.1",
+                "mkdirp-promise": "^5.0.0",
                 "node-html-encoder": "0.0.2",
-                "nunjucks": "3.1.3",
-                "semver": "5.5.0",
-                "shelljs": "0.7.8",
-                "source-map-support": "0.4.18",
-                "spdx-license-list": "2.1.0",
-                "stringmap": "0.2.2",
-                "typescript": "2.7.2",
-                "urlencode": "1.1.0"
+                "nunjucks": "^3.0.1",
+                "semver": "^5.2.0",
+                "shelljs": "^0.7.0",
+                "source-map-support": "^0.4.15",
+                "spdx-license-list": "^2.1.0",
+                "stringmap": "^0.2.2",
+                "typescript": "~2.7.1",
+                "urlencode": "^1.1.0"
             },
             "dependencies": {
                 "espree": {
@@ -5051,7 +5060,7 @@
                     "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
                     "dev": true,
                     "requires": {
-                        "source-map": "0.5.7"
+                        "source-map": "^0.5.6"
                     }
                 }
             }
@@ -5074,9 +5083,9 @@
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "miller-rabin": "4.0.1",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
             }
         },
         "dir-glob": {
@@ -5085,8 +5094,8 @@
             "integrity": "sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "path-type": "3.0.0"
+                "arrify": "^1.0.1",
+                "path-type": "^3.0.0"
             }
         },
         "dns-equal": {
@@ -5101,8 +5110,8 @@
             "integrity": "sha512-0UxfQkMhYAUaZI+xrNZOz/as5KgDU0M/fQ9b6SpkyLbk3GEswDi6PADJVaYJradtRVsRIlF1zLyOodbcTCDzUg==",
             "dev": true,
             "requires": {
-                "ip": "1.1.5",
-                "safe-buffer": "5.1.2"
+                "ip": "^1.1.0",
+                "safe-buffer": "^5.0.1"
             }
         },
         "dns-txt": {
@@ -5111,7 +5120,7 @@
             "integrity": "sha1-uR2Ab10nGI5Ks+fRB9iBocxGQrY=",
             "dev": true,
             "requires": {
-                "buffer-indexof": "1.1.1"
+                "buffer-indexof": "^1.0.0"
             }
         },
         "doctrine": {
@@ -5120,7 +5129,7 @@
             "integrity": "sha1-fLhgNZujvpDgQLJrcpzkv6ZUxSM=",
             "dev": true,
             "requires": {
-                "esutils": "1.1.6",
+                "esutils": "^1.1.6",
                 "isarray": "0.0.1"
             },
             "dependencies": {
@@ -5144,7 +5153,7 @@
             "integrity": "sha1-pF71cnuJDJv/5tfIduexnLDhfzs=",
             "dev": true,
             "requires": {
-                "utila": "0.3.3"
+                "utila": "~0.3"
             },
             "dependencies": {
                 "utila": {
@@ -5161,10 +5170,10 @@
             "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
             "dev": true,
             "requires": {
-                "custom-event": "1.0.1",
-                "ent": "2.2.0",
-                "extend": "3.0.2",
-                "void-elements": "2.0.1"
+                "custom-event": "~1.0.0",
+                "ent": "~2.2.0",
+                "extend": "^3.0.0",
+                "void-elements": "^2.0.0"
             }
         },
         "dom-serializer": {
@@ -5173,8 +5182,8 @@
             "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.1.3",
-                "entities": "1.1.1"
+                "domelementtype": "~1.1.1",
+                "entities": "~1.1.1"
             },
             "dependencies": {
                 "domelementtype": {
@@ -5203,7 +5212,7 @@
             "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0"
+                "domelementtype": "1"
             }
         },
         "domino": {
@@ -5218,8 +5227,8 @@
             "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
             "dev": true,
             "requires": {
-                "dom-serializer": "0.1.0",
-                "domelementtype": "1.3.0"
+                "dom-serializer": "0",
+                "domelementtype": "1"
             }
         },
         "dot-case": {
@@ -5228,7 +5237,7 @@
             "integrity": "sha1-NNzzf1Co6TwrO8qLt/uRVcfaO+4=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2"
+                "no-case": "^2.2.0"
             }
         },
         "dot-prop": {
@@ -5237,7 +5246,7 @@
             "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "double-ended-queue": {
@@ -5253,7 +5262,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.1.14"
+                "readable-stream": "~1.1.9"
             },
             "dependencies": {
                 "isarray": {
@@ -5268,10 +5277,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -5288,10 +5297,10 @@
             "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -5300,7 +5309,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 }
             }
@@ -5311,8 +5320,8 @@
             "integrity": "sha512-vV0Hem3zAGkJAyU7JSjixeU66rwdynTAa1vofCrSA5fEln+m67Az9CcnkVD776/fsN/UjIWmBDoNRS6t6G9RfA==",
             "dev": true,
             "requires": {
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0"
+                "is-plain-object": "^2.0.1",
+                "object.defaults": "^1.1.0"
             }
         },
         "ecc-jsbn": {
@@ -5322,8 +5331,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2"
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.1.0"
             }
         },
         "ee-first": {
@@ -5350,13 +5359,13 @@
             "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0",
-                "hash.js": "1.1.5",
-                "hmac-drbg": "1.0.1",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1",
-                "minimalistic-crypto-utils": "1.0.1"
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
             }
         },
         "emojis-list": {
@@ -5377,7 +5386,7 @@
             "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
             "dev": true,
             "requires": {
-                "once": "1.3.3"
+                "once": "~1.3.0"
             },
             "dependencies": {
                 "once": {
@@ -5386,7 +5395,7 @@
                     "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 }
             }
@@ -5397,13 +5406,13 @@
             "integrity": "sha512-D06ivJkYxyRrcEe0bTpNnBQNgP9d3xog+qZlLbui8EsMr/DouQpf5o9FzJnWYHEYE0YsFHllUv2R1dkgYZXHcA==",
             "dev": true,
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.4",
                 "base64id": "1.0.0",
                 "cookie": "0.3.1",
-                "debug": "3.1.0",
-                "engine.io-parser": "2.1.2",
-                "uws": "9.14.0",
-                "ws": "3.3.3"
+                "debug": "~3.1.0",
+                "engine.io-parser": "~2.1.0",
+                "uws": "~9.14.0",
+                "ws": "~3.3.1"
             },
             "dependencies": {
                 "debug": {
@@ -5425,14 +5434,14 @@
             "requires": {
                 "component-emitter": "1.2.1",
                 "component-inherit": "0.0.3",
-                "debug": "3.1.0",
-                "engine.io-parser": "2.1.2",
+                "debug": "~3.1.0",
+                "engine.io-parser": "~2.1.1",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "ws": "3.3.3",
-                "xmlhttprequest-ssl": "1.5.5",
+                "ws": "~3.3.1",
+                "xmlhttprequest-ssl": "~1.5.4",
                 "yeast": "0.1.2"
             },
             "dependencies": {
@@ -5454,10 +5463,10 @@
             "dev": true,
             "requires": {
                 "after": "0.8.2",
-                "arraybuffer.slice": "0.0.7",
+                "arraybuffer.slice": "~0.0.7",
                 "base64-arraybuffer": "0.1.5",
                 "blob": "0.0.4",
-                "has-binary2": "1.0.3"
+                "has-binary2": "~1.0.2"
             }
         },
         "enhanced-resolve": {
@@ -5466,9 +5475,9 @@
             "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "memory-fs": "0.4.1",
-                "tapable": "1.0.0"
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.4.0",
+                "tapable": "^1.0.0"
             }
         },
         "ent": {
@@ -5489,7 +5498,7 @@
             "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
             "dev": true,
             "requires": {
-                "prr": "1.0.1"
+                "prr": "~1.0.1"
             }
         },
         "error-ex": {
@@ -5498,7 +5507,7 @@
             "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
             "dev": true,
             "requires": {
-                "is-arrayish": "0.2.1"
+                "is-arrayish": "^0.2.1"
             }
         },
         "es-abstract": {
@@ -5507,11 +5516,11 @@
             "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
             "dev": true,
             "requires": {
-                "es-to-primitive": "1.1.1",
-                "function-bind": "1.1.1",
-                "has": "1.0.3",
-                "is-callable": "1.1.4",
-                "is-regex": "1.0.4"
+                "es-to-primitive": "^1.1.1",
+                "function-bind": "^1.1.1",
+                "has": "^1.0.1",
+                "is-callable": "^1.1.3",
+                "is-regex": "^1.0.4"
             }
         },
         "es-to-primitive": {
@@ -5520,9 +5529,9 @@
             "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
             "dev": true,
             "requires": {
-                "is-callable": "1.1.4",
-                "is-date-object": "1.0.1",
-                "is-symbol": "1.0.1"
+                "is-callable": "^1.1.1",
+                "is-date-object": "^1.0.1",
+                "is-symbol": "^1.0.1"
             }
         },
         "es5-ext": {
@@ -5531,9 +5540,9 @@
             "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1",
-                "next-tick": "1.0.0"
+                "es6-iterator": "~2.0.3",
+                "es6-symbol": "~3.1.1",
+                "next-tick": "1"
             }
         },
         "es6-iterator": {
@@ -5542,9 +5551,9 @@
             "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.45",
-                "es6-symbol": "3.1.1"
+                "d": "1",
+                "es5-ext": "^0.10.35",
+                "es6-symbol": "^3.1.1"
             }
         },
         "es6-promise": {
@@ -5555,11 +5564,11 @@
         },
         "es6-promisify": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/es6-promisify/-/es6-promisify-5.0.0.tgz",
             "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
             "dev": true,
             "requires": {
-                "es6-promise": "4.2.4"
+                "es6-promise": "^4.0.3"
             }
         },
         "es6-symbol": {
@@ -5568,8 +5577,8 @@
             "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
             "dev": true,
             "requires": {
-                "d": "1.0.0",
-                "es5-ext": "0.10.45"
+                "d": "1",
+                "es5-ext": "~0.10.14"
             }
         },
         "escape-html": {
@@ -5590,11 +5599,11 @@
             "integrity": "sha512-IeMV45ReixHS53K/OmfKAIztN/igDHzTJUhZM3k1jMhIZWjk45SMwAtBsEXiJp3vSPmTcu6CXn7mDvFHRN66fw==",
             "dev": true,
             "requires": {
-                "esprima": "3.1.3",
-                "estraverse": "4.2.0",
-                "esutils": "2.0.2",
-                "optionator": "0.8.2",
-                "source-map": "0.6.1"
+                "esprima": "^3.1.3",
+                "estraverse": "^4.2.0",
+                "esutils": "^2.0.2",
+                "optionator": "^0.8.1",
+                "source-map": "~0.6.1"
             },
             "dependencies": {
                 "esprima": {
@@ -5611,8 +5620,8 @@
             "integrity": "sha512-1G6UTDi7Jc1ELFwnR58HV4fK9OQK4S6N985f166xqXxpjU6plxFISJa2Ba9KCQuFa8RCnj/lSFJbHo7UFDBnUA==",
             "dev": true,
             "requires": {
-                "esrecurse": "4.2.1",
-                "estraverse": "4.2.0"
+                "esrecurse": "^4.1.0",
+                "estraverse": "^4.1.1"
             }
         },
         "esprima": {
@@ -5627,7 +5636,7 @@
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
             "dev": true,
             "requires": {
-                "estraverse": "4.2.0"
+                "estraverse": "^4.1.0"
             }
         },
         "estraverse": {
@@ -5666,7 +5675,7 @@
             "integrity": "sha1-Cs7ehJ7X3RzMMsgRuxG5RNTykjI=",
             "dev": true,
             "requires": {
-                "original": "1.0.2"
+                "original": ">=0.0.5"
             }
         },
         "evp_bytestokey": {
@@ -5675,8 +5684,8 @@
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
             "requires": {
-                "md5.js": "1.3.4",
-                "safe-buffer": "5.1.2"
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
             }
         },
         "execa": {
@@ -5685,13 +5694,13 @@
             "integrity": "sha512-BbUMBiX4hqiHZUA5+JujIjNb6TyAlp2D5KLheMjMluwOuzcnylDL4AxZYLLn1n2AGB49eSWwyKvvEQoRpnAtmA==",
             "dev": true,
             "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^5.0.1",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             },
             "dependencies": {
                 "cross-spawn": {
@@ -5700,9 +5709,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "4.1.3",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "lru-cache": {
@@ -5711,8 +5720,8 @@
                     "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 }
             }
@@ -5723,7 +5732,7 @@
             "integrity": "sha1-c9CQTjlbPKsGWLCNCewlMH8pu3M=",
             "dev": true,
             "requires": {
-                "clone-regexp": "1.0.1"
+                "clone-regexp": "^1.0.0"
             }
         },
         "exit-hook": {
@@ -5738,9 +5747,9 @@
             "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
             "dev": true,
             "requires": {
-                "array-slice": "0.2.3",
-                "array-unique": "0.2.1",
-                "braces": "0.1.5"
+                "array-slice": "^0.2.3",
+                "array-unique": "^0.2.1",
+                "braces": "^0.1.2"
             },
             "dependencies": {
                 "array-slice": {
@@ -5755,7 +5764,7 @@
                     "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
                     "dev": true,
                     "requires": {
-                        "expand-range": "0.1.1"
+                        "expand-range": "^0.1.0"
                     }
                 },
                 "expand-range": {
@@ -5764,8 +5773,8 @@
                     "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
                     "dev": true,
                     "requires": {
-                        "is-number": "0.1.1",
-                        "repeat-string": "0.2.2"
+                        "is-number": "^0.1.1",
+                        "repeat-string": "^0.2.2"
                     }
                 },
                 "is-number": {
@@ -5788,7 +5797,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -5797,7 +5806,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.4"
+                "fill-range": "^2.1.0"
             }
         },
         "expand-tilde": {
@@ -5806,7 +5815,7 @@
             "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1"
+                "homedir-polyfill": "^1.0.1"
             }
         },
         "express": {
@@ -5815,36 +5824,36 @@
             "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
             "dev": true,
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.5",
                 "array-flatten": "1.1.1",
                 "body-parser": "1.18.2",
                 "content-disposition": "0.5.2",
-                "content-type": "1.0.4",
+                "content-type": "~1.0.4",
                 "cookie": "0.3.1",
                 "cookie-signature": "1.0.6",
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "finalhandler": "1.1.1",
                 "fresh": "0.5.2",
                 "merge-descriptors": "1.0.1",
-                "methods": "1.1.2",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
+                "methods": "~1.1.2",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
                 "path-to-regexp": "0.1.7",
-                "proxy-addr": "2.0.4",
+                "proxy-addr": "~2.0.3",
                 "qs": "6.5.1",
-                "range-parser": "1.2.0",
+                "range-parser": "~1.2.0",
                 "safe-buffer": "5.1.1",
                 "send": "0.16.2",
                 "serve-static": "1.13.2",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.4.0",
-                "type-is": "1.6.16",
+                "statuses": "~1.4.0",
+                "type-is": "~1.6.16",
                 "utils-merge": "1.0.1",
-                "vary": "1.1.2"
+                "vary": "~1.1.2"
             },
             "dependencies": {
                 "array-flatten": {
@@ -5860,15 +5869,15 @@
                     "dev": true,
                     "requires": {
                         "bytes": "3.0.0",
-                        "content-type": "1.0.4",
+                        "content-type": "~1.0.4",
                         "debug": "2.6.9",
-                        "depd": "1.1.2",
-                        "http-errors": "1.6.3",
+                        "depd": "~1.1.1",
+                        "http-errors": "~1.6.2",
                         "iconv-lite": "0.4.19",
-                        "on-finished": "2.3.0",
+                        "on-finished": "~2.3.0",
                         "qs": "6.5.1",
                         "raw-body": "2.3.2",
-                        "type-is": "1.6.16"
+                        "type-is": "~1.6.15"
                     }
                 },
                 "finalhandler": {
@@ -5878,12 +5887,12 @@
                     "dev": true,
                     "requires": {
                         "debug": "2.6.9",
-                        "encodeurl": "1.0.2",
-                        "escape-html": "1.0.3",
-                        "on-finished": "2.3.0",
-                        "parseurl": "1.3.2",
-                        "statuses": "1.4.0",
-                        "unpipe": "1.0.0"
+                        "encodeurl": "~1.0.2",
+                        "escape-html": "~1.0.3",
+                        "on-finished": "~2.3.0",
+                        "parseurl": "~1.3.2",
+                        "statuses": "~1.4.0",
+                        "unpipe": "~1.0.0"
                     }
                 },
                 "iconv-lite": {
@@ -5925,7 +5934,7 @@
                                 "depd": "1.1.1",
                                 "inherits": "2.0.3",
                                 "setprototypeof": "1.0.3",
-                                "statuses": "1.4.0"
+                                "statuses": ">= 1.3.1 < 2"
                             }
                         },
                         "setprototypeof": {
@@ -5962,8 +5971,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -5972,7 +5981,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -5983,9 +5992,9 @@
             "integrity": "sha512-mpkfj0FEdxrIhOC04zk85X7StNtr0yXnG7zCb+8ikO8OJi2jsHh5YGoknNTyXgsbHOf1WOOcVU3kPFWT2WgCkQ==",
             "dev": true,
             "requires": {
-                "chardet": "0.5.0",
-                "iconv-lite": "0.4.23",
-                "tmp": "0.0.33"
+                "chardet": "^0.5.0",
+                "iconv-lite": "^0.4.22",
+                "tmp": "^0.0.33"
             }
         },
         "extglob": {
@@ -5994,7 +6003,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             }
         },
         "extsprintf": {
@@ -6015,9 +6024,9 @@
             "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
             "dev": true,
             "requires": {
-                "ansi-gray": "0.1.1",
-                "color-support": "1.1.3",
-                "time-stamp": "1.1.0"
+                "ansi-gray": "^0.1.1",
+                "color-support": "^1.1.3",
+                "time-stamp": "^1.0.0"
             }
         },
         "fast-deep-equal": {
@@ -6032,12 +6041,12 @@
             "integrity": "sha512-TR6zxCKftDQnUAPvkrCWdBgDq/gbqx8A3ApnBrR5rMvpp6+KMJI0Igw7fkWPgeVK0uhRXTXdvO3O+YP0CaUX2g==",
             "dev": true,
             "requires": {
-                "@mrmlnc/readdir-enhanced": "2.2.1",
-                "@nodelib/fs.stat": "1.1.0",
-                "glob-parent": "3.1.0",
-                "is-glob": "4.0.0",
-                "merge2": "1.2.2",
-                "micromatch": "3.1.10"
+                "@mrmlnc/readdir-enhanced": "^2.2.1",
+                "@nodelib/fs.stat": "^1.0.1",
+                "glob-parent": "^3.1.0",
+                "is-glob": "^4.0.0",
+                "merge2": "^1.2.1",
+                "micromatch": "^3.1.10"
             },
             "dependencies": {
                 "arr-diff": {
@@ -6058,16 +6067,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -6076,7 +6085,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -6087,13 +6096,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -6102,7 +6111,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -6111,7 +6120,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -6120,7 +6129,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -6129,7 +6138,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -6140,7 +6149,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -6149,7 +6158,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -6160,9 +6169,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -6179,14 +6188,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -6195,7 +6204,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -6204,7 +6213,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -6215,10 +6224,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -6227,7 +6236,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -6238,8 +6247,8 @@
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
                     },
                     "dependencies": {
                         "is-glob": {
@@ -6248,7 +6257,7 @@
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "requires": {
-                                "is-extglob": "2.1.1"
+                                "is-extglob": "^2.1.0"
                             }
                         }
                     }
@@ -6259,7 +6268,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -6268,7 +6277,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -6277,9 +6286,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-extglob": {
@@ -6294,7 +6303,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 },
                 "is-number": {
@@ -6303,7 +6312,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6312,7 +6321,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6335,19 +6344,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -6370,7 +6379,7 @@
             "integrity": "sha1-TkkvjQTftviQA1B/btvy1QHnxvQ=",
             "dev": true,
             "requires": {
-                "websocket-driver": "0.7.0"
+                "websocket-driver": ">=0.5.1"
             }
         },
         "figures": {
@@ -6379,8 +6388,8 @@
             "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
             "dev": true,
             "requires": {
-                "escape-string-regexp": "1.0.5",
-                "object-assign": "4.1.1"
+                "escape-string-regexp": "^1.0.5",
+                "object-assign": "^4.1.0"
             }
         },
         "file-entry-cache": {
@@ -6389,8 +6398,8 @@
             "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
             "dev": true,
             "requires": {
-                "flat-cache": "1.3.0",
-                "object-assign": "4.1.1"
+                "flat-cache": "^1.2.1",
+                "object-assign": "^4.0.1"
             }
         },
         "file-exists": {
@@ -6418,18 +6427,18 @@
             "integrity": "sha512-UIPZII8rPTUDRmLNCXbu/326xK13k3OK2CW0aA7gI1POSYdwCeBEi4FwD6i3NUN0ZS3dFFkJDYRYyv9+HkPI/w==",
             "dev": true,
             "requires": {
-                "app-module-path": "2.2.0",
-                "commander": "2.17.1",
-                "debug": "3.1.0",
-                "enhanced-resolve": "4.1.0",
-                "is-relative-path": "1.0.2",
-                "module-definition": "2.2.4",
-                "module-lookup-amd": "5.0.1",
-                "resolve": "1.8.1",
-                "resolve-dependency-path": "1.0.2",
-                "sass-lookup": "2.0.0",
-                "stylus-lookup": "2.0.0",
-                "typescript": "2.7.2"
+                "app-module-path": "^2.2.0",
+                "commander": "^2.13.0",
+                "debug": "^3.1.0",
+                "enhanced-resolve": "^4.1.0",
+                "is-relative-path": "^1.0.2",
+                "module-definition": "^2.2.4",
+                "module-lookup-amd": "^5.0.1",
+                "resolve": "^1.5.0",
+                "resolve-dependency-path": "^1.0.2",
+                "sass-lookup": "^2.0.0",
+                "stylus-lookup": "^2.0.0",
+                "typescript": "^2.4.2"
             },
             "dependencies": {
                 "debug": {
@@ -6447,9 +6456,9 @@
                     "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "memory-fs": "0.4.1",
-                        "tapable": "1.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "memory-fs": "^0.4.0",
+                        "tapable": "^1.0.0"
                     }
                 },
                 "tapable": {
@@ -6466,11 +6475,11 @@
             "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "3.0.0",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^3.0.0",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "finalhandler": {
@@ -6480,12 +6489,12 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "on-finished": "2.3.0",
-                "parseurl": "1.3.2",
-                "statuses": "1.3.1",
-                "unpipe": "1.0.0"
+                "encodeurl": "~1.0.1",
+                "escape-html": "~1.0.3",
+                "on-finished": "~2.3.0",
+                "parseurl": "~1.3.2",
+                "statuses": "~1.3.1",
+                "unpipe": "~1.0.0"
             },
             "dependencies": {
                 "statuses": {
@@ -6502,7 +6511,7 @@
             "integrity": "sha1-S3Px/55WrZG3bnFkB/5f/mVUu4w=",
             "dev": true,
             "requires": {
-                "traverse-chain": "0.1.0"
+                "traverse-chain": "~0.1.0"
             }
         },
         "find-cache-dir": {
@@ -6511,9 +6520,9 @@
             "integrity": "sha1-kojj6ePMN0hxfTnq3hfPcfww7m8=",
             "dev": true,
             "requires": {
-                "commondir": "1.0.1",
-                "make-dir": "1.3.0",
-                "pkg-dir": "2.0.0"
+                "commondir": "^1.0.1",
+                "make-dir": "^1.0.0",
+                "pkg-dir": "^2.0.0"
             }
         },
         "find-index": {
@@ -6534,7 +6543,7 @@
             "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
             "dev": true,
             "requires": {
-                "locate-path": "2.0.0"
+                "locate-path": "^2.0.0"
             }
         },
         "findup-sync": {
@@ -6543,10 +6552,10 @@
             "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
             "dev": true,
             "requires": {
-                "detect-file": "1.0.0",
-                "is-glob": "3.1.0",
-                "micromatch": "3.1.10",
-                "resolve-dir": "1.0.1"
+                "detect-file": "^1.0.0",
+                "is-glob": "^3.1.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -6567,16 +6576,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -6585,7 +6594,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -6596,13 +6605,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -6611,7 +6620,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -6620,7 +6629,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -6629,7 +6638,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -6638,7 +6647,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -6649,7 +6658,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -6658,7 +6667,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -6669,9 +6678,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -6688,14 +6697,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -6704,7 +6713,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -6713,7 +6722,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -6724,10 +6733,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -6736,7 +6745,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -6747,7 +6756,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -6756,7 +6765,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -6765,9 +6774,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-extglob": {
@@ -6782,7 +6791,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 },
                 "is-number": {
@@ -6791,7 +6800,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -6800,7 +6809,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -6823,19 +6832,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -6846,11 +6855,11 @@
             "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0",
-                "object.pick": "1.3.0",
-                "parse-filepath": "1.0.2"
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
             }
         },
         "first-chunk-stream": {
@@ -6871,10 +6880,10 @@
             "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
             "dev": true,
             "requires": {
-                "circular-json": "0.3.3",
-                "del": "2.2.2",
-                "graceful-fs": "4.1.11",
-                "write": "0.2.1"
+                "circular-json": "^0.3.1",
+                "del": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "write": "^0.2.1"
             },
             "dependencies": {
                 "circular-json": {
@@ -6897,8 +6906,8 @@
             "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.4"
             }
         },
         "follow-redirects": {
@@ -6907,7 +6916,7 @@
             "integrity": "sha512-kssLorP/9acIdpQ2udQVTiCS5LQmdEz9mvdIfDcl1gYX2tPKFADHSyFdvJS040XdFsPzemWtgI3q8mFVCxtX8A==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0"
+                "debug": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -6933,7 +6942,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "foreach": {
@@ -6960,9 +6969,9 @@
             "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
+                "asynckit": "^0.4.0",
                 "combined-stream": "1.0.6",
-                "mime-types": "2.1.19"
+                "mime-types": "^2.1.12"
             }
         },
         "forwarded": {
@@ -6977,7 +6986,7 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
         },
         "fresh": {
@@ -6992,8 +7001,8 @@
             "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0"
             }
         },
         "fs-access": {
@@ -7002,7 +7011,7 @@
             "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
             "dev": true,
             "requires": {
-                "null-check": "1.0.0"
+                "null-check": "^1.0.0"
             }
         },
         "fs-constants": {
@@ -7017,9 +7026,9 @@
             "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "jsonfile": "4.0.0",
-                "universalify": "0.1.2"
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
             }
         },
         "fs-write-stream-atomic": {
@@ -7028,10 +7037,10 @@
             "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "iferr": "0.1.5",
-                "imurmurhash": "0.1.4",
-                "readable-stream": "2.3.6"
+                "graceful-fs": "^4.1.2",
+                "iferr": "^0.1.5",
+                "imurmurhash": "^0.1.4",
+                "readable-stream": "1 || 2"
             }
         },
         "fs.realpath": {
@@ -7047,8 +7056,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.10.0",
-                "node-pre-gyp": "0.10.0"
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.10.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -7074,8 +7083,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.3.6"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
                 },
                 "balanced-match": {
@@ -7088,7 +7097,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "balanced-match": "1.0.0",
+                        "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
                     }
                 },
@@ -7152,7 +7161,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "fs.realpath": {
@@ -7167,14 +7176,14 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.2.0",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "glob": {
@@ -7183,12 +7192,12 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "has-unicode": {
@@ -7203,7 +7212,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safer-buffer": "2.1.2"
+                        "safer-buffer": "^2.1.0"
                     }
                 },
                 "ignore-walk": {
@@ -7212,7 +7221,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minimatch": "3.0.4"
+                        "minimatch": "^3.0.4"
                     }
                 },
                 "inflight": {
@@ -7221,8 +7230,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -7241,7 +7250,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -7255,7 +7264,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
@@ -7268,8 +7277,8 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.0"
                     }
                 },
                 "minizlib": {
@@ -7278,7 +7287,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "minipass": "2.2.4"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "mkdirp": {
@@ -7301,9 +7310,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "iconv-lite": "0.4.21",
-                        "sax": "1.2.4"
+                        "debug": "^2.1.2",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
                     }
                 },
                 "node-pre-gyp": {
@@ -7312,16 +7321,16 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.3",
-                        "mkdirp": "0.5.1",
-                        "needle": "2.2.0",
-                        "nopt": "4.0.1",
-                        "npm-packlist": "1.1.10",
-                        "npmlog": "4.1.2",
-                        "rc": "1.2.7",
-                        "rimraf": "2.6.2",
-                        "semver": "5.5.0",
-                        "tar": "4.4.1"
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.0",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
                     }
                 },
                 "nopt": {
@@ -7330,8 +7339,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.1",
-                        "osenv": "0.1.5"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
                 "npm-bundled": {
@@ -7346,8 +7355,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ignore-walk": "3.0.1",
-                        "npm-bundled": "1.0.3"
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
                     }
                 },
                 "npmlog": {
@@ -7356,10 +7365,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
@@ -7378,7 +7387,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -7399,8 +7408,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
@@ -7421,10 +7430,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.5.1",
-                        "ini": "1.3.5",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -7441,13 +7450,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "2.0.0",
-                        "safe-buffer": "5.1.1",
-                        "string_decoder": "1.1.1",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "rimraf": {
@@ -7456,7 +7465,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
@@ -7499,9 +7508,9 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
@@ -7510,7 +7519,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 },
                 "strip-ansi": {
@@ -7518,7 +7527,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -7533,13 +7542,13 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chownr": "1.0.1",
-                        "fs-minipass": "1.2.5",
-                        "minipass": "2.2.4",
-                        "minizlib": "1.1.0",
-                        "mkdirp": "0.5.1",
-                        "safe-buffer": "5.1.1",
-                        "yallist": "3.0.2"
+                        "chownr": "^1.0.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.2.4",
+                        "minizlib": "^1.1.0",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.2"
                     }
                 },
                 "util-deprecate": {
@@ -7554,7 +7563,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
@@ -7575,10 +7584,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "ftp": {
@@ -7588,7 +7597,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "readable-stream": "1.1.14",
+                "readable-stream": "1.1.x",
                 "xregexp": "2.0.0"
             },
             "dependencies": {
@@ -7606,10 +7615,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -7633,14 +7642,14 @@
             "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0",
-                "console-control-strings": "1.1.0",
-                "has-unicode": "2.0.1",
-                "object-assign": "4.1.1",
-                "signal-exit": "3.0.2",
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1",
-                "wide-align": "1.1.3"
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
             }
         },
         "gaze": {
@@ -7649,7 +7658,7 @@
             "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
             "dev": true,
             "requires": {
-                "globule": "0.1.0"
+                "globule": "~0.1.0"
             }
         },
         "generate-function": {
@@ -7666,7 +7675,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "is-property": "1.0.2"
+                "is-property": "^1.0.0"
             }
         },
         "get-amd-module-type": {
@@ -7675,8 +7684,8 @@
             "integrity": "sha1-5nHsWpatX79To6IqKJ6SOMdy3bA=",
             "dev": true,
             "requires": {
-                "ast-module-types": "2.3.2",
-                "node-source-walk": "3.3.0"
+                "ast-module-types": "^2.3.2",
+                "node-source-walk": "^3.2.0"
             }
         },
         "get-caller-file": {
@@ -7697,11 +7706,11 @@
             "integrity": "sha1-xztInAbYDMVTbCyFP54FIyBWly0=",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.7.1",
-                "meow": "3.7.0",
-                "normalize-package-data": "2.4.0",
-                "parse-github-repo-url": "1.4.1",
-                "through2": "2.0.3"
+                "hosted-git-info": "^2.1.4",
+                "meow": "^3.3.0",
+                "normalize-package-data": "^2.3.0",
+                "parse-github-repo-url": "^1.3.0",
+                "through2": "^2.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -7716,8 +7725,8 @@
                     "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "2.1.1",
-                        "map-obj": "1.0.1"
+                        "camelcase": "^2.0.0",
+                        "map-obj": "^1.0.0"
                     }
                 },
                 "find-up": {
@@ -7726,8 +7735,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "get-stdin": {
@@ -7742,7 +7751,7 @@
                     "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
                     "dev": true,
                     "requires": {
-                        "repeating": "2.0.1"
+                        "repeating": "^2.0.0"
                     }
                 },
                 "load-json-file": {
@@ -7751,11 +7760,11 @@
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "map-obj": {
@@ -7770,16 +7779,16 @@
                     "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "2.1.0",
-                        "decamelize": "1.2.0",
-                        "loud-rejection": "1.6.0",
-                        "map-obj": "1.0.1",
-                        "minimist": "1.2.0",
-                        "normalize-package-data": "2.4.0",
-                        "object-assign": "4.1.1",
-                        "read-pkg-up": "1.0.1",
-                        "redent": "1.0.0",
-                        "trim-newlines": "1.0.0"
+                        "camelcase-keys": "^2.0.0",
+                        "decamelize": "^1.1.2",
+                        "loud-rejection": "^1.0.0",
+                        "map-obj": "^1.0.1",
+                        "minimist": "^1.1.3",
+                        "normalize-package-data": "^2.3.4",
+                        "object-assign": "^4.0.1",
+                        "read-pkg-up": "^1.0.1",
+                        "redent": "^1.0.0",
+                        "trim-newlines": "^1.0.0"
                     }
                 },
                 "parse-json": {
@@ -7788,7 +7797,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -7797,7 +7806,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -7806,9 +7815,9 @@
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -7823,9 +7832,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -7834,8 +7843,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     }
                 },
                 "redent": {
@@ -7844,8 +7853,8 @@
                     "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
                     "dev": true,
                     "requires": {
-                        "indent-string": "2.1.0",
-                        "strip-indent": "1.0.1"
+                        "indent-string": "^2.1.0",
+                        "strip-indent": "^1.0.1"
                     }
                 },
                 "strip-bom": {
@@ -7854,7 +7863,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "strip-indent": {
@@ -7863,7 +7872,7 @@
                     "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "4.0.1"
+                        "get-stdin": "^4.0.1"
                     }
                 },
                 "trim-newlines": {
@@ -7893,12 +7902,12 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "data-uri-to-buffer": "1.2.0",
-                "debug": "2.6.9",
-                "extend": "3.0.2",
-                "file-uri-to-path": "1.0.0",
-                "ftp": "0.3.10",
-                "readable-stream": "2.3.6"
+                "data-uri-to-buffer": "1",
+                "debug": "2",
+                "extend": "3",
+                "file-uri-to-path": "1",
+                "ftp": "~0.3.10",
+                "readable-stream": "2"
             }
         },
         "get-value": {
@@ -7913,7 +7922,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             }
         },
         "git-raw-commits": {
@@ -7922,11 +7931,11 @@
             "integrity": "sha512-svsK26tQ8vEKnMshTDatSIQSMDdz8CxIIqKsvPqbtV23Etmw6VNaFAitu8zwZ0VrOne7FztwPyRLxK7/DIUTQg==",
             "dev": true,
             "requires": {
-                "dargs": "4.1.0",
-                "lodash.template": "4.4.0",
-                "meow": "4.0.1",
-                "split2": "2.2.0",
-                "through2": "2.0.3"
+                "dargs": "^4.0.1",
+                "lodash.template": "^4.0.2",
+                "meow": "^4.0.0",
+                "split2": "^2.0.0",
+                "through2": "^2.0.0"
             },
             "dependencies": {
                 "meow": {
@@ -7935,15 +7944,15 @@
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "4.2.0",
-                        "decamelize-keys": "1.1.0",
-                        "loud-rejection": "1.6.0",
-                        "minimist": "1.2.0",
-                        "minimist-options": "3.0.2",
-                        "normalize-package-data": "2.4.0",
-                        "read-pkg-up": "3.0.0",
-                        "redent": "2.0.0",
-                        "trim-newlines": "2.0.0"
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
                     }
                 }
             }
@@ -7954,8 +7963,8 @@
             "integrity": "sha1-UoJlna4hBxRaERJhEq0yFuxfpl8=",
             "dev": true,
             "requires": {
-                "gitconfiglocal": "1.0.0",
-                "pify": "2.3.0"
+                "gitconfiglocal": "^1.0.0",
+                "pify": "^2.3.0"
             },
             "dependencies": {
                 "pify": {
@@ -7972,8 +7981,8 @@
             "integrity": "sha512-lSgFc3zQTul31nFje2Q8XdNcTOI6B4I3mJRPCgFzHQQLfxfqdWTYzdtCaynkK5Xmb2wQlSJoKolhXJ1VhKROnQ==",
             "dev": true,
             "requires": {
-                "meow": "4.0.1",
-                "semver": "5.5.0"
+                "meow": "^4.0.0",
+                "semver": "^5.5.0"
             },
             "dependencies": {
                 "meow": {
@@ -7982,15 +7991,15 @@
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "4.2.0",
-                        "decamelize-keys": "1.1.0",
-                        "loud-rejection": "1.6.0",
-                        "minimist": "1.2.0",
-                        "minimist-options": "3.0.2",
-                        "normalize-package-data": "2.4.0",
-                        "read-pkg-up": "3.0.0",
-                        "redent": "2.0.0",
-                        "trim-newlines": "2.0.0"
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
                     }
                 }
             }
@@ -8001,7 +8010,7 @@
             "integrity": "sha1-QdBF84UaXqiPA/JMocYXgRRGS5s=",
             "dev": true,
             "requires": {
-                "ini": "1.3.5"
+                "ini": "^1.3.2"
             }
         },
         "glob": {
@@ -8010,12 +8019,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-base": {
@@ -8024,8 +8033,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "glob-parent": {
@@ -8034,7 +8043,7 @@
             "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
             "dev": true,
             "requires": {
-                "is-glob": "2.0.1"
+                "is-glob": "^2.0.0"
             }
         },
         "glob-stream": {
@@ -8043,12 +8052,12 @@
             "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
             "dev": true,
             "requires": {
-                "glob": "4.5.3",
-                "glob2base": "0.0.12",
-                "minimatch": "2.0.10",
-                "ordered-read-streams": "0.1.0",
-                "through2": "0.6.5",
-                "unique-stream": "1.0.0"
+                "glob": "^4.3.1",
+                "glob2base": "^0.0.12",
+                "minimatch": "^2.0.1",
+                "ordered-read-streams": "^0.1.0",
+                "through2": "^0.6.1",
+                "unique-stream": "^1.0.0"
             },
             "dependencies": {
                 "glob": {
@@ -8057,10 +8066,10 @@
                     "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "2.0.10",
-                        "once": "1.4.0"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^2.0.1",
+                        "once": "^1.3.0"
                     }
                 },
                 "isarray": {
@@ -8075,7 +8084,7 @@
                     "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.0.0"
                     }
                 },
                 "readable-stream": {
@@ -8084,10 +8093,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -8102,8 +8111,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -8120,7 +8129,7 @@
             "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
             "dev": true,
             "requires": {
-                "gaze": "0.5.2"
+                "gaze": "^0.5.1"
             }
         },
         "glob2base": {
@@ -8129,7 +8138,7 @@
             "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
             "dev": true,
             "requires": {
-                "find-index": "0.1.1"
+                "find-index": "^0.1.1"
             }
         },
         "global-dirs": {
@@ -8138,7 +8147,7 @@
             "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
             "dev": true,
             "requires": {
-                "ini": "1.3.5"
+                "ini": "^1.3.4"
             }
         },
         "global-modules": {
@@ -8147,9 +8156,9 @@
             "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
             "dev": true,
             "requires": {
-                "global-prefix": "1.0.2",
-                "is-windows": "1.0.2",
-                "resolve-dir": "1.0.1"
+                "global-prefix": "^1.0.1",
+                "is-windows": "^1.0.1",
+                "resolve-dir": "^1.0.0"
             }
         },
         "global-modules-path": {
@@ -8164,11 +8173,11 @@
             "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "homedir-polyfill": "1.0.1",
-                "ini": "1.3.5",
-                "is-windows": "1.0.2",
-                "which": "1.3.1"
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
             }
         },
         "globby": {
@@ -8177,13 +8186,13 @@
             "integrity": "sha512-oMrYrJERnKBLXNLVTqhm3vPEdJ/b2ZE28xN4YARiix1NOIOBPEpOUnm844K1iu/BkphCaf2WNFwMszv8Soi1pw==",
             "dev": true,
             "requires": {
-                "array-union": "1.0.2",
-                "dir-glob": "2.0.0",
-                "fast-glob": "2.2.2",
-                "glob": "7.1.2",
-                "ignore": "3.3.10",
-                "pify": "3.0.0",
-                "slash": "1.0.0"
+                "array-union": "^1.0.1",
+                "dir-glob": "^2.0.0",
+                "fast-glob": "^2.0.2",
+                "glob": "^7.1.2",
+                "ignore": "^3.3.5",
+                "pify": "^3.0.0",
+                "slash": "^1.0.0"
             }
         },
         "globjoin": {
@@ -8198,7 +8207,7 @@
             "integrity": "sha512-D23dWbOq48vlOraoSigbcQV4tWrnhwk+E/Um2cMuDS3/5dwGmdFeA7L/vAvDhLFlQOTDqHcXh35m/71g2A2WzQ==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.1.1"
             }
         },
         "globule": {
@@ -8207,9 +8216,9 @@
             "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
             "dev": true,
             "requires": {
-                "glob": "3.1.21",
-                "lodash": "1.0.2",
-                "minimatch": "0.2.14"
+                "glob": "~3.1.21",
+                "lodash": "~1.0.1",
+                "minimatch": "~0.2.11"
             },
             "dependencies": {
                 "glob": {
@@ -8218,9 +8227,9 @@
                     "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "1.2.3",
-                        "inherits": "1.0.2",
-                        "minimatch": "0.2.14"
+                        "graceful-fs": "~1.2.0",
+                        "inherits": "1",
+                        "minimatch": "~0.2.11"
                     }
                 },
                 "graceful-fs": {
@@ -8247,8 +8256,8 @@
                     "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
                     }
                 }
             }
@@ -8259,7 +8268,7 @@
             "integrity": "sha512-ynYqXLoluBKf9XGR1gA59yEJisIL7YHEH4xr3ZziHB5/yl4qWfaK8Js9jGe6gBGCSCKVqiyO30WnRZADvemUNw==",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.1"
+                "sparkles": "^1.0.0"
             }
         },
         "gonzales-pe": {
@@ -8268,7 +8277,7 @@
             "integrity": "sha1-F8e+Z61sr/Ynej44esc26YPSgOw=",
             "dev": true,
             "requires": {
-                "minimist": "1.1.3"
+                "minimist": "1.1.x"
             },
             "dependencies": {
                 "minimist": {
@@ -8291,7 +8300,7 @@
             "integrity": "sha1-5ZnkBzPvgOFlO/6JpfAx7PKqSqo=",
             "dev": true,
             "requires": {
-                "temp": "0.4.0"
+                "temp": "~0.4.0"
             }
         },
         "gulp": {
@@ -8300,19 +8309,19 @@
             "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
             "dev": true,
             "requires": {
-                "archy": "1.0.0",
-                "chalk": "1.1.3",
-                "deprecated": "0.0.1",
-                "gulp-util": "3.0.8",
-                "interpret": "1.1.0",
-                "liftoff": "2.5.0",
-                "minimist": "1.2.0",
-                "orchestrator": "0.3.8",
-                "pretty-hrtime": "1.0.3",
-                "semver": "4.3.6",
-                "tildify": "1.2.0",
-                "v8flags": "2.1.1",
-                "vinyl-fs": "0.3.14"
+                "archy": "^1.0.0",
+                "chalk": "^1.0.0",
+                "deprecated": "^0.0.1",
+                "gulp-util": "^3.0.0",
+                "interpret": "^1.0.0",
+                "liftoff": "^2.1.0",
+                "minimist": "^1.1.0",
+                "orchestrator": "^0.3.0",
+                "pretty-hrtime": "^1.0.0",
+                "semver": "^4.1.0",
+                "tildify": "^1.0.0",
+                "v8flags": "^2.0.2",
+                "vinyl-fs": "^0.3.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -8327,11 +8336,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "semver": {
@@ -8354,11 +8363,11 @@
             "integrity": "sha512-DARK8rNMo4lHOFLGTiHEJdf19GuoBDHqGUaypz+fOhrvOs3iFO7ntdYtdpNxv+AzSJBx/JfypF0yEj9ks1IStQ==",
             "dev": true,
             "requires": {
-                "fancy-log": "1.3.2",
-                "plugin-error": "0.1.2",
-                "rimraf": "2.6.2",
-                "through2": "2.0.3",
-                "vinyl": "2.2.0"
+                "fancy-log": "^1.3.2",
+                "plugin-error": "^0.1.2",
+                "rimraf": "^2.6.2",
+                "through2": "^2.0.3",
+                "vinyl": "^2.1.0"
             },
             "dependencies": {
                 "clone": {
@@ -8385,12 +8394,12 @@
                     "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
                     "dev": true,
                     "requires": {
-                        "clone": "2.1.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.1.2",
-                        "remove-trailing-separator": "1.1.0",
-                        "replace-ext": "1.0.0"
+                        "clone": "^2.1.1",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -8419,10 +8428,10 @@
                     "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "1.1.0",
-                        "arr-diff": "4.0.0",
-                        "arr-union": "3.1.0",
-                        "extend-shallow": "3.0.2"
+                        "ansi-colors": "^1.0.1",
+                        "arr-diff": "^4.0.0",
+                        "arr-union": "^3.1.0",
+                        "extend-shallow": "^3.0.2"
                     }
                 }
             }
@@ -8433,24 +8442,24 @@
             "integrity": "sha512-RxujJJdN8/O6IW2nPugl7YazhmrIEjmiVfPKrWt68r71UCaLKS71Hp0gpKT+F6qOUFtr7KqtifDKaAJPRVvMYQ==",
             "dev": true,
             "requires": {
-                "ansi-colors": "1.1.0",
-                "archy": "1.0.0",
-                "array-sort": "1.0.0",
-                "color-support": "1.1.3",
-                "concat-stream": "1.6.2",
-                "copy-props": "2.0.4",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "interpret": "1.1.0",
-                "isobject": "3.0.1",
-                "liftoff": "2.5.0",
-                "matchdep": "2.0.0",
-                "mute-stdout": "1.0.0",
-                "pretty-hrtime": "1.0.3",
-                "replace-homedir": "1.0.0",
-                "semver-greatest-satisfied-range": "1.1.0",
-                "v8flags": "3.1.1",
-                "yargs": "7.1.0"
+                "ansi-colors": "^1.0.1",
+                "archy": "^1.0.0",
+                "array-sort": "^1.0.0",
+                "color-support": "^1.1.3",
+                "concat-stream": "^1.6.0",
+                "copy-props": "^2.0.1",
+                "fancy-log": "^1.3.2",
+                "gulplog": "^1.0.0",
+                "interpret": "^1.1.0",
+                "isobject": "^3.0.1",
+                "liftoff": "^2.5.0",
+                "matchdep": "^2.0.0",
+                "mute-stdout": "^1.0.0",
+                "pretty-hrtime": "^1.0.0",
+                "replace-homedir": "^1.0.0",
+                "semver-greatest-satisfied-range": "^1.1.0",
+                "v8flags": "^3.0.1",
+                "yargs": "^7.1.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -8465,9 +8474,9 @@
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "dev": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "find-up": {
@@ -8476,8 +8485,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "isobject": {
@@ -8492,11 +8501,11 @@
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "parse-json": {
@@ -8505,7 +8514,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -8514,7 +8523,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -8523,9 +8532,9 @@
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -8540,9 +8549,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -8551,8 +8560,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     }
                 },
                 "strip-bom": {
@@ -8561,7 +8570,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "v8flags": {
@@ -8570,7 +8579,7 @@
                     "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
                     "dev": true,
                     "requires": {
-                        "homedir-polyfill": "1.0.1"
+                        "homedir-polyfill": "^1.0.1"
                     }
                 },
                 "yargs": {
@@ -8579,19 +8588,19 @@
                     "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.3",
-                        "os-locale": "1.4.0",
-                        "read-pkg-up": "1.0.1",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "1.0.2",
-                        "which-module": "1.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "5.0.0"
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
                     }
                 },
                 "yargs-parser": {
@@ -8600,7 +8609,7 @@
                     "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0"
+                        "camelcase": "^3.0.0"
                     }
                 }
             }
@@ -8611,18 +8620,18 @@
             "integrity": "sha512-qmY8NIR6sd/wP11HLZv1z/JvwnAjVe4sGFLiei5bNFLmOd5b6/2fDTi0ACiITWRaAosfAGH93iRXAaw9cYWRiw==",
             "dev": true,
             "requires": {
-                "add-stream": "1.0.0",
-                "concat-stream": "1.6.2",
-                "conventional-changelog": "2.0.1",
-                "fancy-log": "1.3.2",
-                "object-assign": "4.1.1",
-                "plugin-error": "1.0.1",
-                "through2": "2.0.3"
+                "add-stream": "^1.0.0",
+                "concat-stream": "^1.6.0",
+                "conventional-changelog": "^2.0.1",
+                "fancy-log": "^1.3.2",
+                "object-assign": "^4.0.1",
+                "plugin-error": "^1.0.1",
+                "through2": "^2.0.0"
             },
             "dependencies": {
                 "arr-diff": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/arr-diff/-/arr-diff-4.0.0.tgz",
                     "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
                     "dev": true
                 },
@@ -8632,17 +8641,17 @@
                     "integrity": "sha512-WeWcEcR7uBtRZ/uG6DRIlVqsm7UTnxrixaAPoPvfQP7FRPf1qIXL76nGKy4wXq+wO3zOpqYubWUqrYLIL3+xww==",
                     "dev": true,
                     "requires": {
-                        "conventional-changelog-angular": "1.6.6",
-                        "conventional-changelog-atom": "2.0.0",
-                        "conventional-changelog-codemirror": "2.0.0",
-                        "conventional-changelog-core": "3.0.0",
-                        "conventional-changelog-ember": "2.0.0",
-                        "conventional-changelog-eslint": "3.0.0",
-                        "conventional-changelog-express": "2.0.0",
-                        "conventional-changelog-jquery": "0.1.0",
-                        "conventional-changelog-jscs": "0.1.0",
-                        "conventional-changelog-jshint": "2.0.0",
-                        "conventional-changelog-preset-loader": "2.0.0"
+                        "conventional-changelog-angular": "^1.6.6",
+                        "conventional-changelog-atom": "^2.0.0",
+                        "conventional-changelog-codemirror": "^2.0.0",
+                        "conventional-changelog-core": "^3.0.0",
+                        "conventional-changelog-ember": "^2.0.0",
+                        "conventional-changelog-eslint": "^3.0.0",
+                        "conventional-changelog-express": "^2.0.0",
+                        "conventional-changelog-jquery": "^0.1.0",
+                        "conventional-changelog-jscs": "^0.1.0",
+                        "conventional-changelog-jshint": "^2.0.0",
+                        "conventional-changelog-preset-loader": "^2.0.0"
                     }
                 },
                 "conventional-changelog-atom": {
@@ -8651,7 +8660,7 @@
                     "integrity": "sha512-ygwkwyTQYAm4S0tsDt+1yg8tHhRrv7qu9SOWPhNQlVrInFLsfKc0FActCA3de2ChknxpVPY2B53yhKvCAtkBCg==",
                     "dev": true,
                     "requires": {
-                        "q": "1.5.1"
+                        "q": "^1.5.1"
                     }
                 },
                 "conventional-changelog-codemirror": {
@@ -8660,7 +8669,7 @@
                     "integrity": "sha512-pZt/YynJ5m8C9MGV5wkBuhM1eX+8a84fmNrdOylxg/lJV+lgtAiNhnpskNuixtf71iKVWSlEqMQ6z6CH7/Uo5A==",
                     "dev": true,
                     "requires": {
-                        "q": "1.5.1"
+                        "q": "^1.5.1"
                     }
                 },
                 "conventional-changelog-core": {
@@ -8669,19 +8678,19 @@
                     "integrity": "sha512-D2hApWWsdh4tkNgDjn1KtRapxUJ70Sd+V84btTVJJJ96S3cVRES8Ty3ih0TRkOZmDkw/uS0mxrHSskQ/P/Gvsg==",
                     "dev": true,
                     "requires": {
-                        "conventional-changelog-writer": "4.0.0",
-                        "conventional-commits-parser": "3.0.0",
-                        "dateformat": "3.0.3",
-                        "get-pkg-repo": "1.4.0",
-                        "git-raw-commits": "2.0.0",
-                        "git-remote-origin-url": "2.0.0",
-                        "git-semver-tags": "2.0.0",
-                        "lodash": "4.17.10",
-                        "normalize-package-data": "2.4.0",
-                        "q": "1.5.1",
-                        "read-pkg": "1.1.0",
-                        "read-pkg-up": "1.0.1",
-                        "through2": "2.0.3"
+                        "conventional-changelog-writer": "^4.0.0",
+                        "conventional-commits-parser": "^3.0.0",
+                        "dateformat": "^3.0.0",
+                        "get-pkg-repo": "^1.0.0",
+                        "git-raw-commits": "^2.0.0",
+                        "git-remote-origin-url": "^2.0.0",
+                        "git-semver-tags": "^2.0.0",
+                        "lodash": "^4.2.1",
+                        "normalize-package-data": "^2.3.5",
+                        "q": "^1.5.1",
+                        "read-pkg": "^1.1.0",
+                        "read-pkg-up": "^1.0.1",
+                        "through2": "^2.0.0"
                     }
                 },
                 "conventional-changelog-ember": {
@@ -8690,7 +8699,7 @@
                     "integrity": "sha512-s9ZYf3VMdYe8ca8bw1X+he050HZNy9Pm3dBpYA+BunDGFE4Fy7whOvYhWah2U9+j9l6y/whfa0+eHANvZytE9A==",
                     "dev": true,
                     "requires": {
-                        "q": "1.5.1"
+                        "q": "^1.5.1"
                     }
                 },
                 "conventional-changelog-eslint": {
@@ -8699,7 +8708,7 @@
                     "integrity": "sha512-Acn20v+13c+o1OAWKvc9sCCl73Nj2vOMyn+G82euiMZwgYNE9CcBkTnw/GKdBi9KiZMK9uy+SCQ/QyAEE+8vZA==",
                     "dev": true,
                     "requires": {
-                        "q": "1.5.1"
+                        "q": "^1.5.1"
                     }
                 },
                 "conventional-changelog-express": {
@@ -8708,7 +8717,7 @@
                     "integrity": "sha512-2svPjeXCrjwwqnzu/f3qU5LWoLO0jmUIEbtbbSRXAAP9Ag+137b484eJsiRt9DPYXSVzog0Eoek3rvCzfHcphQ==",
                     "dev": true,
                     "requires": {
-                        "q": "1.5.1"
+                        "q": "^1.5.1"
                     }
                 },
                 "conventional-changelog-jshint": {
@@ -8717,8 +8726,8 @@
                     "integrity": "sha512-+4fCln755N0ZzRUEdcDWR5Due71Dsqkbov6K/UmVCnljZvhVh0/wpT4YROoSsAnhfZO8shyWDPFKm6EP20pLQg==",
                     "dev": true,
                     "requires": {
-                        "compare-func": "1.3.2",
-                        "q": "1.5.1"
+                        "compare-func": "^1.3.1",
+                        "q": "^1.5.1"
                     }
                 },
                 "conventional-changelog-preset-loader": {
@@ -8733,16 +8742,16 @@
                     "integrity": "sha512-hMZPe0AQ6Bi05epeK/7hz80xxk59nPA5z/b63TOHq2wigM0/akreOc8N4Jam5b9nFgKWX1e9PdPv2ewgW6bcfg==",
                     "dev": true,
                     "requires": {
-                        "compare-func": "1.3.2",
-                        "conventional-commits-filter": "2.0.0",
-                        "dateformat": "3.0.3",
-                        "handlebars": "4.0.11",
-                        "json-stringify-safe": "5.0.1",
-                        "lodash": "4.17.10",
-                        "meow": "4.0.1",
-                        "semver": "5.5.0",
-                        "split": "1.0.1",
-                        "through2": "2.0.3"
+                        "compare-func": "^1.3.1",
+                        "conventional-commits-filter": "^2.0.0",
+                        "dateformat": "^3.0.0",
+                        "handlebars": "^4.0.2",
+                        "json-stringify-safe": "^5.0.1",
+                        "lodash": "^4.2.1",
+                        "meow": "^4.0.0",
+                        "semver": "^5.5.0",
+                        "split": "^1.0.0",
+                        "through2": "^2.0.0"
                     }
                 },
                 "conventional-commits-filter": {
@@ -8751,8 +8760,8 @@
                     "integrity": "sha512-Cfl0j1/NquB/TMVx7Wrmyq7uRM+/rPQbtVVGwzfkhZ6/yH6fcMmP0Q/9044TBZPTNdGzm46vXFXL14wbET0/Mg==",
                     "dev": true,
                     "requires": {
-                        "is-subset": "0.1.1",
-                        "modify-values": "1.0.1"
+                        "is-subset": "^0.1.1",
+                        "modify-values": "^1.0.0"
                     }
                 },
                 "conventional-commits-parser": {
@@ -8761,13 +8770,13 @@
                     "integrity": "sha512-GWh71U26BLWgMykCp+VghZ4s64wVbtseECcKQ/PvcPZR2cUnz+FUc2J9KjxNl7/ZbCxST8R03c9fc+Vi0umS9Q==",
                     "dev": true,
                     "requires": {
-                        "JSONStream": "1.3.3",
-                        "is-text-path": "1.0.1",
-                        "lodash": "4.17.10",
-                        "meow": "4.0.1",
-                        "split2": "2.2.0",
-                        "through2": "2.0.3",
-                        "trim-off-newlines": "1.0.1"
+                        "JSONStream": "^1.0.4",
+                        "is-text-path": "^1.0.0",
+                        "lodash": "^4.2.1",
+                        "meow": "^4.0.0",
+                        "split2": "^2.0.0",
+                        "through2": "^2.0.0",
+                        "trim-off-newlines": "^1.0.0"
                     }
                 },
                 "git-raw-commits": {
@@ -8776,11 +8785,11 @@
                     "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
                     "dev": true,
                     "requires": {
-                        "dargs": "4.1.0",
-                        "lodash.template": "4.4.0",
-                        "meow": "4.0.1",
-                        "split2": "2.2.0",
-                        "through2": "2.0.3"
+                        "dargs": "^4.0.1",
+                        "lodash.template": "^4.0.2",
+                        "meow": "^4.0.0",
+                        "split2": "^2.0.0",
+                        "through2": "^2.0.0"
                     }
                 },
                 "git-semver-tags": {
@@ -8789,8 +8798,8 @@
                     "integrity": "sha512-lSgFc3zQTul31nFje2Q8XdNcTOI6B4I3mJRPCgFzHQQLfxfqdWTYzdtCaynkK5Xmb2wQlSJoKolhXJ1VhKROnQ==",
                     "dev": true,
                     "requires": {
-                        "meow": "4.0.1",
-                        "semver": "5.5.0"
+                        "meow": "^4.0.0",
+                        "semver": "^5.5.0"
                     }
                 },
                 "meow": {
@@ -8799,36 +8808,36 @@
                     "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "4.2.0",
-                        "decamelize-keys": "1.1.0",
-                        "loud-rejection": "1.6.0",
-                        "minimist": "1.2.0",
-                        "minimist-options": "3.0.2",
-                        "normalize-package-data": "2.4.0",
-                        "read-pkg-up": "3.0.0",
-                        "redent": "2.0.0",
-                        "trim-newlines": "2.0.0"
+                        "camelcase-keys": "^4.0.0",
+                        "decamelize-keys": "^1.0.0",
+                        "loud-rejection": "^1.0.0",
+                        "minimist": "^1.1.3",
+                        "minimist-options": "^3.0.1",
+                        "normalize-package-data": "^2.3.4",
+                        "read-pkg-up": "^3.0.0",
+                        "redent": "^2.0.0",
+                        "trim-newlines": "^2.0.0"
                     },
                     "dependencies": {
                         "read-pkg": {
                             "version": "3.0.0",
-                            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/read-pkg/-/read-pkg-3.0.0.tgz",
                             "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
                             "dev": true,
                             "requires": {
-                                "load-json-file": "4.0.0",
-                                "normalize-package-data": "2.4.0",
-                                "path-type": "3.0.0"
+                                "load-json-file": "^4.0.0",
+                                "normalize-package-data": "^2.3.2",
+                                "path-type": "^3.0.0"
                             }
                         },
                         "read-pkg-up": {
                             "version": "3.0.0",
-                            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
                             "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
                             "dev": true,
                             "requires": {
-                                "find-up": "2.1.0",
-                                "read-pkg": "3.0.0"
+                                "find-up": "^2.0.0",
+                                "read-pkg": "^3.0.0"
                             }
                         }
                     }
@@ -8839,7 +8848,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -8848,7 +8857,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -8863,10 +8872,10 @@
                     "integrity": "sha512-L1zP0dk7vGweZME2i+EeakvUNqSrdiI3F91TwEoYiGrAfUXmVv6fJIq4g82PAXxNsWOp0J7ZqQy/3Szz0ajTxA==",
                     "dev": true,
                     "requires": {
-                        "ansi-colors": "1.1.0",
-                        "arr-diff": "4.0.0",
-                        "arr-union": "3.1.0",
-                        "extend-shallow": "3.0.2"
+                        "ansi-colors": "^1.0.1",
+                        "arr-diff": "^4.0.0",
+                        "arr-union": "^3.1.0",
+                        "extend-shallow": "^3.0.2"
                     }
                 },
                 "read-pkg": {
@@ -8875,9 +8884,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     },
                     "dependencies": {
                         "load-json-file": {
@@ -8886,11 +8895,11 @@
                             "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                             "dev": true,
                             "requires": {
-                                "graceful-fs": "4.1.11",
-                                "parse-json": "2.2.0",
-                                "pify": "2.3.0",
-                                "pinkie-promise": "2.0.1",
-                                "strip-bom": "2.0.0"
+                                "graceful-fs": "^4.1.2",
+                                "parse-json": "^2.2.0",
+                                "pify": "^2.0.0",
+                                "pinkie-promise": "^2.0.0",
+                                "strip-bom": "^2.0.0"
                             }
                         },
                         "path-type": {
@@ -8899,9 +8908,9 @@
                             "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                             "dev": true,
                             "requires": {
-                                "graceful-fs": "4.1.11",
-                                "pify": "2.3.0",
-                                "pinkie-promise": "2.0.1"
+                                "graceful-fs": "^4.1.2",
+                                "pify": "^2.0.0",
+                                "pinkie-promise": "^2.0.0"
                             }
                         }
                     }
@@ -8912,8 +8921,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     },
                     "dependencies": {
                         "find-up": {
@@ -8922,8 +8931,8 @@
                             "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                             "dev": true,
                             "requires": {
-                                "path-exists": "2.1.0",
-                                "pinkie-promise": "2.0.1"
+                                "path-exists": "^2.0.0",
+                                "pinkie-promise": "^2.0.0"
                             }
                         }
                     }
@@ -8934,7 +8943,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 }
             }
@@ -8968,8 +8977,8 @@
                     "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "2.1.1",
-                        "map-obj": "1.0.1"
+                        "camelcase": "^2.0.0",
+                        "map-obj": "^1.0.0"
                     }
                 },
                 "chalk": {
@@ -8978,11 +8987,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "dateformat": {
@@ -8991,8 +9000,8 @@
                     "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "4.0.1",
-                        "meow": "3.7.0"
+                        "get-stdin": "^4.0.1",
+                        "meow": "^3.3.0"
                     }
                 },
                 "find-up": {
@@ -9001,8 +9010,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "get-stdin": {
@@ -9017,24 +9026,24 @@
                     "integrity": "sha1-eJJcS4+LSQBawBoBHFV+YhiUHLs=",
                     "dev": true,
                     "requires": {
-                        "array-differ": "1.0.0",
-                        "array-uniq": "1.0.3",
-                        "beeper": "1.1.1",
-                        "chalk": "1.1.3",
-                        "dateformat": "1.0.12",
-                        "fancy-log": "1.3.2",
-                        "gulplog": "1.0.0",
-                        "has-gulplog": "0.1.0",
-                        "lodash._reescape": "3.0.0",
-                        "lodash._reevaluate": "3.0.0",
-                        "lodash._reinterpolate": "3.0.0",
-                        "lodash.template": "3.6.2",
-                        "minimist": "1.2.0",
-                        "multipipe": "0.1.2",
-                        "object-assign": "3.0.0",
+                        "array-differ": "^1.0.0",
+                        "array-uniq": "^1.0.2",
+                        "beeper": "^1.0.0",
+                        "chalk": "^1.0.0",
+                        "dateformat": "^1.0.11",
+                        "fancy-log": "^1.1.0",
+                        "gulplog": "^1.0.0",
+                        "has-gulplog": "^0.1.0",
+                        "lodash._reescape": "^3.0.0",
+                        "lodash._reevaluate": "^3.0.0",
+                        "lodash._reinterpolate": "^3.0.0",
+                        "lodash.template": "^3.0.0",
+                        "minimist": "^1.1.0",
+                        "multipipe": "^0.1.2",
+                        "object-assign": "^3.0.0",
                         "replace-ext": "0.0.1",
-                        "through2": "2.0.1",
-                        "vinyl": "0.5.3"
+                        "through2": "^2.0.0",
+                        "vinyl": "^0.5.0"
                     }
                 },
                 "indent-string": {
@@ -9043,7 +9052,7 @@
                     "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
                     "dev": true,
                     "requires": {
-                        "repeating": "2.0.1"
+                        "repeating": "^2.0.0"
                     }
                 },
                 "load-json-file": {
@@ -9052,11 +9061,11 @@
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "lodash.template": {
@@ -9065,15 +9074,15 @@
                     "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
                     "dev": true,
                     "requires": {
-                        "lodash._basecopy": "3.0.1",
-                        "lodash._basetostring": "3.0.1",
-                        "lodash._basevalues": "3.0.0",
-                        "lodash._isiterateecall": "3.0.9",
-                        "lodash._reinterpolate": "3.0.0",
-                        "lodash.escape": "3.2.0",
-                        "lodash.keys": "3.1.2",
-                        "lodash.restparam": "3.6.1",
-                        "lodash.templatesettings": "3.1.1"
+                        "lodash._basecopy": "^3.0.0",
+                        "lodash._basetostring": "^3.0.0",
+                        "lodash._basevalues": "^3.0.0",
+                        "lodash._isiterateecall": "^3.0.0",
+                        "lodash._reinterpolate": "^3.0.0",
+                        "lodash.escape": "^3.0.0",
+                        "lodash.keys": "^3.0.0",
+                        "lodash.restparam": "^3.0.0",
+                        "lodash.templatesettings": "^3.0.0"
                     }
                 },
                 "lodash.templatesettings": {
@@ -9082,8 +9091,8 @@
                     "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "3.0.0",
-                        "lodash.escape": "3.2.0"
+                        "lodash._reinterpolate": "^3.0.0",
+                        "lodash.escape": "^3.0.0"
                     }
                 },
                 "map-obj": {
@@ -9098,16 +9107,16 @@
                     "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "2.1.0",
-                        "decamelize": "1.2.0",
-                        "loud-rejection": "1.6.0",
-                        "map-obj": "1.0.1",
-                        "minimist": "1.2.0",
-                        "normalize-package-data": "2.4.0",
-                        "object-assign": "4.1.1",
-                        "read-pkg-up": "1.0.1",
-                        "redent": "1.0.0",
-                        "trim-newlines": "1.0.0"
+                        "camelcase-keys": "^2.0.0",
+                        "decamelize": "^1.1.2",
+                        "loud-rejection": "^1.0.0",
+                        "map-obj": "^1.0.1",
+                        "minimist": "^1.1.3",
+                        "normalize-package-data": "^2.3.4",
+                        "object-assign": "^4.0.1",
+                        "read-pkg-up": "^1.0.1",
+                        "redent": "^1.0.0",
+                        "trim-newlines": "^1.0.0"
                     },
                     "dependencies": {
                         "object-assign": {
@@ -9130,7 +9139,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -9139,7 +9148,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -9148,9 +9157,9 @@
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -9171,9 +9180,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -9182,8 +9191,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     }
                 },
                 "readable-stream": {
@@ -9192,12 +9201,12 @@
                     "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "redent": {
@@ -9206,8 +9215,8 @@
                     "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
                     "dev": true,
                     "requires": {
-                        "indent-string": "2.1.0",
-                        "strip-indent": "1.0.1"
+                        "indent-string": "^2.1.0",
+                        "strip-indent": "^1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -9222,7 +9231,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "strip-indent": {
@@ -9231,7 +9240,7 @@
                     "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "4.0.1"
+                        "get-stdin": "^4.0.1"
                     }
                 },
                 "supports-color": {
@@ -9246,8 +9255,8 @@
                     "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "2.0.6",
-                        "xtend": "4.0.1"
+                        "readable-stream": "~2.0.0",
+                        "xtend": "~4.0.0"
                     }
                 },
                 "trim-newlines": {
@@ -9264,8 +9273,8 @@
             "integrity": "sha1-Uef+wTozxARXjRjBWJ0bW8Rf4dY=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "through2": "2.0.3"
+                "gulp-util": "^3.0.7",
+                "through2": "^2.0.0"
             }
         },
         "gulp-highlight-files": {
@@ -9274,9 +9283,9 @@
             "integrity": "sha512-lGLApyg6ycB45MWsLx9WbsAv0iTPxGTUH+Lq8evAXUXCFBPITG2JmLxQ3OYWA1/AOItDeAX5yza1HdLlaIXIPA==",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "highlight.js": "9.12.0",
-                "through2": "2.0.3"
+                "gulp-util": "^3.0.8",
+                "highlight.js": "^9.12.0",
+                "through2": "^2.0.3"
             }
         },
         "gulp-htmlmin": {
@@ -9285,11 +9294,11 @@
             "integrity": "sha512-9FX2d4QbSm+4WuXughjZ6GJn4jx0C4BmyK2e+AS6567NPAetNfB+hv2ZL/88AacdC+8OS+TzeIjfKRXPSAgOYw==",
             "dev": true,
             "requires": {
-                "bufferstreams": "1.1.3",
-                "html-minifier": "3.5.19",
-                "plugin-error": "0.1.2",
-                "readable-stream": "2.3.6",
-                "tryit": "1.0.3"
+                "bufferstreams": "^1.1.0",
+                "html-minifier": "^3.0.3",
+                "plugin-error": "^0.1.2",
+                "readable-stream": "^2.0.2",
+                "tryit": "^1.0.1"
             }
         },
         "gulp-if": {
@@ -9298,9 +9307,9 @@
             "integrity": "sha1-pJe351cwBQQcqivIt92jyARE1ik=",
             "dev": true,
             "requires": {
-                "gulp-match": "1.0.3",
-                "ternary-stream": "2.0.1",
-                "through2": "2.0.3"
+                "gulp-match": "^1.0.3",
+                "ternary-stream": "^2.0.1",
+                "through2": "^2.0.1"
             }
         },
         "gulp-markdown": {
@@ -9309,9 +9318,9 @@
             "integrity": "sha1-N83GE3n7A5hB+myrSYSo55Eop3I=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "marked": "0.3.19",
-                "through2": "2.0.3"
+                "gulp-util": "^3.0.0",
+                "marked": "^0.3.2",
+                "through2": "^2.0.0"
             }
         },
         "gulp-match": {
@@ -9320,7 +9329,7 @@
             "integrity": "sha1-kcfA1/Kb7NZgbVfYCn+Hdqh6uo4=",
             "dev": true,
             "requires": {
-                "minimatch": "3.0.4"
+                "minimatch": "^3.0.3"
             }
         },
         "gulp-rename": {
@@ -9335,11 +9344,11 @@
             "integrity": "sha512-UATbRpSDsyXCnpYSPBUEvdvtSEzksJs7/oQ0CujIpzKqKrO6vlnYwhX2UTsGrf4rNLwqlSSaM271It0uHYvJ3Q==",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "lodash.clonedeep": "4.5.0",
-                "node-sass": "4.9.2",
-                "through2": "2.0.3",
-                "vinyl-sourcemaps-apply": "0.2.1"
+                "gulp-util": "^3.0",
+                "lodash.clonedeep": "^4.3.2",
+                "node-sass": "^4.8.3",
+                "through2": "^2.0.0",
+                "vinyl-sourcemaps-apply": "^0.2.0"
             }
         },
         "gulp-transform": {
@@ -9348,8 +9357,8 @@
             "integrity": "sha1-esfj4+Bu1+vFKEe5tOKjaGsi5aI=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "lodash": "4.17.10"
+                "gulp-util": "^3.0.8",
+                "lodash": "^4.17.4"
             }
         },
         "gulp-util": {
@@ -9358,24 +9367,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.2.0",
-                "fancy-log": "1.3.2",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
+                "array-differ": "^1.0.0",
+                "array-uniq": "^1.0.2",
+                "beeper": "^1.0.0",
+                "chalk": "^1.0.0",
+                "dateformat": "^2.0.0",
+                "fancy-log": "^1.1.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash._reescape": "^3.0.0",
+                "lodash._reevaluate": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.template": "^3.0.0",
+                "minimist": "^1.1.0",
+                "multipipe": "^0.1.2",
+                "object-assign": "^3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "through2": "^2.0.0",
+                "vinyl": "^0.5.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -9390,11 +9399,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "dateformat": {
@@ -9409,15 +9418,15 @@
                     "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
                     "dev": true,
                     "requires": {
-                        "lodash._basecopy": "3.0.1",
-                        "lodash._basetostring": "3.0.1",
-                        "lodash._basevalues": "3.0.0",
-                        "lodash._isiterateecall": "3.0.9",
-                        "lodash._reinterpolate": "3.0.0",
-                        "lodash.escape": "3.2.0",
-                        "lodash.keys": "3.1.2",
-                        "lodash.restparam": "3.6.1",
-                        "lodash.templatesettings": "3.1.1"
+                        "lodash._basecopy": "^3.0.0",
+                        "lodash._basetostring": "^3.0.0",
+                        "lodash._basevalues": "^3.0.0",
+                        "lodash._isiterateecall": "^3.0.0",
+                        "lodash._reinterpolate": "^3.0.0",
+                        "lodash.escape": "^3.0.0",
+                        "lodash.keys": "^3.0.0",
+                        "lodash.restparam": "^3.0.0",
+                        "lodash.templatesettings": "^3.0.0"
                     }
                 },
                 "lodash.templatesettings": {
@@ -9426,8 +9435,8 @@
                     "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
                     "dev": true,
                     "requires": {
-                        "lodash._reinterpolate": "3.0.0",
-                        "lodash.escape": "3.2.0"
+                        "lodash._reinterpolate": "^3.0.0",
+                        "lodash.escape": "^3.0.0"
                     }
                 },
                 "object-assign": {
@@ -9450,7 +9459,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "1.0.1"
+                "glogg": "^1.0.0"
             }
         },
         "handle-thing": {
@@ -9465,10 +9474,10 @@
             "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "optimist": "0.6.1",
-                "source-map": "0.4.4",
-                "uglify-js": "2.8.29"
+                "async": "^1.4.0",
+                "optimist": "^0.6.1",
+                "source-map": "^0.4.4",
+                "uglify-js": "^2.6"
             },
             "dependencies": {
                 "source-map": {
@@ -9477,7 +9486,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 },
                 "uglify-js": {
@@ -9487,9 +9496,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "source-map": "0.5.7",
-                        "uglify-to-browserify": "1.0.2",
-                        "yargs": "3.10.0"
+                        "source-map": "~0.5.1",
+                        "uglify-to-browserify": "~1.0.0",
+                        "yargs": "~3.10.0"
                     },
                     "dependencies": {
                         "source-map": {
@@ -9515,8 +9524,8 @@
             "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
             "dev": true,
             "requires": {
-                "ajv": "5.5.2",
-                "har-schema": "2.0.0"
+                "ajv": "^5.1.0",
+                "har-schema": "^2.0.0"
             },
             "dependencies": {
                 "ajv": {
@@ -9525,10 +9534,10 @@
                     "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
                     "dev": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "fast-deep-equal": "1.1.0",
-                        "fast-json-stable-stringify": "2.0.0",
-                        "json-schema-traverse": "0.3.1"
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
                     }
                 },
                 "fast-deep-equal": {
@@ -9551,7 +9560,7 @@
             "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.1.1"
             }
         },
         "has-ansi": {
@@ -9560,7 +9569,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-binary2": {
@@ -9598,7 +9607,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.1"
+                "sparkles": "^1.0.0"
             }
         },
         "has-symbols": {
@@ -9619,9 +9628,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -9638,8 +9647,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -9648,7 +9657,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -9657,7 +9666,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -9668,19 +9677,19 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
         },
         "hash-base": {
             "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/hash-base/-/hash-base-3.0.4.tgz",
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "hash.js": {
@@ -9689,8 +9698,8 @@
             "integrity": "sha512-eWI5HG9Np+eHV1KQhisXWwM+4EPPYe5dFX1UZZH7k/E3JzDEazVH+VGlZi6R94ZqImq+A3D1mCEtrFIfg/E7sA==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
             }
         },
         "hawk": {
@@ -9699,10 +9708,10 @@
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "he": {
@@ -9717,8 +9726,8 @@
             "integrity": "sha1-lTWXMZfBRLCWE81l0xfvGZY70C0=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2",
-                "upper-case": "1.1.3"
+                "no-case": "^2.2.0",
+                "upper-case": "^1.1.3"
             }
         },
         "highlight.js": {
@@ -9734,8 +9743,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "lodash": "4.17.10",
-                "request": "2.87.0"
+                "lodash": "^4.0.0",
+                "request": "^2.0.0"
             }
         },
         "hmac-drbg": {
@@ -9744,9 +9753,9 @@
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "requires": {
-                "hash.js": "1.1.5",
-                "minimalistic-assert": "1.0.1",
-                "minimalistic-crypto-utils": "1.0.1"
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "hoek": {
@@ -9761,7 +9770,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "hosted-git-info": {
@@ -9776,10 +9785,10 @@
             "integrity": "sha1-h3dMCUnlE/QuhFdbPEVoH63ioLI=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "obuf": "1.1.2",
-                "readable-stream": "2.3.6",
-                "wbuf": "1.7.3"
+                "inherits": "^2.0.1",
+                "obuf": "^1.0.0",
+                "readable-stream": "^2.0.1",
+                "wbuf": "^1.1.0"
             }
         },
         "html-encoding-sniffer": {
@@ -9788,7 +9797,7 @@
             "integrity": "sha512-71lZziiDnsuabfdYiUeWdCVyKuqwWi23L8YeIgV9jSSZHCtb6wB1BKWooH7L3tn4/FuZJMVWyNaIDr4RGmaSYw==",
             "dev": true,
             "requires": {
-                "whatwg-encoding": "1.0.3"
+                "whatwg-encoding": "^1.0.1"
             }
         },
         "html-entities": {
@@ -9803,13 +9812,13 @@
             "integrity": "sha512-Qr2JC9nsjK8oCrEmuB430ZIA8YWbF3D5LSjywD75FTuXmeqacwHgIM8wp3vHYzzPbklSjp53RdmDuzR4ub2HzA==",
             "dev": true,
             "requires": {
-                "camel-case": "3.0.0",
-                "clean-css": "4.1.11",
-                "commander": "2.16.0",
-                "he": "1.1.1",
-                "param-case": "2.1.1",
-                "relateurl": "0.2.7",
-                "uglify-js": "3.4.6"
+                "camel-case": "3.0.x",
+                "clean-css": "4.1.x",
+                "commander": "2.16.x",
+                "he": "1.1.x",
+                "param-case": "2.1.x",
+                "relateurl": "0.2.x",
+                "uglify-js": "3.4.x"
             },
             "dependencies": {
                 "commander": {
@@ -9824,8 +9833,8 @@
                     "integrity": "sha512-O1D7L6WcOzS1qW2ehopEm4cWm5yA6bQBozlks8jO8ODxYCy4zv+bR/la4Lwp01tpkYGNonnpXvUpYtrvSu8Yzg==",
                     "dev": true,
                     "requires": {
-                        "commander": "2.16.0",
-                        "source-map": "0.6.1"
+                        "commander": "~2.16.0",
+                        "source-map": "~0.6.1"
                     }
                 }
             }
@@ -9842,12 +9851,12 @@
             "integrity": "sha1-sBq71yOsqqeze2r0SS69oD2d03s=",
             "dev": true,
             "requires": {
-                "html-minifier": "3.5.19",
-                "loader-utils": "0.2.17",
-                "lodash": "4.17.10",
-                "pretty-error": "2.1.1",
-                "tapable": "1.0.0",
-                "toposort": "1.0.7",
+                "html-minifier": "^3.2.3",
+                "loader-utils": "^0.2.16",
+                "lodash": "^4.17.3",
+                "pretty-error": "^2.0.2",
+                "tapable": "^1.0.0",
+                "toposort": "^1.0.0",
                 "util.promisify": "1.0.0"
             }
         },
@@ -9857,12 +9866,12 @@
             "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
             "dev": true,
             "requires": {
-                "domelementtype": "1.3.0",
-                "domhandler": "2.4.2",
-                "domutils": "1.7.0",
-                "entities": "1.1.1",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "domelementtype": "^1.3.0",
+                "domhandler": "^2.3.0",
+                "domutils": "^1.5.1",
+                "entities": "^1.1.1",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "http-deceiver": {
@@ -9877,10 +9886,10 @@
             "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
             "dev": true,
             "requires": {
-                "depd": "1.1.2",
+                "depd": "~1.1.2",
                 "inherits": "2.0.3",
                 "setprototypeof": "1.1.0",
-                "statuses": "1.5.0"
+                "statuses": ">= 1.4.0 < 2"
             }
         },
         "http-parser-js": {
@@ -9895,9 +9904,9 @@
             "integrity": "sha512-Taqn+3nNvYRfJ3bGvKfBSRwy1v6eePlm3oc/aWVxZp57DQr5Eq3xhKJi7Z4hZpS8PC3H4qI+Yly5EmFacGuA/g==",
             "dev": true,
             "requires": {
-                "eventemitter3": "3.1.0",
-                "follow-redirects": "1.5.2",
-                "requires-port": "1.0.0"
+                "eventemitter3": "^3.0.0",
+                "follow-redirects": "^1.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "http-proxy-agent": {
@@ -9906,7 +9915,7 @@
             "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
             "dev": true,
             "requires": {
-                "agent-base": "4.2.1",
+                "agent-base": "4",
                 "debug": "3.1.0"
             },
             "dependencies": {
@@ -9927,10 +9936,10 @@
             "integrity": "sha512-Fs25KVMPAIIcgjMZkVHJoKg9VcXcC1C8yb9JUgeDvVXY0S/zgVIhMb+qVswDIgtJe2DfckMSY2d6TuTEutlk6Q==",
             "dev": true,
             "requires": {
-                "http-proxy": "1.17.0",
-                "is-glob": "4.0.0",
-                "lodash": "4.17.10",
-                "micromatch": "3.1.10"
+                "http-proxy": "^1.16.2",
+                "is-glob": "^4.0.0",
+                "lodash": "^4.17.5",
+                "micromatch": "^3.1.9"
             },
             "dependencies": {
                 "arr-diff": {
@@ -9951,16 +9960,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -9969,7 +9978,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -9980,13 +9989,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -9995,7 +10004,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -10004,7 +10013,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -10013,7 +10022,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -10022,7 +10031,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -10033,7 +10042,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -10042,7 +10051,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -10053,9 +10062,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -10072,14 +10081,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -10088,7 +10097,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -10097,7 +10106,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -10108,10 +10117,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -10120,7 +10129,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -10131,7 +10140,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -10140,7 +10149,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -10149,9 +10158,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-extglob": {
@@ -10166,7 +10175,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 },
                 "is-number": {
@@ -10175,7 +10184,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -10184,7 +10193,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -10207,19 +10216,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -10230,9 +10239,9 @@
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.14.2"
+                "assert-plus": "^1.0.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "httpntlm": {
@@ -10241,13 +10250,13 @@
             "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
             "dev": true,
             "requires": {
-                "httpreq": "0.4.24",
-                "underscore": "1.7.0"
+                "httpreq": ">=0.4.22",
+                "underscore": "~1.7.0"
             },
             "dependencies": {
                 "underscore": {
                     "version": "1.7.0",
-                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/underscore/-/underscore-1.7.0.tgz",
                     "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
                     "dev": true
                 }
@@ -10271,8 +10280,8 @@
             "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
             "dev": true,
             "requires": {
-                "agent-base": "4.2.1",
-                "debug": "3.1.0"
+                "agent-base": "^4.1.0",
+                "debug": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -10292,9 +10301,9 @@
             "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
             "dev": true,
             "requires": {
-                "is-ci": "1.1.0",
-                "normalize-path": "1.0.0",
-                "strip-indent": "2.0.0"
+                "is-ci": "^1.0.10",
+                "normalize-path": "^1.0.0",
+                "strip-indent": "^2.0.0"
             },
             "dependencies": {
                 "normalize-path": {
@@ -10311,7 +10320,7 @@
             "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
             "dev": true,
             "requires": {
-                "safer-buffer": "2.1.2"
+                "safer-buffer": ">= 2.1.2 < 3"
             }
         },
         "ieee754": {
@@ -10334,25 +10343,25 @@
         },
         "import-cwd": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/import-cwd/-/import-cwd-2.1.0.tgz",
             "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
             "dev": true,
             "requires": {
-                "import-from": "2.1.0"
+                "import-from": "^2.1.0"
             }
         },
         "import-from": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/import-from/-/import-from-2.1.0.tgz",
             "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
             "dev": true,
             "requires": {
-                "resolve-from": "3.0.0"
+                "resolve-from": "^3.0.0"
             },
             "dependencies": {
                 "resolve-from": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/resolve-from/-/resolve-from-3.0.0.tgz",
                     "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
                     "dev": true
                 }
@@ -10370,8 +10379,8 @@
             "integrity": "sha512-vAaZHieK9qjGo58agRBg+bhHX3hoTZU/Oa3GESWLz7t1U62fk63aHuDJJEteXoDeTCcPmUT+z38gkHPZkkmpmQ==",
             "dev": true,
             "requires": {
-                "pkg-dir": "2.0.0",
-                "resolve-cwd": "2.0.0"
+                "pkg-dir": "^2.0.0",
+                "resolve-cwd": "^2.0.0"
             }
         },
         "imurmurhash": {
@@ -10406,7 +10415,7 @@
         },
         "inflection": {
             "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/inflection/-/inflection-1.12.0.tgz",
             "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
             "dev": true,
             "optional": true
@@ -10417,8 +10426,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -10439,19 +10448,19 @@
             "integrity": "sha512-f9K2MMx/G/AVmJSaZg2a+GVLRRmTdlGLbwxsibNd6yNTxXujqxPypjCnxnC0y4+Wb/rNY5KyKuq06AO5jrE+7w==",
             "dev": true,
             "requires": {
-                "ansi-escapes": "3.1.0",
-                "chalk": "2.4.1",
-                "cli-cursor": "2.1.0",
-                "cli-width": "2.2.0",
-                "external-editor": "3.0.0",
-                "figures": "2.0.0",
-                "lodash": "4.17.10",
+                "ansi-escapes": "^3.0.0",
+                "chalk": "^2.0.0",
+                "cli-cursor": "^2.1.0",
+                "cli-width": "^2.0.0",
+                "external-editor": "^3.0.0",
+                "figures": "^2.0.0",
+                "lodash": "^4.3.0",
                 "mute-stream": "0.0.7",
-                "run-async": "2.3.0",
-                "rxjs": "6.2.2",
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0",
-                "through": "2.3.8"
+                "run-async": "^2.2.0",
+                "rxjs": "^6.1.0",
+                "string-width": "^2.1.0",
+                "strip-ansi": "^4.0.0",
+                "through": "^2.3.6"
             },
             "dependencies": {
                 "ansi-escapes": {
@@ -10472,7 +10481,7 @@
                     "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
                     "dev": true,
                     "requires": {
-                        "restore-cursor": "2.0.0"
+                        "restore-cursor": "^2.0.0"
                     }
                 },
                 "figures": {
@@ -10481,7 +10490,7 @@
                     "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
                     "dev": true,
                     "requires": {
-                        "escape-string-regexp": "1.0.5"
+                        "escape-string-regexp": "^1.0.5"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -10496,7 +10505,7 @@
                     "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "1.2.0"
+                        "mimic-fn": "^1.0.0"
                     }
                 },
                 "restore-cursor": {
@@ -10505,8 +10514,8 @@
                     "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
                     "dev": true,
                     "requires": {
-                        "onetime": "2.0.1",
-                        "signal-exit": "3.0.2"
+                        "onetime": "^2.0.0",
+                        "signal-exit": "^3.0.2"
                     }
                 },
                 "rxjs": {
@@ -10515,7 +10524,7 @@
                     "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
                     "dev": true,
                     "requires": {
-                        "tslib": "1.9.3"
+                        "tslib": "^1.9.0"
                     }
                 },
                 "string-width": {
@@ -10524,8 +10533,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -10534,7 +10543,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -10545,7 +10554,7 @@
             "integrity": "sha1-rp+/k7mEh4eF1QqN4bNWlWBYz1w=",
             "dev": true,
             "requires": {
-                "meow": "3.7.0"
+                "meow": "^3.3.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -10560,8 +10569,8 @@
                     "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "2.1.1",
-                        "map-obj": "1.0.1"
+                        "camelcase": "^2.0.0",
+                        "map-obj": "^1.0.0"
                     }
                 },
                 "find-up": {
@@ -10570,8 +10579,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "get-stdin": {
@@ -10586,7 +10595,7 @@
                     "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
                     "dev": true,
                     "requires": {
-                        "repeating": "2.0.1"
+                        "repeating": "^2.0.0"
                     }
                 },
                 "load-json-file": {
@@ -10595,11 +10604,11 @@
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "map-obj": {
@@ -10614,16 +10623,16 @@
                     "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "2.1.0",
-                        "decamelize": "1.2.0",
-                        "loud-rejection": "1.6.0",
-                        "map-obj": "1.0.1",
-                        "minimist": "1.2.0",
-                        "normalize-package-data": "2.4.0",
-                        "object-assign": "4.1.1",
-                        "read-pkg-up": "1.0.1",
-                        "redent": "1.0.0",
-                        "trim-newlines": "1.0.0"
+                        "camelcase-keys": "^2.0.0",
+                        "decamelize": "^1.1.2",
+                        "loud-rejection": "^1.0.0",
+                        "map-obj": "^1.0.1",
+                        "minimist": "^1.1.3",
+                        "normalize-package-data": "^2.3.4",
+                        "object-assign": "^4.0.1",
+                        "read-pkg-up": "^1.0.1",
+                        "redent": "^1.0.0",
+                        "trim-newlines": "^1.0.0"
                     }
                 },
                 "parse-json": {
@@ -10632,7 +10641,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -10641,7 +10650,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -10650,9 +10659,9 @@
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -10667,9 +10676,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -10678,8 +10687,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     }
                 },
                 "redent": {
@@ -10688,8 +10697,8 @@
                     "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
                     "dev": true,
                     "requires": {
-                        "indent-string": "2.1.0",
-                        "strip-indent": "1.0.1"
+                        "indent-string": "^2.1.0",
+                        "strip-indent": "^1.0.1"
                     }
                 },
                 "strip-bom": {
@@ -10698,7 +10707,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "strip-indent": {
@@ -10707,7 +10716,7 @@
                     "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "4.0.1"
+                        "get-stdin": "^4.0.1"
                     }
                 },
                 "trim-newlines": {
@@ -10732,7 +10741,7 @@
         },
         "ip": {
             "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/ip/-/ip-1.1.5.tgz",
             "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
             "dev": true
         },
@@ -10748,8 +10757,8 @@
             "integrity": "sha512-dOWoqflvcydARa360Gvv18DZ/gRuHKi2NU/wU5X1ZFzdYfH29nkiNZsF3mp4OJ3H4yo9Mx8A/uAGNzpzPN3yBA==",
             "dev": true,
             "requires": {
-                "is-relative": "1.0.0",
-                "is-windows": "1.0.2"
+                "is-relative": "^1.0.0",
+                "is-windows": "^1.0.1"
             }
         },
         "is-accessor-descriptor": {
@@ -10758,7 +10767,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-alphabetical": {
@@ -10779,8 +10788,8 @@
             "integrity": "sha512-pyfU/0kHdISIgslFfZN9nfY1Gk3MquQgUm1mJTjdkEPpkAKNWuBTSqFwewOpR7N351VkErCiyV71zX7mlQQqsg==",
             "dev": true,
             "requires": {
-                "is-alphabetical": "1.0.2",
-                "is-decimal": "1.0.2"
+                "is-alphabetical": "^1.0.0",
+                "is-decimal": "^1.0.0"
             }
         },
         "is-arrayish": {
@@ -10795,7 +10804,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -10810,7 +10819,7 @@
             "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
             "dev": true,
             "requires": {
-                "builtin-modules": "1.1.1"
+                "builtin-modules": "^1.0.0"
             }
         },
         "is-callable": {
@@ -10825,7 +10834,7 @@
             "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
             "dev": true,
             "requires": {
-                "ci-info": "1.1.3"
+                "ci-info": "^1.0.0"
             }
         },
         "is-data-descriptor": {
@@ -10834,7 +10843,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-date-object": {
@@ -10855,9 +10864,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -10886,7 +10895,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -10907,7 +10916,7 @@
             "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-fullwidth-code-point": {
@@ -10916,7 +10925,7 @@
             "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
             "dev": true,
             "requires": {
-                "number-is-nan": "1.0.1"
+                "number-is-nan": "^1.0.0"
             }
         },
         "is-glob": {
@@ -10925,7 +10934,7 @@
             "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             }
         },
         "is-hexadecimal": {
@@ -10940,7 +10949,7 @@
             "integrity": "sha1-fhR75HaNxGbbO/shzGCzHmrWk5M=",
             "dev": true,
             "requires": {
-                "lower-case": "1.1.4"
+                "lower-case": "^1.1.0"
             }
         },
         "is-module": {
@@ -10963,11 +10972,11 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "is-my-ip-valid": "1.0.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "is-my-ip-valid": "^1.0.0",
+                "jsonpointer": "^4.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "is-number": {
@@ -10976,7 +10985,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-obj": {
@@ -10991,7 +11000,7 @@
             "integrity": "sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==",
             "dev": true,
             "requires": {
-                "symbol-observable": "1.2.0"
+                "symbol-observable": "^1.1.0"
             }
         },
         "is-path-cwd": {
@@ -11006,7 +11015,7 @@
             "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
             "dev": true,
             "requires": {
-                "is-path-inside": "1.0.1"
+                "is-path-inside": "^1.0.0"
             }
         },
         "is-path-inside": {
@@ -11015,7 +11024,7 @@
             "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
             "dev": true,
             "requires": {
-                "path-is-inside": "1.0.2"
+                "path-is-inside": "^1.0.1"
             }
         },
         "is-plain-obj": {
@@ -11030,7 +11039,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -11072,7 +11081,7 @@
             "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
             "dev": true,
             "requires": {
-                "has": "1.0.3"
+                "has": "^1.0.1"
             }
         },
         "is-regexp": {
@@ -11087,7 +11096,7 @@
             "integrity": "sha512-Kw/ReK0iqwKeu0MITLFuj0jbPAmEiOsIwyIXvvbfa6QfmN9pkD1M+8pdk7Rl/dTKbH34/XBFMbgD4iMJhLQbGA==",
             "dev": true,
             "requires": {
-                "is-unc-path": "1.0.0"
+                "is-unc-path": "^1.0.0"
             }
         },
         "is-relative-path": {
@@ -11126,7 +11135,7 @@
             "integrity": "sha1-Thqg+1G/vLPpJogAE5cgLBd1tm4=",
             "dev": true,
             "requires": {
-                "text-extensions": "1.7.0"
+                "text-extensions": "^1.0.0"
             }
         },
         "is-typedarray": {
@@ -11141,7 +11150,7 @@
             "integrity": "sha512-mrGpVd0fs7WWLfVsStvgF6iEJnbjDFZh9/emhRDcGWTduTfNHd9CHeUwH3gYIjdbwo4On6hunkztwOaAw0yllQ==",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.2"
             }
         },
         "is-upper-case": {
@@ -11150,7 +11159,7 @@
             "integrity": "sha1-jQsfp+eTOh5YSDYA7H2WYcuvdW8=",
             "dev": true,
             "requires": {
-                "upper-case": "1.1.3"
+                "upper-case": "^1.1.0"
             }
         },
         "is-url": {
@@ -11201,7 +11210,7 @@
             "integrity": "sha512-8cJBL5tTd2OS0dM4jz07wQd5g0dCCqIhUxPIGtZfa5L6hWlvV5MHTITy/DBAsF+Oe2LS1X3krBUhNwaGUWpWxw==",
             "dev": true,
             "requires": {
-                "buffer-alloc": "1.2.0"
+                "buffer-alloc": "^1.2.0"
             }
         },
         "isexe": {
@@ -11231,20 +11240,20 @@
             "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
             "dev": true,
             "requires": {
-                "abbrev": "1.0.9",
-                "async": "1.5.2",
-                "escodegen": "1.8.1",
-                "esprima": "2.7.3",
-                "glob": "5.0.15",
-                "handlebars": "4.0.11",
-                "js-yaml": "3.12.0",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "once": "1.4.0",
-                "resolve": "1.1.7",
-                "supports-color": "3.2.3",
-                "which": "1.3.1",
-                "wordwrap": "1.0.0"
+                "abbrev": "1.0.x",
+                "async": "1.x",
+                "escodegen": "1.8.x",
+                "esprima": "2.7.x",
+                "glob": "^5.0.15",
+                "handlebars": "^4.0.1",
+                "js-yaml": "3.x",
+                "mkdirp": "0.5.x",
+                "nopt": "3.x",
+                "once": "1.x",
+                "resolve": "1.1.x",
+                "supports-color": "^3.1.0",
+                "which": "^1.1.1",
+                "wordwrap": "^1.0.0"
             },
             "dependencies": {
                 "abbrev": {
@@ -11259,11 +11268,11 @@
                     "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
                     "dev": true,
                     "requires": {
-                        "esprima": "2.7.3",
-                        "estraverse": "1.9.3",
-                        "esutils": "2.0.2",
-                        "optionator": "0.8.2",
-                        "source-map": "0.2.0"
+                        "esprima": "^2.7.1",
+                        "estraverse": "^1.9.1",
+                        "esutils": "^2.0.2",
+                        "optionator": "^0.8.1",
+                        "source-map": "~0.2.0"
                     }
                 },
                 "esprima": {
@@ -11284,11 +11293,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "has-flag": {
@@ -11310,7 +11319,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 },
                 "supports-color": {
@@ -11319,7 +11328,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 },
                 "wordwrap": {
@@ -11348,10 +11357,10 @@
             "integrity": "sha1-2W7t4B7wOskJwAnpyORVGX1IwgE=",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "jest-get-type": "22.4.3",
-                "leven": "2.1.0",
-                "pretty-format": "23.2.0"
+                "chalk": "^2.0.1",
+                "jest-get-type": "^22.1.0",
+                "leven": "^2.1.0",
+                "pretty-format": "^23.2.0"
             }
         },
         "js-base64": {
@@ -11372,8 +11381,8 @@
             "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
             "dev": true,
             "requires": {
-                "argparse": "1.0.10",
-                "esprima": "4.0.1"
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
             }
         },
         "jsbn": {
@@ -11389,26 +11398,26 @@
             "integrity": "sha1-/eKcEJwyoRMeC2xlkU5kGY+Xw3A=",
             "dev": true,
             "requires": {
-                "abab": "1.0.4",
-                "acorn": "2.7.0",
-                "acorn-globals": "1.0.9",
-                "array-equal": "1.0.0",
-                "content-type-parser": "1.0.2",
-                "cssom": "0.3.4",
-                "cssstyle": "0.2.37",
-                "escodegen": "1.11.0",
-                "html-encoding-sniffer": "1.0.2",
-                "iconv-lite": "0.4.23",
-                "nwmatcher": "1.4.4",
-                "parse5": "1.5.1",
-                "request": "2.87.0",
-                "sax": "1.2.4",
-                "symbol-tree": "3.2.2",
-                "tough-cookie": "2.4.3",
-                "webidl-conversions": "3.0.1",
-                "whatwg-encoding": "1.0.3",
-                "whatwg-url": "3.1.0",
-                "xml-name-validator": "2.0.1"
+                "abab": "^1.0.0",
+                "acorn": "^2.4.0",
+                "acorn-globals": "^1.0.4",
+                "array-equal": "^1.0.0",
+                "content-type-parser": "^1.0.1",
+                "cssom": ">= 0.3.0 < 0.4.0",
+                "cssstyle": ">= 0.2.36 < 0.3.0",
+                "escodegen": "^1.6.1",
+                "html-encoding-sniffer": "^1.0.1",
+                "iconv-lite": "^0.4.13",
+                "nwmatcher": ">= 1.3.7 < 2.0.0",
+                "parse5": "^1.5.1",
+                "request": "^2.55.0",
+                "sax": "^1.1.4",
+                "symbol-tree": ">= 3.1.0 < 4.0.0",
+                "tough-cookie": "^2.3.1",
+                "webidl-conversions": "^3.0.1",
+                "whatwg-encoding": "^1.0.1",
+                "whatwg-url": "^3.0.0",
+                "xml-name-validator": ">= 2.0.1 < 3.0.0"
             }
         },
         "json-parse-better-errors": {
@@ -11435,7 +11444,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -11462,7 +11471,7 @@
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.6"
             }
         },
         "jsonify": {
@@ -11502,31 +11511,31 @@
             "integrity": "sha512-rECezBeY7mjzGUWhFlB7CvPHgkHJLXyUmWg+6vHCEsdWNUTnmiS6jRrIMcJEWgU2DUGZzGWG0bTRVky8fsDTOA==",
             "dev": true,
             "requires": {
-                "bluebird": "3.5.1",
-                "body-parser": "1.18.3",
-                "chokidar": "2.0.4",
-                "colors": "1.1.2",
-                "combine-lists": "1.0.1",
-                "connect": "3.6.6",
-                "core-js": "2.5.7",
-                "di": "0.0.1",
-                "dom-serialize": "2.2.1",
-                "expand-braces": "0.1.2",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "http-proxy": "1.17.0",
-                "isbinaryfile": "3.0.3",
-                "lodash": "4.17.10",
-                "log4js": "2.11.0",
-                "mime": "1.6.0",
-                "minimatch": "3.0.4",
-                "optimist": "0.6.1",
-                "qjobs": "1.2.0",
-                "range-parser": "1.2.0",
-                "rimraf": "2.6.2",
-                "safe-buffer": "5.1.2",
+                "bluebird": "^3.3.0",
+                "body-parser": "^1.16.1",
+                "chokidar": "^2.0.3",
+                "colors": "^1.1.0",
+                "combine-lists": "^1.0.0",
+                "connect": "^3.6.0",
+                "core-js": "^2.2.0",
+                "di": "^0.0.1",
+                "dom-serialize": "^2.2.0",
+                "expand-braces": "^0.1.1",
+                "glob": "^7.1.1",
+                "graceful-fs": "^4.1.2",
+                "http-proxy": "^1.13.0",
+                "isbinaryfile": "^3.0.0",
+                "lodash": "^4.17.4",
+                "log4js": "^2.5.3",
+                "mime": "^1.3.4",
+                "minimatch": "^3.0.2",
+                "optimist": "^0.6.1",
+                "qjobs": "^1.1.4",
+                "range-parser": "^1.2.0",
+                "rimraf": "^2.6.0",
+                "safe-buffer": "^5.0.1",
                 "socket.io": "2.0.4",
-                "source-map": "0.6.1",
+                "source-map": "^0.6.1",
                 "tmp": "0.0.33",
                 "useragent": "2.2.1"
             },
@@ -11537,19 +11546,19 @@
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "3.1.10",
-                        "normalize-path": "2.1.1"
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
                     }
                 },
                 "arr-diff": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/arr-diff/-/arr-diff-4.0.0.tgz",
                     "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
                     "dev": true
                 },
                 "array-unique": {
                     "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/array-unique/-/array-unique-0.3.2.tgz",
                     "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
                     "dev": true
                 },
@@ -11559,25 +11568,25 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -11588,52 +11597,52 @@
                     "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "2.0.0",
-                        "async-each": "1.0.1",
-                        "braces": "2.3.2",
-                        "fsevents": "1.2.4",
-                        "glob-parent": "3.1.0",
-                        "inherits": "2.0.3",
-                        "is-binary-path": "1.0.1",
-                        "is-glob": "4.0.0",
-                        "lodash.debounce": "4.0.8",
-                        "normalize-path": "2.1.1",
-                        "path-is-absolute": "1.0.1",
-                        "readdirp": "2.1.0",
-                        "upath": "1.1.0"
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.0",
+                        "braces": "^2.3.0",
+                        "fsevents": "^1.2.2",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.1",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "lodash.debounce": "^4.0.8",
+                        "normalize-path": "^2.1.1",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.0.0",
+                        "upath": "^1.0.5"
                     }
                 },
                 "expand-brackets": {
                     "version": "2.1.4",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/expand-brackets/-/expand-brackets-2.1.4.tgz",
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
                             "version": "0.2.5",
-                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/define-property/-/define-property-0.2.5.tgz",
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -11642,7 +11651,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -11651,7 +11660,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -11662,7 +11671,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -11671,7 +11680,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -11682,9 +11691,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -11701,76 +11710,76 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/define-property/-/define-property-1.0.0.tgz",
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
                 },
                 "fill-range": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
                 },
                 "glob-parent": {
                     "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/glob-parent/-/glob-parent-3.1.0.tgz",
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
                     },
                     "dependencies": {
                         "is-glob": {
                             "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-glob/-/is-glob-3.1.0.tgz",
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "requires": {
-                                "is-extglob": "2.1.1"
+                                "is-extglob": "^2.1.0"
                             }
                         }
                     }
@@ -11781,7 +11790,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -11790,7 +11799,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -11799,49 +11808,49 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-extglob": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-extglob/-/is-extglob-2.1.1.tgz",
                     "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
                     "dev": true
                 },
                 "is-glob": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-glob/-/is-glob-4.0.0.tgz",
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 },
                 "is-number": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
                             "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
                 },
                 "isobject": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/isobject/-/isobject-3.0.1.tgz",
                     "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
                     "dev": true
                 },
@@ -11857,19 +11866,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -11880,8 +11889,8 @@
             "integrity": "sha512-uf/ZVpAabDBPvdPdveyk1EPgbnloPvFFGgmRhYLTDH7gEB4nZdSBk8yTU47w1g/drLSx5uMOkjKk7IWKfWg/+w==",
             "dev": true,
             "requires": {
-                "fs-access": "1.0.1",
-                "which": "1.3.1"
+                "fs-access": "^1.0.0",
+                "which": "^1.2.1"
             }
         },
         "karma-coverage": {
@@ -11890,11 +11899,11 @@
             "integrity": "sha512-eQawj4Cl3z/CjxslYy9ariU4uDh7cCNFZHNWXWRpl0pNeblY/4wHR7M7boTYXWrn9bY0z2pZmr11eKje/S/hIw==",
             "dev": true,
             "requires": {
-                "dateformat": "1.0.12",
-                "istanbul": "0.4.5",
-                "lodash": "4.17.10",
-                "minimatch": "3.0.4",
-                "source-map": "0.5.7"
+                "dateformat": "^1.0.6",
+                "istanbul": "^0.4.0",
+                "lodash": "^4.17.0",
+                "minimatch": "^3.0.0",
+                "source-map": "^0.5.1"
             },
             "dependencies": {
                 "camelcase": {
@@ -11909,8 +11918,8 @@
                     "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "2.1.1",
-                        "map-obj": "1.0.1"
+                        "camelcase": "^2.0.0",
+                        "map-obj": "^1.0.0"
                     }
                 },
                 "dateformat": {
@@ -11919,8 +11928,8 @@
                     "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "4.0.1",
-                        "meow": "3.7.0"
+                        "get-stdin": "^4.0.1",
+                        "meow": "^3.3.0"
                     }
                 },
                 "find-up": {
@@ -11929,8 +11938,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "get-stdin": {
@@ -11945,7 +11954,7 @@
                     "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
                     "dev": true,
                     "requires": {
-                        "repeating": "2.0.1"
+                        "repeating": "^2.0.0"
                     }
                 },
                 "load-json-file": {
@@ -11954,11 +11963,11 @@
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "map-obj": {
@@ -11973,16 +11982,16 @@
                     "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "2.1.0",
-                        "decamelize": "1.2.0",
-                        "loud-rejection": "1.6.0",
-                        "map-obj": "1.0.1",
-                        "minimist": "1.2.0",
-                        "normalize-package-data": "2.4.0",
-                        "object-assign": "4.1.1",
-                        "read-pkg-up": "1.0.1",
-                        "redent": "1.0.0",
-                        "trim-newlines": "1.0.0"
+                        "camelcase-keys": "^2.0.0",
+                        "decamelize": "^1.1.2",
+                        "loud-rejection": "^1.0.0",
+                        "map-obj": "^1.0.1",
+                        "minimist": "^1.1.3",
+                        "normalize-package-data": "^2.3.4",
+                        "object-assign": "^4.0.1",
+                        "read-pkg-up": "^1.0.1",
+                        "redent": "^1.0.0",
+                        "trim-newlines": "^1.0.0"
                     }
                 },
                 "parse-json": {
@@ -11991,7 +12000,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -12000,7 +12009,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -12009,9 +12018,9 @@
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -12026,9 +12035,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -12037,8 +12046,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     }
                 },
                 "redent": {
@@ -12047,8 +12056,8 @@
                     "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
                     "dev": true,
                     "requires": {
-                        "indent-string": "2.1.0",
-                        "strip-indent": "1.0.1"
+                        "indent-string": "^2.1.0",
+                        "strip-indent": "^1.0.1"
                     }
                 },
                 "source-map": {
@@ -12063,7 +12072,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "strip-indent": {
@@ -12072,7 +12081,7 @@
                     "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "4.0.1"
+                        "get-stdin": "^4.0.1"
                     }
                 },
                 "trim-newlines": {
@@ -12091,11 +12100,11 @@
         },
         "karma-junit-reporter": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/karma-junit-reporter/-/karma-junit-reporter-1.2.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/karma-junit-reporter/-/karma-junit-reporter-1.2.0.tgz",
             "integrity": "sha1-T5xAzt+xo5X4rvh2q/lhiZF8Y5Y=",
             "dev": true,
             "requires": {
-                "path-is-absolute": "1.0.1",
+                "path-is-absolute": "^1.0.0",
                 "xmlbuilder": "8.2.2"
             }
         },
@@ -12105,7 +12114,7 @@
             "integrity": "sha512-FM5h8eHcHbMMR+2INBUxD+4+wUbkCnobfn5uWprkLyj6Xcm2MRFQOuAJn9h2H13nNso6rk+QoNpHd5xCevlPOw==",
             "dev": true,
             "requires": {
-                "remap-istanbul": "0.10.1"
+                "remap-istanbul": "^0.10"
             }
         },
         "karma-sauce-launcher": {
@@ -12114,10 +12123,10 @@
             "integrity": "sha512-lEhtGRGS+3Yw6JSx/vJY9iQyHNtTjcojrSwNzqNUOaDceKDu9dPZqA/kr69bUO9G2T6GKbu8AZgXqy94qo31Jg==",
             "dev": true,
             "requires": {
-                "q": "1.5.1",
-                "sauce-connect-launcher": "1.2.4",
-                "saucelabs": "1.5.0",
-                "wd": "1.10.3"
+                "q": "^1.5.0",
+                "sauce-connect-launcher": "^1.2.2",
+                "saucelabs": "^1.4.0",
+                "wd": "^1.4.0"
             }
         },
         "karma-sourcemap-loader": {
@@ -12126,7 +12135,7 @@
             "integrity": "sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11"
+                "graceful-fs": "^4.1.2"
             }
         },
         "karma-spec-reporter": {
@@ -12135,7 +12144,7 @@
             "integrity": "sha1-LpxyB+pyZ3EmAln4K+y1QyCeRAo=",
             "dev": true,
             "requires": {
-                "colors": "1.1.2"
+                "colors": "^1.1.2"
             }
         },
         "killable": {
@@ -12150,7 +12159,7 @@
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6"
+                "is-buffer": "^1.1.5"
             }
         },
         "known-css-properties": {
@@ -12171,7 +12180,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.5"
             }
         },
         "lcid": {
@@ -12180,7 +12189,7 @@
             "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "dev": true,
             "requires": {
-                "invert-kv": "1.0.0"
+                "invert-kv": "^1.0.0"
             }
         },
         "leven": {
@@ -12195,8 +12204,8 @@
             "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2"
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2"
             }
         },
         "libbase64": {
@@ -12236,16 +12245,16 @@
             "integrity": "sha512-TAZDfuhEM1oZcBXICOeTBMt+bXIHllvoKHZA658YgPLzcnT45MS2Tjqqwkd5ctkHOlKJ8fTdl5dft2YTCe/4LQ==",
             "dev": true,
             "requires": {
-                "chalk": "0.5.1",
-                "debug": "2.6.9",
-                "mkdirp": "0.3.5",
-                "nopt": "2.2.1",
-                "read-installed": "4.0.3",
-                "semver": "5.5.0",
-                "spdx": "0.5.2",
-                "spdx-correct": "2.0.4",
-                "spdx-satisfies": "0.1.3",
-                "treeify": "1.1.0"
+                "chalk": "~0.5.1",
+                "debug": "^2.2.0",
+                "mkdirp": "^0.3.5",
+                "nopt": "^2.2.0",
+                "read-installed": "~4.0.3",
+                "semver": "^5.3.0",
+                "spdx": "^0.5.1",
+                "spdx-correct": "^2.0.3",
+                "spdx-satisfies": "^0.1.3",
+                "treeify": "^1.0.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -12266,11 +12275,11 @@
                     "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "1.1.0",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "0.1.0",
-                        "strip-ansi": "0.3.0",
-                        "supports-color": "0.2.0"
+                        "ansi-styles": "^1.1.0",
+                        "escape-string-regexp": "^1.0.0",
+                        "has-ansi": "^0.1.0",
+                        "strip-ansi": "^0.3.0",
+                        "supports-color": "^0.2.0"
                     }
                 },
                 "has-ansi": {
@@ -12279,7 +12288,7 @@
                     "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.0"
                     }
                 },
                 "mkdirp": {
@@ -12294,7 +12303,7 @@
                     "integrity": "sha1-KqCbfRdoSHs7ianFqlIzW/8Lrqc=",
                     "dev": true,
                     "requires": {
-                        "abbrev": "1.1.1"
+                        "abbrev": "1"
                     }
                 },
                 "spdx-correct": {
@@ -12303,8 +12312,8 @@
                     "integrity": "sha512-c+4gPpt9YDhz7cHlz5UrsHzxxRi4ksclxnEEKsuGT9JdwSC+ZNmsGbYRzzgxyZaBYpcWnlu+4lPcdLKx4DOCmA==",
                     "dev": true,
                     "requires": {
-                        "spdx-expression-parse": "2.0.2",
-                        "spdx-license-ids": "2.0.1"
+                        "spdx-expression-parse": "^2.0.1",
+                        "spdx-license-ids": "^2.0.1"
                     }
                 },
                 "spdx-expression-parse": {
@@ -12313,8 +12322,8 @@
                     "integrity": "sha512-oFxOkWCfFS0ltNp0H66gXlU4NF6bxg7RkoTYR0413t+yTY9zyj+AIWsjtN8dcVp6703ijDYBWBIARlJ7DkyP9Q==",
                     "dev": true,
                     "requires": {
-                        "spdx-exceptions": "2.1.0",
-                        "spdx-license-ids": "2.0.1"
+                        "spdx-exceptions": "^2.0.0",
+                        "spdx-license-ids": "^2.0.1"
                     }
                 },
                 "spdx-license-ids": {
@@ -12329,7 +12338,7 @@
                     "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "0.2.1"
+                        "ansi-regex": "^0.2.1"
                     }
                 },
                 "supports-color": {
@@ -12346,14 +12355,14 @@
             "integrity": "sha1-IAkpG7Mc6oYbvxCnwVooyvdcMew=",
             "dev": true,
             "requires": {
-                "extend": "3.0.2",
-                "findup-sync": "2.0.0",
-                "fined": "1.1.0",
-                "flagged-respawn": "1.0.0",
-                "is-plain-object": "2.0.4",
-                "object.map": "1.0.1",
-                "rechoir": "0.6.2",
-                "resolve": "1.8.1"
+                "extend": "^3.0.0",
+                "findup-sync": "^2.0.0",
+                "fined": "^1.0.1",
+                "flagged-respawn": "^1.0.0",
+                "is-plain-object": "^2.0.4",
+                "object.map": "^1.0.0",
+                "rechoir": "^0.6.2",
+                "resolve": "^1.1.7"
             }
         },
         "lint-staged": {
@@ -12362,29 +12371,29 @@
             "integrity": "sha512-jPoIMbmgtWMUrz/l0rhBVa1j6H71zr0rEoxDWBA333PZcaqBvELdg0Sf4tdGHlwrBM0GXaXMVgTRkLTm2vA7Jg==",
             "dev": true,
             "requires": {
-                "app-root-path": "2.1.0",
-                "chalk": "2.4.1",
-                "commander": "2.17.1",
-                "cosmiconfig": "5.0.5",
-                "debug": "3.1.0",
-                "dedent": "0.7.0",
-                "execa": "0.9.0",
-                "find-parent-dir": "0.3.0",
-                "is-glob": "4.0.0",
-                "is-windows": "1.0.2",
-                "jest-validate": "23.4.0",
-                "listr": "0.14.1",
-                "lodash": "4.17.10",
-                "log-symbols": "2.2.0",
-                "micromatch": "3.1.10",
-                "npm-which": "3.0.1",
-                "p-map": "1.2.0",
-                "path-is-inside": "1.0.2",
-                "pify": "3.0.0",
-                "please-upgrade-node": "3.1.1",
+                "app-root-path": "^2.0.1",
+                "chalk": "^2.3.1",
+                "commander": "^2.14.1",
+                "cosmiconfig": "^5.0.2",
+                "debug": "^3.1.0",
+                "dedent": "^0.7.0",
+                "execa": "^0.9.0",
+                "find-parent-dir": "^0.3.0",
+                "is-glob": "^4.0.0",
+                "is-windows": "^1.0.2",
+                "jest-validate": "^23.0.0",
+                "listr": "^0.14.1",
+                "lodash": "^4.17.5",
+                "log-symbols": "^2.2.0",
+                "micromatch": "^3.1.8",
+                "npm-which": "^3.0.1",
+                "p-map": "^1.1.1",
+                "path-is-inside": "^1.0.2",
+                "pify": "^3.0.0",
+                "please-upgrade-node": "^3.0.2",
                 "staged-git-files": "1.1.1",
-                "string-argv": "0.0.2",
-                "stringify-object": "3.2.2"
+                "string-argv": "^0.0.2",
+                "stringify-object": "^3.2.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -12405,16 +12414,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -12423,7 +12432,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -12434,9 +12443,9 @@
                     "integrity": "sha512-94j37OtvxS5w7qr7Ta6dt67tWdnOxigBVN4VnSxNXFez9o18PGQ0D33SchKP17r9LAcWVTYV72G6vDayAUBFIg==",
                     "dev": true,
                     "requires": {
-                        "is-directory": "0.3.1",
-                        "js-yaml": "3.12.0",
-                        "parse-json": "4.0.0"
+                        "is-directory": "^0.3.1",
+                        "js-yaml": "^3.9.0",
+                        "parse-json": "^4.0.0"
                     }
                 },
                 "debug": {
@@ -12454,13 +12463,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "debug": {
@@ -12478,7 +12487,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -12487,7 +12496,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -12496,7 +12505,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -12505,7 +12514,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -12516,7 +12525,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -12525,7 +12534,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -12536,9 +12545,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -12555,14 +12564,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -12571,7 +12580,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -12580,7 +12589,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -12591,10 +12600,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -12603,7 +12612,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -12614,7 +12623,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -12623,7 +12632,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -12632,9 +12641,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-extglob": {
@@ -12649,7 +12658,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 },
                 "is-number": {
@@ -12658,7 +12667,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -12667,7 +12676,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -12690,19 +12699,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -12713,22 +12722,22 @@
             "integrity": "sha512-MSMUUVN1f8aRnPi4034RkOqdiUlpYW+FqwFE3aL0uYNPRavkt2S2SsSpDDofn8BDpqv2RNnsdOcCHWsChcq77A==",
             "dev": true,
             "requires": {
-                "@samverschueren/stream-to-observable": "0.3.0",
-                "cli-truncate": "0.2.1",
-                "figures": "1.7.0",
-                "indent-string": "2.1.0",
-                "is-observable": "1.1.0",
-                "is-promise": "2.1.0",
-                "is-stream": "1.1.0",
-                "listr-silent-renderer": "1.1.1",
-                "listr-update-renderer": "0.4.0",
-                "listr-verbose-renderer": "0.4.1",
-                "log-symbols": "1.0.2",
-                "log-update": "1.0.2",
-                "ora": "0.2.3",
-                "p-map": "1.2.0",
-                "rxjs": "6.2.2",
-                "strip-ansi": "3.0.1"
+                "@samverschueren/stream-to-observable": "^0.3.0",
+                "cli-truncate": "^0.2.1",
+                "figures": "^1.7.0",
+                "indent-string": "^2.1.0",
+                "is-observable": "^1.1.0",
+                "is-promise": "^2.1.0",
+                "is-stream": "^1.1.0",
+                "listr-silent-renderer": "^1.1.1",
+                "listr-update-renderer": "^0.4.0",
+                "listr-verbose-renderer": "^0.4.0",
+                "log-symbols": "^1.0.2",
+                "log-update": "^1.0.2",
+                "ora": "^0.2.3",
+                "p-map": "^1.1.1",
+                "rxjs": "^6.1.0",
+                "strip-ansi": "^3.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12743,11 +12752,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "indent-string": {
@@ -12756,7 +12765,7 @@
                     "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
                     "dev": true,
                     "requires": {
-                        "repeating": "2.0.1"
+                        "repeating": "^2.0.0"
                     }
                 },
                 "log-symbols": {
@@ -12765,7 +12774,7 @@
                     "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3"
+                        "chalk": "^1.0.0"
                     }
                 },
                 "rxjs": {
@@ -12774,7 +12783,7 @@
                     "integrity": "sha512-0MI8+mkKAXZUF9vMrEoPnaoHkfzBPP4IGwUYRJhIRJF6/w3uByO1e91bEHn8zd43RdkTMKiooYKmwz7RH6zfOQ==",
                     "dev": true,
                     "requires": {
-                        "tslib": "1.9.3"
+                        "tslib": "^1.9.0"
                     }
                 },
                 "supports-color": {
@@ -12797,14 +12806,14 @@
             "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "cli-truncate": "0.2.1",
-                "elegant-spinner": "1.0.1",
-                "figures": "1.7.0",
-                "indent-string": "3.2.0",
-                "log-symbols": "1.0.2",
-                "log-update": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "chalk": "^1.1.3",
+                "cli-truncate": "^0.2.1",
+                "elegant-spinner": "^1.0.1",
+                "figures": "^1.7.0",
+                "indent-string": "^3.0.0",
+                "log-symbols": "^1.0.2",
+                "log-update": "^1.0.2",
+                "strip-ansi": "^3.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12819,11 +12828,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "log-symbols": {
@@ -12832,7 +12841,7 @@
                     "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
                     "dev": true,
                     "requires": {
-                        "chalk": "1.1.3"
+                        "chalk": "^1.0.0"
                     }
                 },
                 "supports-color": {
@@ -12849,10 +12858,10 @@
             "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "date-fns": "1.29.0",
-                "figures": "1.7.0"
+                "chalk": "^1.1.3",
+                "cli-cursor": "^1.0.2",
+                "date-fns": "^1.27.2",
+                "figures": "^1.7.0"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -12867,11 +12876,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -12888,10 +12897,10 @@
             "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "parse-json": "4.0.0",
-                "pify": "3.0.0",
-                "strip-bom": "3.0.0"
+                "graceful-fs": "^4.1.2",
+                "parse-json": "^4.0.0",
+                "pify": "^3.0.0",
+                "strip-bom": "^3.0.0"
             }
         },
         "loader-runner": {
@@ -12906,10 +12915,10 @@
             "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
             "dev": true,
             "requires": {
-                "big.js": "3.2.0",
-                "emojis-list": "2.1.0",
-                "json5": "0.5.1",
-                "object-assign": "4.1.1"
+                "big.js": "^3.1.3",
+                "emojis-list": "^2.0.0",
+                "json5": "^0.5.0",
+                "object-assign": "^4.0.1"
             }
         },
         "locate-path": {
@@ -12918,8 +12927,8 @@
             "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
             "dev": true,
             "requires": {
-                "p-locate": "2.0.0",
-                "path-exists": "3.0.0"
+                "p-locate": "^2.0.0",
+                "path-exists": "^3.0.0"
             }
         },
         "lodash": {
@@ -12934,8 +12943,8 @@
             "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash.keys": "3.1.2"
+                "lodash._basecopy": "^3.0.0",
+                "lodash.keys": "^3.0.0"
             }
         },
         "lodash._basecopy": {
@@ -12968,9 +12977,9 @@
             "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
             "dev": true,
             "requires": {
-                "lodash._bindcallback": "3.0.1",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash.restparam": "3.6.1"
+                "lodash._bindcallback": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash.restparam": "^3.0.0"
             }
         },
         "lodash._getnative": {
@@ -13029,7 +13038,7 @@
         },
         "lodash.debounce": {
             "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
             "dev": true
         },
@@ -13045,7 +13054,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash._root": "^3.0.0"
             }
         },
         "lodash.isarguments": {
@@ -13072,9 +13081,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lodash.merge": {
@@ -13131,8 +13140,8 @@
             "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.templatesettings": "4.1.0"
+                "lodash._reinterpolate": "~3.0.0",
+                "lodash.templatesettings": "^4.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -13141,7 +13150,7 @@
             "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0"
+                "lodash._reinterpolate": "~3.0.0"
             }
         },
         "lodash.topairs": {
@@ -13168,7 +13177,7 @@
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1"
+                "chalk": "^2.0.1"
             }
         },
         "log-update": {
@@ -13177,8 +13186,8 @@
             "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
             "dev": true,
             "requires": {
-                "ansi-escapes": "1.4.0",
-                "cli-cursor": "1.0.2"
+                "ansi-escapes": "^1.0.0",
+                "cli-cursor": "^1.0.2"
             }
         },
         "log4js": {
@@ -13187,18 +13196,18 @@
             "integrity": "sha512-z1XdwyGFg8/WGkOyF6DPJjivCWNLKrklGdViywdYnSKOvgtEBo2UyEMZS5sD2mZrQlU3TvO8wDWLc8mzE1ncBQ==",
             "dev": true,
             "requires": {
-                "amqplib": "0.5.2",
-                "axios": "0.15.3",
-                "circular-json": "0.5.5",
-                "date-format": "1.2.0",
-                "debug": "3.1.0",
-                "hipchat-notifier": "1.1.0",
-                "loggly": "1.1.1",
-                "mailgun-js": "0.18.1",
-                "nodemailer": "2.7.2",
-                "redis": "2.8.0",
-                "semver": "5.5.0",
-                "slack-node": "0.2.0",
+                "amqplib": "^0.5.2",
+                "axios": "^0.15.3",
+                "circular-json": "^0.5.4",
+                "date-format": "^1.2.0",
+                "debug": "^3.1.0",
+                "hipchat-notifier": "^1.1.0",
+                "loggly": "^1.1.0",
+                "mailgun-js": "^0.18.0",
+                "nodemailer": "^2.5.0",
+                "redis": "^2.7.1",
+                "semver": "^5.5.0",
+                "slack-node": "~0.2.0",
                 "streamroller": "0.7.0"
             },
             "dependencies": {
@@ -13220,9 +13229,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "json-stringify-safe": "5.0.1",
-                "request": "2.75.0",
-                "timespan": "2.3.0"
+                "json-stringify-safe": "5.0.x",
+                "request": "2.75.x",
+                "timespan": "2.3.x"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -13260,11 +13269,11 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "form-data": {
@@ -13274,9 +13283,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.6",
-                        "mime-types": "2.1.19"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.5",
+                        "mime-types": "^2.1.11"
                     }
                 },
                 "har-validator": {
@@ -13286,10 +13295,10 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "chalk": "1.1.3",
-                        "commander": "2.17.1",
-                        "is-my-json-valid": "2.17.2",
-                        "pinkie-promise": "2.0.1"
+                        "chalk": "^1.1.1",
+                        "commander": "^2.9.0",
+                        "is-my-json-valid": "^2.12.4",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "http-signature": {
@@ -13299,9 +13308,9 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.14.2"
+                        "assert-plus": "^0.2.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "node-uuid": {
@@ -13332,27 +13341,27 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.8.0",
-                        "bl": "1.1.2",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.2",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.0.0",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.19",
-                        "node-uuid": "1.4.8",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.2.3",
-                        "stringstream": "0.0.6",
-                        "tough-cookie": "2.3.4",
-                        "tunnel-agent": "0.4.3"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "bl": "~1.1.2",
+                        "caseless": "~0.11.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.0.0",
+                        "har-validator": "~2.0.6",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "node-uuid": "~1.4.7",
+                        "oauth-sign": "~0.8.1",
+                        "qs": "~6.2.0",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "~0.4.1"
                     }
                 },
                 "supports-color": {
@@ -13369,7 +13378,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": "^1.4.1"
                     }
                 },
                 "tunnel-agent": {
@@ -13393,8 +13402,8 @@
             "integrity": "sha512-V/73qkPuJmx4BcBF19xPBr+0ZRVBhc4POxvZTZdMeXpJ4NItXSJ/MSwuFT0kQJlCbXvdlZoQQ/418bS1y9Jh6A==",
             "dev": true,
             "requires": {
-                "es6-symbol": "3.1.1",
-                "object.assign": "4.1.0"
+                "es6-symbol": "^3.1.1",
+                "object.assign": "^4.1.0"
             }
         },
         "long": {
@@ -13421,8 +13430,8 @@
             "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
             "dev": true,
             "requires": {
-                "currently-unhandled": "0.4.1",
-                "signal-exit": "3.0.2"
+                "currently-unhandled": "^0.4.1",
+                "signal-exit": "^3.0.0"
             }
         },
         "lower-case": {
@@ -13437,7 +13446,7 @@
             "integrity": "sha1-5dp8JvKacHO+AtUrrJmA5ZIq36E=",
             "dev": true,
             "requires": {
-                "lower-case": "1.1.4"
+                "lower-case": "^1.1.2"
             }
         },
         "lru-cache": {
@@ -13452,18 +13461,18 @@
             "integrity": "sha512-+hD7bd39QGsY4slEiU+ohjy+xqaELIeoN1cBZhv5oRLQyKR6sOJTaFXYfb7ttLjypCHza0KQY3QopljjveQW2A==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "commander": "2.17.1",
-                "commondir": "1.0.1",
-                "debug": "3.1.0",
-                "dependency-tree": "6.1.1",
-                "graphviz": "0.0.8",
-                "ora": "2.1.0",
-                "pify": "3.0.0",
-                "pluralize": "7.0.0",
-                "pretty-ms": "3.2.0",
-                "rc": "1.2.8",
-                "walkdir": "0.0.12"
+                "chalk": "^2.4.1",
+                "commander": "^2.15.1",
+                "commondir": "^1.0.1",
+                "debug": "^3.1.0",
+                "dependency-tree": "^6.1.0",
+                "graphviz": "^0.0.8",
+                "ora": "^2.1.0",
+                "pify": "^3.0.0",
+                "pluralize": "^7.0.0",
+                "pretty-ms": "^3.1.0",
+                "rc": "^1.2.7",
+                "walkdir": "^0.0.12"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -13478,7 +13487,7 @@
                     "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
                     "dev": true,
                     "requires": {
-                        "restore-cursor": "2.0.0"
+                        "restore-cursor": "^2.0.0"
                     }
                 },
                 "cli-spinners": {
@@ -13502,7 +13511,7 @@
                     "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
                     "dev": true,
                     "requires": {
-                        "mimic-fn": "1.2.0"
+                        "mimic-fn": "^1.0.0"
                     }
                 },
                 "ora": {
@@ -13511,12 +13520,12 @@
                     "integrity": "sha512-hNNlAd3gfv/iPmsNxYoAPLvxg7HuPozww7fFonMZvL84tP6Ox5igfk5j/+a9rtJJwqMgKK+JgWsAQik5o0HTLA==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.1",
-                        "cli-cursor": "2.1.0",
-                        "cli-spinners": "1.3.1",
-                        "log-symbols": "2.2.0",
-                        "strip-ansi": "4.0.0",
-                        "wcwidth": "1.0.1"
+                        "chalk": "^2.3.1",
+                        "cli-cursor": "^2.1.0",
+                        "cli-spinners": "^1.1.0",
+                        "log-symbols": "^2.2.0",
+                        "strip-ansi": "^4.0.0",
+                        "wcwidth": "^1.0.1"
                     }
                 },
                 "restore-cursor": {
@@ -13525,8 +13534,8 @@
                     "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
                     "dev": true,
                     "requires": {
-                        "onetime": "2.0.1",
-                        "signal-exit": "3.0.2"
+                        "onetime": "^2.0.0",
+                        "signal-exit": "^3.0.2"
                     }
                 },
                 "strip-ansi": {
@@ -13535,7 +13544,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -13546,7 +13555,7 @@
             "integrity": "sha512-oreip9rJZkzvA8Qzk9HFs8fZGF/u7H/gtrE8EN6RjKJ9kh2HlC+yQ2QezifqTZfGyiuAV0dRv5a+y/8gBb1m9w==",
             "dev": true,
             "requires": {
-                "vlq": "0.2.3"
+                "vlq": "^0.2.2"
             }
         },
         "mailcomposer": {
@@ -13567,15 +13576,15 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "async": "2.6.1",
-                "debug": "3.1.0",
-                "form-data": "2.3.2",
-                "inflection": "1.12.0",
-                "is-stream": "1.1.0",
-                "path-proxy": "1.0.0",
-                "promisify-call": "2.0.4",
-                "proxy-agent": "3.0.1",
-                "tsscmp": "1.0.6"
+                "async": "~2.6.0",
+                "debug": "~3.1.0",
+                "form-data": "~2.3.0",
+                "inflection": "~1.12.0",
+                "is-stream": "^1.1.0",
+                "path-proxy": "~1.0.0",
+                "promisify-call": "^2.0.2",
+                "proxy-agent": "~3.0.0",
+                "tsscmp": "~1.0.0"
             },
             "dependencies": {
                 "async": {
@@ -13585,7 +13594,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "lodash": "4.17.10"
+                        "lodash": "^4.17.10"
                     }
                 },
                 "debug": {
@@ -13606,7 +13615,7 @@
             "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "make-error": {
@@ -13621,7 +13630,7 @@
             "integrity": "sha512-pxiuXh0iVEq7VM7KMIhs5gxsfxCux2URptUQaXo4iZZJxBAzTPOLE2BumO5dbfVYq/hBJFBR/a1mFDmOx5AGmw==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -13656,7 +13665,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "markdown-escapes": {
@@ -13683,9 +13692,9 @@
             "integrity": "sha1-xvNINKDY28OzfCfui7yyfHd1WC4=",
             "dev": true,
             "requires": {
-                "findup-sync": "2.0.0",
-                "micromatch": "3.1.10",
-                "resolve": "1.8.1",
+                "findup-sync": "^2.0.0",
+                "micromatch": "^3.0.4",
+                "resolve": "^1.4.0",
                 "stack-trace": "0.0.10"
             },
             "dependencies": {
@@ -13707,16 +13716,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -13725,7 +13734,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -13736,13 +13745,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -13751,7 +13760,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -13760,7 +13769,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -13769,7 +13778,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -13778,7 +13787,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -13789,7 +13798,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -13798,7 +13807,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -13809,9 +13818,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -13828,14 +13837,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -13844,7 +13853,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -13853,7 +13862,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -13864,10 +13873,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -13876,7 +13885,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -13887,7 +13896,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -13896,7 +13905,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -13905,9 +13914,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-number": {
@@ -13916,7 +13925,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -13925,7 +13934,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -13948,19 +13957,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -13983,8 +13992,8 @@
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "dev": true,
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "mdast-util-compact": {
@@ -13993,8 +14002,8 @@
             "integrity": "sha1-zbX4TitqLTEU3zO9BdnLMuPECDo=",
             "dev": true,
             "requires": {
-                "unist-util-modify-children": "1.1.2",
-                "unist-util-visit": "1.4.0"
+                "unist-util-modify-children": "^1.0.0",
+                "unist-util-visit": "^1.1.0"
             }
         },
         "media-typer": {
@@ -14009,7 +14018,7 @@
             "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "memory-fs": {
@@ -14018,8 +14027,8 @@
             "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
             "dev": true,
             "requires": {
-                "errno": "0.1.7",
-                "readable-stream": "2.3.6"
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
             }
         },
         "meow": {
@@ -14028,15 +14037,15 @@
             "integrity": "sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==",
             "dev": true,
             "requires": {
-                "camelcase-keys": "4.2.0",
-                "decamelize-keys": "1.1.0",
-                "loud-rejection": "1.6.0",
-                "minimist-options": "3.0.2",
-                "normalize-package-data": "2.4.0",
-                "read-pkg-up": "3.0.0",
-                "redent": "2.0.0",
-                "trim-newlines": "2.0.0",
-                "yargs-parser": "10.1.0"
+                "camelcase-keys": "^4.0.0",
+                "decamelize-keys": "^1.0.0",
+                "loud-rejection": "^1.0.0",
+                "minimist-options": "^3.0.1",
+                "normalize-package-data": "^2.3.4",
+                "read-pkg-up": "^3.0.0",
+                "redent": "^2.0.0",
+                "trim-newlines": "^2.0.0",
+                "yargs-parser": "^10.0.0"
             }
         },
         "merge-descriptors": {
@@ -14051,7 +14060,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.1"
             }
         },
         "merge2": {
@@ -14072,19 +14081,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.4"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             }
         },
         "miller-rabin": {
@@ -14093,8 +14102,8 @@
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0"
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
             }
         },
         "mime": {
@@ -14115,7 +14124,7 @@
             "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
             "dev": true,
             "requires": {
-                "mime-db": "1.35.0"
+                "mime-db": "~1.35.0"
             }
         },
         "mimic-fn": {
@@ -14142,7 +14151,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -14157,8 +14166,8 @@
             "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "is-plain-obj": "1.1.0"
+                "arrify": "^1.0.1",
+                "is-plain-obj": "^1.1.0"
             }
         },
         "mississippi": {
@@ -14167,16 +14176,16 @@
             "integrity": "sha512-zHo8v+otD1J10j/tC+VNoGK9keCuByhKovAvdn74dmxJl9+mWHnx6EMsDN4lgRoMI/eYo2nchAxniIbUPb5onw==",
             "dev": true,
             "requires": {
-                "concat-stream": "1.6.2",
-                "duplexify": "3.6.0",
-                "end-of-stream": "1.4.1",
-                "flush-write-stream": "1.0.3",
-                "from2": "2.3.0",
-                "parallel-transform": "1.1.0",
-                "pump": "2.0.1",
-                "pumpify": "1.5.1",
-                "stream-each": "1.2.3",
-                "through2": "2.0.3"
+                "concat-stream": "^1.5.0",
+                "duplexify": "^3.4.2",
+                "end-of-stream": "^1.1.0",
+                "flush-write-stream": "^1.0.0",
+                "from2": "^2.1.0",
+                "parallel-transform": "^1.1.0",
+                "pump": "^2.0.1",
+                "pumpify": "^1.3.3",
+                "stream-each": "^1.1.0",
+                "through2": "^2.0.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -14185,7 +14194,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 }
             }
@@ -14196,8 +14205,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -14206,7 +14215,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -14217,8 +14226,8 @@
             "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
             "dev": true,
             "requires": {
-                "for-in": "0.1.8",
-                "is-extendable": "0.1.1"
+                "for-in": "^0.1.3",
+                "is-extendable": "^0.1.1"
             },
             "dependencies": {
                 "for-in": {
@@ -14252,7 +14261,16 @@
             "integrity": "sha1-6bj2jlUsaKnBcTuEiD96HdA5uKE=",
             "dev": true,
             "requires": {
-                "mkdirp": "0.5.1"
+                "mkdirp": "*"
+            }
+        },
+        "mock-require": {
+            "version": "2.0.2",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/mock-require/-/mock-require-2.0.2.tgz",
+            "integrity": "sha1-HqpxqtIwE3c9En3H6Ro/u0g31g0=",
+            "dev": true,
+            "requires": {
+                "caller-id": "^0.1.0"
             }
         },
         "modify-values": {
@@ -14267,8 +14285,8 @@
             "integrity": "sha1-wKN3HeWM9rzxKu0kdnBsWWrUsss=",
             "dev": true,
             "requires": {
-                "ast-module-types": "2.3.2",
-                "node-source-walk": "3.3.0"
+                "ast-module-types": "^2.3.2",
+                "node-source-walk": "^3.0.0"
             }
         },
         "module-lookup-amd": {
@@ -14277,12 +14295,12 @@
             "integrity": "sha512-rmljyiMrPqEfeOD1myMULVgnv1pRUqq1Dv/Xn0f9g36wCDWvqj07arG0fCEbKqU1sYFXptnaC1o+0oR7JpwOtg==",
             "dev": true,
             "requires": {
-                "commander": "2.17.1",
-                "debug": "3.1.0",
-                "file-exists": "2.0.0",
-                "find": "0.2.9",
-                "requirejs": "2.3.5",
-                "requirejs-config-file": "3.0.0"
+                "commander": "^2.8.1",
+                "debug": "^3.1.0",
+                "file-exists": "^2.0.0",
+                "find": "^0.2.8",
+                "requirejs": "^2.3.5",
+                "requirejs-config-file": "^3.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -14302,12 +14320,12 @@
             "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0",
-                "copy-concurrently": "1.0.5",
-                "fs-write-stream-atomic": "1.0.10",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2",
-                "run-queue": "1.0.3"
+                "aproba": "^1.1.1",
+                "copy-concurrently": "^1.0.0",
+                "fs-write-stream-atomic": "^1.0.8",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.4",
+                "run-queue": "^1.0.3"
             }
         },
         "ms": {
@@ -14322,8 +14340,8 @@
             "integrity": "sha512-ji6J5enbMyGRHIAkAOu3WdV8nggqviKCEKtXcOqfphZZtQrmHKycfynJ2V7eVPUA4NhJ6V7Wf4TmGbTwKE9B6g==",
             "dev": true,
             "requires": {
-                "dns-packet": "1.3.1",
-                "thunky": "1.0.2"
+                "dns-packet": "^1.3.1",
+                "thunky": "^1.0.2"
             }
         },
         "multicast-dns-service-types": {
@@ -14365,17 +14383,17 @@
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "arr-diff": {
@@ -14441,7 +14459,7 @@
             "integrity": "sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==",
             "dev": true,
             "requires": {
-                "lower-case": "1.1.4"
+                "lower-case": "^1.1.1"
             }
         },
         "node-forge": {
@@ -14456,18 +14474,18 @@
             "integrity": "sha512-qDQE/Ft9xXP6zphwx4sD0t+VhwV7yFaloMpfbL2QnnDZcyaiakWlLdtFGGQfTAwpFHdpbRhRxVhIHN1OKAjgbg==",
             "dev": true,
             "requires": {
-                "fstream": "1.0.11",
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "mkdirp": "0.5.1",
-                "nopt": "3.0.6",
-                "npmlog": "4.1.2",
-                "osenv": "0.1.5",
-                "request": "2.81.0",
-                "rimraf": "2.6.2",
-                "semver": "5.3.0",
-                "tar": "2.2.1",
-                "which": "1.3.1"
+                "fstream": "^1.0.0",
+                "glob": "^7.0.3",
+                "graceful-fs": "^4.1.2",
+                "mkdirp": "^0.5.0",
+                "nopt": "2 || 3",
+                "npmlog": "0 || 1 || 2 || 3 || 4",
+                "osenv": "0",
+                "request": ">=2.9.0 <2.82.0",
+                "rimraf": "2",
+                "semver": "~5.3.0",
+                "tar": "^2.0.0",
+                "which": "1"
             },
             "dependencies": {
                 "ajv": {
@@ -14476,8 +14494,8 @@
                     "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
                     "dev": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 },
                 "assert-plus": {
@@ -14498,9 +14516,9 @@
                     "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
                     "dev": true,
                     "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.6",
-                        "mime-types": "2.1.19"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.5",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "har-schema": {
@@ -14515,8 +14533,8 @@
                     "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
                     "dev": true,
                     "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
+                        "ajv": "^4.9.1",
+                        "har-schema": "^1.0.5"
                     }
                 },
                 "http-signature": {
@@ -14525,9 +14543,9 @@
                     "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
                     "dev": true,
                     "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.14.2"
+                        "assert-plus": "^0.2.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "performance-now": {
@@ -14554,28 +14572,28 @@
                     "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.8.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.2",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.19",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.1.2",
-                        "stringstream": "0.0.6",
-                        "tough-cookie": "2.3.4",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.3.2"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~4.2.1",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "performance-now": "^0.2.0",
+                        "qs": "~6.4.0",
+                        "safe-buffer": "^5.0.1",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "semver": {
@@ -14590,7 +14608,7 @@
                     "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
                     "dev": true,
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": "^1.4.1"
                     }
                 }
             }
@@ -14607,28 +14625,28 @@
             "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
             "dev": true,
             "requires": {
-                "assert": "1.4.1",
-                "browserify-zlib": "0.2.0",
-                "buffer": "4.9.1",
-                "console-browserify": "1.1.0",
-                "constants-browserify": "1.0.0",
-                "crypto-browserify": "3.12.0",
-                "domain-browser": "1.2.0",
-                "events": "1.1.1",
-                "https-browserify": "1.0.0",
-                "os-browserify": "0.3.0",
+                "assert": "^1.1.1",
+                "browserify-zlib": "^0.2.0",
+                "buffer": "^4.3.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "^1.0.0",
+                "crypto-browserify": "^3.11.0",
+                "domain-browser": "^1.1.1",
+                "events": "^1.0.0",
+                "https-browserify": "^1.0.0",
+                "os-browserify": "^0.3.0",
                 "path-browserify": "0.0.0",
-                "process": "0.11.10",
-                "punycode": "1.4.1",
-                "querystring-es3": "0.2.1",
-                "readable-stream": "2.3.6",
-                "stream-browserify": "2.0.1",
-                "stream-http": "2.8.3",
-                "string_decoder": "1.1.1",
-                "timers-browserify": "2.0.10",
+                "process": "^0.11.10",
+                "punycode": "^1.2.4",
+                "querystring-es3": "^0.2.0",
+                "readable-stream": "^2.3.3",
+                "stream-browserify": "^2.0.1",
+                "stream-http": "^2.7.2",
+                "string_decoder": "^1.0.0",
+                "timers-browserify": "^2.0.4",
                 "tty-browserify": "0.0.0",
-                "url": "0.11.0",
-                "util": "0.10.3",
+                "url": "^0.11.0",
+                "util": "^0.10.3",
                 "vm-browserify": "0.0.4"
             },
             "dependencies": {
@@ -14638,9 +14656,9 @@
                     "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
                     "dev": true,
                     "requires": {
-                        "base64-js": "1.3.0",
-                        "ieee754": "1.1.12",
-                        "isarray": "1.0.0"
+                        "base64-js": "^1.0.2",
+                        "ieee754": "^1.1.4",
+                        "isarray": "^1.0.0"
                     }
                 },
                 "punycode": {
@@ -14657,7 +14675,7 @@
             "integrity": "sha512-BSQrRgOfN6L/MoKIa7pRUc7dHvflCXMcqyTBvphixcSsgJTuUd24vAFONuNfVsuwTyz28S1HEc9XN6ZKylk4Hg==",
             "dev": true,
             "requires": {
-                "semver": "5.5.0"
+                "semver": "^5.3.0"
             }
         },
         "node-sass": {
@@ -14666,25 +14684,25 @@
             "integrity": "sha512-LdxoJLZutx0aQXHtWIYwJKMj+9pTjneTcLWJgzf2XbGu0q5pRNqW5QvFCEdm3mc5rJOdru/mzln5d0EZLacf6g==",
             "dev": true,
             "requires": {
-                "async-foreach": "0.1.3",
-                "chalk": "1.1.3",
-                "cross-spawn": "3.0.1",
-                "gaze": "1.1.3",
-                "get-stdin": "4.0.1",
-                "glob": "7.1.2",
-                "in-publish": "2.0.0",
-                "lodash.assign": "4.2.0",
-                "lodash.clonedeep": "4.5.0",
-                "lodash.mergewith": "4.6.1",
-                "meow": "3.7.0",
-                "mkdirp": "0.5.1",
-                "nan": "2.10.0",
-                "node-gyp": "3.7.0",
-                "npmlog": "4.1.2",
+                "async-foreach": "^0.1.3",
+                "chalk": "^1.1.1",
+                "cross-spawn": "^3.0.0",
+                "gaze": "^1.0.0",
+                "get-stdin": "^4.0.1",
+                "glob": "^7.0.3",
+                "in-publish": "^2.0.0",
+                "lodash.assign": "^4.2.0",
+                "lodash.clonedeep": "^4.3.2",
+                "lodash.mergewith": "^4.6.0",
+                "meow": "^3.7.0",
+                "mkdirp": "^0.5.1",
+                "nan": "^2.10.0",
+                "node-gyp": "^3.3.1",
+                "npmlog": "^4.0.0",
                 "request": "2.87.0",
-                "sass-graph": "2.2.4",
-                "stdout-stream": "1.4.0",
-                "true-case-path": "1.0.2"
+                "sass-graph": "^2.2.4",
+                "stdout-stream": "^1.4.0",
+                "true-case-path": "^1.0.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -14705,8 +14723,8 @@
                     "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "2.1.1",
-                        "map-obj": "1.0.1"
+                        "camelcase": "^2.0.0",
+                        "map-obj": "^1.0.0"
                     }
                 },
                 "chalk": {
@@ -14715,11 +14733,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "find-up": {
@@ -14728,8 +14746,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "gaze": {
@@ -14738,7 +14756,7 @@
                     "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
                     "dev": true,
                     "requires": {
-                        "globule": "1.2.1"
+                        "globule": "^1.0.0"
                     }
                 },
                 "get-stdin": {
@@ -14753,9 +14771,9 @@
                     "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
                     "dev": true,
                     "requires": {
-                        "glob": "7.1.2",
-                        "lodash": "4.17.10",
-                        "minimatch": "3.0.4"
+                        "glob": "~7.1.1",
+                        "lodash": "~4.17.10",
+                        "minimatch": "~3.0.2"
                     }
                 },
                 "indent-string": {
@@ -14764,7 +14782,7 @@
                     "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
                     "dev": true,
                     "requires": {
-                        "repeating": "2.0.1"
+                        "repeating": "^2.0.0"
                     }
                 },
                 "load-json-file": {
@@ -14773,11 +14791,11 @@
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "map-obj": {
@@ -14792,16 +14810,16 @@
                     "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
                     "dev": true,
                     "requires": {
-                        "camelcase-keys": "2.1.0",
-                        "decamelize": "1.2.0",
-                        "loud-rejection": "1.6.0",
-                        "map-obj": "1.0.1",
-                        "minimist": "1.2.0",
-                        "normalize-package-data": "2.4.0",
-                        "object-assign": "4.1.1",
-                        "read-pkg-up": "1.0.1",
-                        "redent": "1.0.0",
-                        "trim-newlines": "1.0.0"
+                        "camelcase-keys": "^2.0.0",
+                        "decamelize": "^1.1.2",
+                        "loud-rejection": "^1.0.0",
+                        "map-obj": "^1.0.1",
+                        "minimist": "^1.1.3",
+                        "normalize-package-data": "^2.3.4",
+                        "object-assign": "^4.0.1",
+                        "read-pkg-up": "^1.0.1",
+                        "redent": "^1.0.0",
+                        "trim-newlines": "^1.0.0"
                     }
                 },
                 "parse-json": {
@@ -14810,7 +14828,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -14819,7 +14837,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -14828,9 +14846,9 @@
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -14845,9 +14863,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -14856,8 +14874,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     }
                 },
                 "redent": {
@@ -14866,8 +14884,8 @@
                     "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
                     "dev": true,
                     "requires": {
-                        "indent-string": "2.1.0",
-                        "strip-indent": "1.0.1"
+                        "indent-string": "^2.1.0",
+                        "strip-indent": "^1.0.1"
                     }
                 },
                 "strip-bom": {
@@ -14876,7 +14894,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "strip-indent": {
@@ -14885,7 +14903,7 @@
                     "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
                     "dev": true,
                     "requires": {
-                        "get-stdin": "4.0.1"
+                        "get-stdin": "^4.0.1"
                     }
                 },
                 "supports-color": {
@@ -14908,7 +14926,7 @@
             "integrity": "sha1-rRjjW/2z0Lb34OSv8eePhGo7iHM=",
             "dev": true,
             "requires": {
-                "babylon": "6.18.0"
+                "babylon": "^6.17.0"
             }
         },
         "nodemailer": {
@@ -14934,8 +14952,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "1.1.15"
+                        "ip": "^1.1.2",
+                        "smart-buffer": "^1.0.4"
                     }
                 }
             }
@@ -15002,7 +15020,7 @@
             "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
             "dev": true,
             "requires": {
-                "abbrev": "1.1.1"
+                "abbrev": "1"
             }
         },
         "normalize-package-data": {
@@ -15011,10 +15029,10 @@
             "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
             "dev": true,
             "requires": {
-                "hosted-git-info": "2.7.1",
-                "is-builtin-module": "1.0.0",
-                "semver": "5.5.0",
-                "validate-npm-package-license": "3.0.4"
+                "hosted-git-info": "^2.1.4",
+                "is-builtin-module": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "validate-npm-package-license": "^3.0.1"
             }
         },
         "normalize-path": {
@@ -15023,7 +15041,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "normalize-range": {
@@ -15044,7 +15062,7 @@
             "integrity": "sha512-IFsj0R9C7ZdR5cP+ET342q77uSRdtWOlWpih5eC+lu29tIDbNEgDbzgVJ5UFvYHWhxDZ5TFkJafFioO0pPQjCw==",
             "dev": true,
             "requires": {
-                "which": "1.3.1"
+                "which": "^1.2.10"
             }
         },
         "npm-run-path": {
@@ -15053,7 +15071,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "npm-which": {
@@ -15062,9 +15080,9 @@
             "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
             "dev": true,
             "requires": {
-                "commander": "2.17.1",
-                "npm-path": "2.0.4",
-                "which": "1.3.1"
+                "commander": "^2.9.0",
+                "npm-path": "^2.0.2",
+                "which": "^1.2.10"
             }
         },
         "npmlog": {
@@ -15073,10 +15091,10 @@
             "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
             "dev": true,
             "requires": {
-                "are-we-there-yet": "1.1.5",
-                "console-control-strings": "1.1.0",
-                "gauge": "2.7.4",
-                "set-blocking": "2.0.0"
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
             }
         },
         "nth-check": {
@@ -15085,7 +15103,7 @@
             "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
             "dev": true,
             "requires": {
-                "boolbase": "1.0.0"
+                "boolbase": "~1.0.0"
             }
         },
         "null-check": {
@@ -15112,11 +15130,11 @@
             "integrity": "sha512-UtlKKAzg9vdtvURdNy9DjGhiB7qYf2R7Ez+hsucOQG5gYJexSggXSSZ+9IpSDyKOlWu/4rMVPH2oVoANOSqNKA==",
             "dev": true,
             "requires": {
-                "a-sync-waterfall": "1.0.0",
-                "asap": "2.0.6",
-                "chokidar": "2.0.4",
-                "postinstall-build": "5.0.1",
-                "yargs": "3.32.0"
+                "a-sync-waterfall": "^1.0.0",
+                "asap": "^2.0.3",
+                "chokidar": "^2.0.0",
+                "postinstall-build": "^5.0.1",
+                "yargs": "^3.32.0"
             },
             "dependencies": {
                 "anymatch": {
@@ -15126,20 +15144,20 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "micromatch": "3.1.10",
-                        "normalize-path": "2.1.1"
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
                     }
                 },
                 "arr-diff": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/arr-diff/-/arr-diff-4.0.0.tgz",
                     "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
                     "dev": true,
                     "optional": true
                 },
                 "array-unique": {
                     "version": "0.3.2",
-                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/array-unique/-/array-unique-0.3.2.tgz",
                     "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
                     "dev": true
                 },
@@ -15149,25 +15167,25 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -15185,19 +15203,19 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "anymatch": "2.0.0",
-                        "async-each": "1.0.1",
-                        "braces": "2.3.2",
-                        "fsevents": "1.2.4",
-                        "glob-parent": "3.1.0",
-                        "inherits": "2.0.3",
-                        "is-binary-path": "1.0.1",
-                        "is-glob": "4.0.0",
-                        "lodash.debounce": "4.0.8",
-                        "normalize-path": "2.1.1",
-                        "path-is-absolute": "1.0.1",
-                        "readdirp": "2.1.0",
-                        "upath": "1.1.0"
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.0",
+                        "braces": "^2.3.0",
+                        "fsevents": "^1.2.2",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.1",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "lodash.debounce": "^4.0.8",
+                        "normalize-path": "^2.1.1",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.0.0",
+                        "upath": "^1.0.5"
                     }
                 },
                 "cliui": {
@@ -15206,45 +15224,45 @@
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "dev": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "expand-brackets": {
                     "version": "2.1.4",
-                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/expand-brackets/-/expand-brackets-2.1.4.tgz",
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
                             "version": "0.2.5",
-                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/define-property/-/define-property-0.2.5.tgz",
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -15254,7 +15272,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -15264,7 +15282,7 @@
                                     "dev": true,
                                     "optional": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -15276,7 +15294,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -15286,7 +15304,7 @@
                                     "dev": true,
                                     "optional": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -15298,9 +15316,9 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -15319,80 +15337,80 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
                             "version": "1.0.0",
-                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/define-property/-/define-property-1.0.0.tgz",
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
                 },
                 "fill-range": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
                 },
                 "glob-parent": {
                     "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/glob-parent/-/glob-parent-3.1.0.tgz",
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
                     },
                     "dependencies": {
                         "is-glob": {
                             "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-glob/-/is-glob-3.1.0.tgz",
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "is-extglob": "2.1.1"
+                                "is-extglob": "^2.1.0"
                             }
                         }
                     }
@@ -15404,7 +15422,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -15414,7 +15432,7 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -15424,50 +15442,50 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-extglob": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-extglob/-/is-extglob-2.1.1.tgz",
                     "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
                     "dev": true
                 },
                 "is-glob": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-glob/-/is-glob-4.0.0.tgz",
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 },
                 "is-number": {
                     "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
                             "version": "3.2.2",
-                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
                 },
                 "isobject": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/isobject/-/isobject-3.0.1.tgz",
                     "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
                     "dev": true
                 },
@@ -15484,19 +15502,19 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 },
                 "window-size": {
@@ -15511,13 +15529,13 @@
                     "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "2.1.1",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "os-locale": "1.4.0",
-                        "string-width": "1.0.2",
-                        "window-size": "0.1.4",
-                        "y18n": "3.2.1"
+                        "camelcase": "^2.0.1",
+                        "cliui": "^3.0.3",
+                        "decamelize": "^1.1.1",
+                        "os-locale": "^1.4.0",
+                        "string-width": "^1.0.1",
+                        "window-size": "^0.1.4",
+                        "y18n": "^3.2.0"
                     }
                 }
             }
@@ -15552,9 +15570,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -15563,7 +15581,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -15586,7 +15604,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "isobject": {
@@ -15603,10 +15621,10 @@
             "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "function-bind": "1.1.1",
-                "has-symbols": "1.0.0",
-                "object-keys": "1.0.12"
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "has-symbols": "^1.0.0",
+                "object-keys": "^1.0.11"
             }
         },
         "object.defaults": {
@@ -15615,10 +15633,10 @@
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "1.0.1",
-                "array-slice": "1.1.0",
-                "for-own": "1.0.0",
-                "isobject": "3.0.1"
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "for-own": {
@@ -15627,7 +15645,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 },
                 "isobject": {
@@ -15644,8 +15662,8 @@
             "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "es-abstract": "1.12.0"
+                "define-properties": "^1.1.2",
+                "es-abstract": "^1.5.1"
             }
         },
         "object.map": {
@@ -15654,8 +15672,8 @@
             "integrity": "sha1-z4Plncj8wK1fQlDh94s7gb2AHTc=",
             "dev": true,
             "requires": {
-                "for-own": "1.0.0",
-                "make-iterator": "1.0.1"
+                "for-own": "^1.0.0",
+                "make-iterator": "^1.0.0"
             },
             "dependencies": {
                 "for-own": {
@@ -15664,7 +15682,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 }
             }
@@ -15675,8 +15693,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "object.pick": {
@@ -15685,7 +15703,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -15729,12 +15747,12 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
             "version": "1.1.0",
-            "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
             "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
             "dev": true
         },
@@ -15744,7 +15762,7 @@
             "integrity": "sha512-bYJHo/LOmoTd+pfiYhfZDnf9zekVJrY+cnS2a5F2x+w5ppvTqObojTP7WiFG+kVZs9Inw+qQ/lw7TroWwhdd2g==",
             "dev": true,
             "requires": {
-                "is-wsl": "1.1.0"
+                "is-wsl": "^1.1.0"
             }
         },
         "optimist": {
@@ -15753,8 +15771,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             },
             "dependencies": {
                 "minimist": {
@@ -15771,12 +15789,12 @@
             "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
             "dev": true,
             "requires": {
-                "deep-is": "0.1.3",
-                "fast-levenshtein": "2.0.6",
-                "levn": "0.3.0",
-                "prelude-ls": "1.1.2",
-                "type-check": "0.3.2",
-                "wordwrap": "1.0.0"
+                "deep-is": "~0.1.3",
+                "fast-levenshtein": "~2.0.4",
+                "levn": "~0.3.0",
+                "prelude-ls": "~1.1.2",
+                "type-check": "~0.3.2",
+                "wordwrap": "~1.0.0"
             },
             "dependencies": {
                 "wordwrap": {
@@ -15793,10 +15811,10 @@
             "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "cli-cursor": "1.0.2",
-                "cli-spinners": "0.1.2",
-                "object-assign": "4.1.1"
+                "chalk": "^1.1.1",
+                "cli-cursor": "^1.0.2",
+                "cli-spinners": "^0.1.2",
+                "object-assign": "^4.0.1"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -15811,11 +15829,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -15832,9 +15850,9 @@
             "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "0.1.5",
-                "sequencify": "0.0.7",
-                "stream-consume": "0.1.1"
+                "end-of-stream": "~0.1.5",
+                "sequencify": "~0.0.7",
+                "stream-consume": "~0.1.0"
             }
         },
         "ordered-read-streams": {
@@ -15849,7 +15867,7 @@
             "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
             "dev": true,
             "requires": {
-                "url-parse": "1.4.3"
+                "url-parse": "^1.4.3"
             }
         },
         "os-browserify": {
@@ -15870,7 +15888,7 @@
             "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "dev": true,
             "requires": {
-                "lcid": "1.0.0"
+                "lcid": "^1.0.0"
             }
         },
         "os-tmpdir": {
@@ -15885,8 +15903,8 @@
             "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2",
-                "os-tmpdir": "1.0.2"
+                "os-homedir": "^1.0.0",
+                "os-tmpdir": "^1.0.0"
             }
         },
         "p-each-series": {
@@ -15895,7 +15913,7 @@
             "integrity": "sha1-kw89Et0fUOdDRFeiLNbwSsatf3E=",
             "dev": true,
             "requires": {
-                "p-reduce": "1.0.0"
+                "p-reduce": "^1.0.0"
             }
         },
         "p-finally": {
@@ -15910,7 +15928,7 @@
             "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
             "dev": true,
             "requires": {
-                "p-try": "1.0.0"
+                "p-try": "^1.0.0"
             }
         },
         "p-locate": {
@@ -15919,7 +15937,7 @@
             "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
             "dev": true,
             "requires": {
-                "p-limit": "1.3.0"
+                "p-limit": "^1.1.0"
             }
         },
         "p-map": {
@@ -15947,14 +15965,14 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "agent-base": "4.2.1",
-                "debug": "3.1.0",
-                "get-uri": "2.0.2",
-                "http-proxy-agent": "2.1.0",
-                "https-proxy-agent": "2.2.1",
-                "pac-resolver": "3.0.0",
-                "raw-body": "2.3.3",
-                "socks-proxy-agent": "3.0.1"
+                "agent-base": "^4.2.0",
+                "debug": "^3.1.0",
+                "get-uri": "^2.0.0",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1",
+                "pac-resolver": "^3.0.0",
+                "raw-body": "^2.2.0",
+                "socks-proxy-agent": "^3.0.0"
             },
             "dependencies": {
                 "debug": {
@@ -15974,8 +15992,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "agent-base": "4.2.1",
-                        "socks": "1.1.10"
+                        "agent-base": "^4.1.0",
+                        "socks": "^1.1.10"
                     }
                 }
             }
@@ -15987,11 +16005,11 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "co": "4.6.0",
-                "degenerator": "1.0.4",
-                "ip": "1.1.5",
-                "netmask": "1.0.6",
-                "thunkify": "2.1.2"
+                "co": "^4.6.0",
+                "degenerator": "^1.0.4",
+                "ip": "^1.1.5",
+                "netmask": "^1.0.6",
+                "thunkify": "^2.1.2"
             }
         },
         "pako": {
@@ -16006,9 +16024,9 @@
             "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
             "dev": true,
             "requires": {
-                "cyclist": "0.2.2",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "cyclist": "~0.2.2",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.1.5"
             }
         },
         "param-case": {
@@ -16017,7 +16035,7 @@
             "integrity": "sha1-35T9jPZTHs915r75oIWPvHK+Ikc=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2"
+                "no-case": "^2.2.0"
             }
         },
         "parse-asn1": {
@@ -16026,11 +16044,11 @@
             "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
             "dev": true,
             "requires": {
-                "asn1.js": "4.10.1",
-                "browserify-aes": "1.2.0",
-                "create-hash": "1.2.0",
-                "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.0.16"
+                "asn1.js": "^4.0.0",
+                "browserify-aes": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3"
             }
         },
         "parse-entities": {
@@ -16039,12 +16057,12 @@
             "integrity": "sha512-5N9lmQ7tmxfXf+hO3X6KRG6w7uYO/HL9fHalSySTdyn63C3WNvTM/1R8tn1u1larNcEbo3Slcy2bsVDQqvEpUg==",
             "dev": true,
             "requires": {
-                "character-entities": "1.2.2",
-                "character-entities-legacy": "1.1.2",
-                "character-reference-invalid": "1.1.2",
-                "is-alphanumerical": "1.0.2",
-                "is-decimal": "1.0.2",
-                "is-hexadecimal": "1.0.2"
+                "character-entities": "^1.0.0",
+                "character-entities-legacy": "^1.0.0",
+                "character-reference-invalid": "^1.0.0",
+                "is-alphanumerical": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-hexadecimal": "^1.0.0"
             }
         },
         "parse-filepath": {
@@ -16053,9 +16071,9 @@
             "integrity": "sha1-pjISf1Oq89FYdvWHLz/6x2PWyJE=",
             "dev": true,
             "requires": {
-                "is-absolute": "1.0.0",
-                "map-cache": "0.2.2",
-                "path-root": "0.1.1"
+                "is-absolute": "^1.0.0",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
             }
         },
         "parse-github-repo-url": {
@@ -16070,10 +16088,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             }
         },
         "parse-json": {
@@ -16082,8 +16100,8 @@
             "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
             "dev": true,
             "requires": {
-                "error-ex": "1.3.2",
-                "json-parse-better-errors": "1.0.2"
+                "error-ex": "^1.3.1",
+                "json-parse-better-errors": "^1.0.1"
             }
         },
         "parse-ms": {
@@ -16110,7 +16128,7 @@
             "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
             "dev": true,
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseuri": {
@@ -16119,7 +16137,7 @@
             "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
             "dev": true,
             "requires": {
-                "better-assert": "1.0.2"
+                "better-assert": "~1.0.0"
             }
         },
         "parseurl": {
@@ -16134,8 +16152,8 @@
             "integrity": "sha1-LVeNNFX2YNpl7KGO+VtODekSdh4=",
             "dev": true,
             "requires": {
-                "camel-case": "3.0.0",
-                "upper-case-first": "1.1.2"
+                "camel-case": "^3.0.0",
+                "upper-case-first": "^1.1.0"
             }
         },
         "pascalcase": {
@@ -16156,7 +16174,7 @@
             "integrity": "sha1-lLgDfDctP+KQbkZbtF4l0ibo7qU=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2"
+                "no-case": "^2.2.0"
             }
         },
         "path-dirname": {
@@ -16202,7 +16220,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "inflection": "1.3.8"
+                "inflection": "~1.3.0"
             },
             "dependencies": {
                 "inflection": {
@@ -16220,7 +16238,7 @@
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "0.1.2"
+                "path-root-regex": "^0.1.0"
             }
         },
         "path-root-regex": {
@@ -16241,7 +16259,7 @@
             "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
             "dev": true,
             "requires": {
-                "pify": "3.0.0"
+                "pify": "^3.0.0"
             }
         },
         "pbkdf2": {
@@ -16250,11 +16268,11 @@
             "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
             "dev": true,
             "requires": {
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "ripemd160": "2.0.2",
-                "safe-buffer": "5.1.2",
-                "sha.js": "2.4.11"
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "performance-now": {
@@ -16281,7 +16299,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "pkg-dir": {
@@ -16290,7 +16308,7 @@
             "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0"
+                "find-up": "^2.1.0"
             }
         },
         "please-upgrade-node": {
@@ -16299,7 +16317,7 @@
             "integrity": "sha512-KY1uHnQ2NlQHqIJQpnh/i54rKkuxCEBx+voJIS/Mvb+L2iYd2NMotwduhKTMjfC1uKoX3VXOxLjIYG66dfJTVQ==",
             "dev": true,
             "requires": {
-                "semver-compare": "1.0.0"
+                "semver-compare": "^1.0.0"
             }
         },
         "plugin-error": {
@@ -16308,11 +16326,11 @@
             "integrity": "sha1-O5uzM1zPAPQl4HQ34ZJ2ln2kes4=",
             "dev": true,
             "requires": {
-                "ansi-cyan": "0.1.1",
-                "ansi-red": "0.1.1",
-                "arr-diff": "1.1.0",
-                "arr-union": "2.1.0",
-                "extend-shallow": "1.1.4"
+                "ansi-cyan": "^0.1.1",
+                "ansi-red": "^0.1.1",
+                "arr-diff": "^1.0.1",
+                "arr-union": "^2.0.1",
+                "extend-shallow": "^1.1.2"
             },
             "dependencies": {
                 "arr-diff": {
@@ -16321,8 +16339,8 @@
                     "integrity": "sha1-aHwydYFjWI/vfeezb6vklesaOZo=",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-slice": "0.2.3"
+                        "arr-flatten": "^1.0.1",
+                        "array-slice": "^0.2.3"
                     }
                 },
                 "arr-union": {
@@ -16343,7 +16361,7 @@
                     "integrity": "sha1-Gda/lN/AnXa6cR85uHLSH/TdkHE=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "1.1.0"
+                        "kind-of": "^1.1.0"
                     }
                 },
                 "kind-of": {
@@ -16366,9 +16384,9 @@
             "integrity": "sha512-icBXCFQxzlK2PMepOM0QeEdPPFSLAaXXeuKOv5AClJlMy1oVCBrkDGJ12IZYesI/BF8mpeVco3vRCmgeBb4+hw==",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "debug": "2.6.9",
-                "mkdirp": "0.5.1"
+                "async": "^1.5.2",
+                "debug": "^2.2.0",
+                "mkdirp": "0.5.x"
             }
         },
         "posix-character-classes": {
@@ -16383,10 +16401,10 @@
             "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "js-base64": "2.4.8",
-                "source-map": "0.5.7",
-                "supports-color": "3.2.3"
+                "chalk": "^1.1.3",
+                "js-base64": "^2.1.9",
+                "source-map": "^0.5.6",
+                "supports-color": "^3.2.3"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -16401,11 +16419,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     },
                     "dependencies": {
                         "supports-color": {
@@ -16434,7 +16452,7 @@
                     "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
                     "dev": true,
                     "requires": {
-                        "has-flag": "1.0.0"
+                        "has-flag": "^1.0.0"
                     }
                 }
             }
@@ -16445,7 +16463,7 @@
             "integrity": "sha512-5orIml7dVf17OrHyO39BXMGlklKT884FvkB+gdCtGJ63b1AAeGF7NuXGC1HM83TI0Ip1gZyBowrPuXCOPqqerA==",
             "dev": true,
             "requires": {
-                "htmlparser2": "3.9.2"
+                "htmlparser2": "^3.9.2"
             }
         },
         "postcss-less": {
@@ -16454,7 +16472,7 @@
             "integrity": "sha512-pPNsVnpCB13nBMOcl5GVh8JGmB0JGFjqkLUDzKdVpptFFKEe9wFdEzvh2j4lD2AD+7qcrUfw9Ta+oi5+Fw7jjQ==",
             "dev": true,
             "requires": {
-                "postcss": "5.2.18"
+                "postcss": "^5.2.16"
             }
         },
         "postcss-load-config": {
@@ -16463,8 +16481,8 @@
             "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
             "dev": true,
             "requires": {
-                "cosmiconfig": "4.0.0",
-                "import-cwd": "2.1.0"
+                "cosmiconfig": "^4.0.0",
+                "import-cwd": "^2.0.0"
             }
         },
         "postcss-loader": {
@@ -16473,10 +16491,10 @@
             "integrity": "sha512-hgiWSc13xVQAq25cVw80CH0l49ZKlAnU1hKPOdRrNj89bokRr/bZF2nT+hebPPF9c9xs8c3gw3Fr2nxtmXYnNg==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "postcss": "6.0.23",
-                "postcss-load-config": "2.0.0",
-                "schema-utils": "0.4.7"
+                "loader-utils": "^1.1.0",
+                "postcss": "^6.0.0",
+                "postcss-load-config": "^2.0.0",
+                "schema-utils": "^0.4.0"
             },
             "dependencies": {
                 "loader-utils": {
@@ -16485,9 +16503,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 },
                 "postcss": {
@@ -16496,9 +16514,9 @@
                     "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.1",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.4.0"
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
                     }
                 }
             }
@@ -16509,8 +16527,8 @@
             "integrity": "sha512-2fKbCxnyACX0ZSRpgZD0XYmVLlz0Sam8cCy423xn08t/EygOYPsK6FOp7gGrLsVXzQVwtN3HNLfcPkiseIZSSA==",
             "dev": true,
             "requires": {
-                "remark": "9.0.0",
-                "unist-util-find-all-after": "1.0.2"
+                "remark": "^9.0.0",
+                "unist-util-find-all-after": "^1.0.2"
             }
         },
         "postcss-media-query-parser": {
@@ -16525,10 +16543,10 @@
             "integrity": "sha512-rBkDbaHAu5uywbCR2XE8a25tats3xSOsGNx6mppK6Q9kSFGKc/FyAzfci+fWM2l+K402p1D0pNcfDGxeje5IKg==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "lodash": "4.17.10",
-                "log-symbols": "2.2.0",
-                "postcss": "6.0.23"
+                "chalk": "^2.0.1",
+                "lodash": "^4.17.4",
+                "log-symbols": "^2.0.0",
+                "postcss": "^6.0.8"
             },
             "dependencies": {
                 "postcss": {
@@ -16537,9 +16555,9 @@
                     "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.1",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.4.0"
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
                     }
                 }
             }
@@ -16556,7 +16574,7 @@
             "integrity": "sha512-xZsFA3uX8MO3yAda03QrG3/Eg1LN3EPfjjf07vke/46HERLZyHrTsQ9E1r1w1W//fWEhtYNndo2hQplN2cVpCQ==",
             "dev": true,
             "requires": {
-                "postcss": "7.0.2"
+                "postcss": "^7.0.0"
             },
             "dependencies": {
                 "postcss": {
@@ -16565,9 +16583,9 @@
                     "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.1",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.4.0"
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
                     }
                 }
             }
@@ -16588,7 +16606,7 @@
                     "integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
                     "dev": true,
                     "requires": {
-                        "minimist": "1.1.3"
+                        "minimist": "1.1.x"
                     }
                 },
                 "minimist": {
@@ -16603,9 +16621,9 @@
                     "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.1",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.4.0"
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
                     }
                 }
             }
@@ -16616,7 +16634,7 @@
             "integrity": "sha512-um9zdGKaDZirMm+kZFKKVsnKPF7zF7qBAtIfTSnZXD1jZ0JNZIxdB6TxQOjCnlSzLRInVl2v3YdBh/M881C4ug==",
             "dev": true,
             "requires": {
-                "postcss": "7.0.2"
+                "postcss": "^7.0.0"
             },
             "dependencies": {
                 "postcss": {
@@ -16625,9 +16643,9 @@
                     "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.1",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.4.0"
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
                     }
                 }
             }
@@ -16656,9 +16674,9 @@
             "integrity": "sha512-3M3p+2gMp0AH3da530TlX8kiO1nxdTnc3C6vr8dMxRLIlh8UYkz0/wcwptSXjhtx2Fr0TySI7a+BHDQ8NL7LaQ==",
             "dev": true,
             "requires": {
-                "flatten": "1.0.2",
-                "indexes-of": "1.0.1",
-                "uniq": "1.0.1"
+                "flatten": "^1.0.2",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
             }
         },
         "postinstall-build": {
@@ -16673,19 +16691,19 @@
             "integrity": "sha512-8h3qbpa33mE+VAoxo0e9HPw7aBN7iwDqdTts2Jz0hCxWDy9FMBXJTm2WAYsNdfvA3oz1j+FgvPSCvo0ngoXBaQ==",
             "dev": true,
             "requires": {
-                "commander": "2.17.1",
-                "debug": "3.1.0",
-                "detective-amd": "2.4.0",
-                "detective-cjs": "2.0.0",
-                "detective-es6": "1.2.0",
-                "detective-less": "1.0.1",
-                "detective-postcss": "2.1.2",
-                "detective-sass": "2.0.1",
-                "detective-scss": "1.0.1",
-                "detective-stylus": "1.0.0",
-                "detective-typescript": "2.0.0",
-                "module-definition": "2.2.4",
-                "node-source-walk": "3.3.0"
+                "commander": "^2.11.0",
+                "debug": "^3.0.1",
+                "detective-amd": "^2.4.0",
+                "detective-cjs": "^2.0.0",
+                "detective-es6": "^1.2.0",
+                "detective-less": "^1.0.1",
+                "detective-postcss": "^2.1.0",
+                "detective-sass": "^2.0.0",
+                "detective-scss": "^1.0.0",
+                "detective-stylus": "^1.0.0",
+                "detective-typescript": "^2.0.0",
+                "module-definition": "^2.2.4",
+                "node-source-walk": "^3.3.0"
             },
             "dependencies": {
                 "debug": {
@@ -16729,18 +16747,18 @@
             "integrity": "sha1-X0+HyPkeWuPzuoerTPXgOxoX8aM=",
             "dev": true,
             "requires": {
-                "renderkid": "2.0.1",
-                "utila": "0.4.0"
+                "renderkid": "^2.0.1",
+                "utila": "~0.4"
             }
         },
         "pretty-format": {
             "version": "23.2.0",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.2.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/pretty-format/-/pretty-format-23.2.0.tgz",
             "integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
             "dev": true,
             "requires": {
-                "ansi-regex": "3.0.0",
-                "ansi-styles": "3.2.1"
+                "ansi-regex": "^3.0.0",
+                "ansi-styles": "^3.2.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -16763,7 +16781,7 @@
             "integrity": "sha512-ZypexbfVUGTFxb0v+m1bUyy92DHe5SyYlnyY0msyms5zd3RwyvNgyxZZsXXgoyzlxjx5MiqtXUdhUfvQbe0A2Q==",
             "dev": true,
             "requires": {
-                "parse-ms": "1.0.1"
+                "parse-ms": "^1.0.0"
             }
         },
         "process": {
@@ -16784,7 +16802,7 @@
             "integrity": "sha1-5F1osAoXZHttpxG/he1u1HII9FA=",
             "dev": true,
             "requires": {
-                "asap": "2.0.6"
+                "asap": "~2.0.3"
             }
         },
         "promise-inflight": {
@@ -16795,12 +16813,12 @@
         },
         "promisify-call": {
             "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/promisify-call/-/promisify-call-2.0.4.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/promisify-call/-/promisify-call-2.0.4.tgz",
             "integrity": "sha1-1IwtRWUszM1SgB3ey9UzptS9X7o=",
             "dev": true,
             "optional": true,
             "requires": {
-                "with-callback": "1.0.2"
+                "with-callback": "^1.0.2"
             }
         },
         "proxy-addr": {
@@ -16809,7 +16827,7 @@
             "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
             "dev": true,
             "requires": {
-                "forwarded": "0.1.2",
+                "forwarded": "~0.1.2",
                 "ipaddr.js": "1.8.0"
             }
         },
@@ -16820,14 +16838,14 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "agent-base": "4.2.1",
-                "debug": "3.1.0",
-                "http-proxy-agent": "2.1.0",
-                "https-proxy-agent": "2.2.1",
-                "lru-cache": "4.1.3",
-                "pac-proxy-agent": "2.0.2",
-                "proxy-from-env": "1.0.0",
-                "socks-proxy-agent": "4.0.1"
+                "agent-base": "^4.2.0",
+                "debug": "^3.1.0",
+                "http-proxy-agent": "^2.1.0",
+                "https-proxy-agent": "^2.2.1",
+                "lru-cache": "^4.1.2",
+                "pac-proxy-agent": "^2.0.1",
+                "proxy-from-env": "^1.0.0",
+                "socks-proxy-agent": "^4.0.1"
             },
             "dependencies": {
                 "debug": {
@@ -16847,15 +16865,15 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 }
             }
         },
         "proxy-from-env": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
             "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
             "dev": true,
             "optional": true
@@ -16884,11 +16902,11 @@
             "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.2.0",
-                "parse-asn1": "5.1.1",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1"
             }
         },
         "pump": {
@@ -16897,8 +16915,8 @@
             "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -16907,7 +16925,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 }
             }
@@ -16918,9 +16936,9 @@
             "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
             "dev": true,
             "requires": {
-                "duplexify": "3.6.0",
-                "inherits": "2.0.3",
-                "pump": "2.0.1"
+                "duplexify": "^3.6.0",
+                "inherits": "^2.0.3",
+                "pump": "^2.0.0"
             }
         },
         "punycode": {
@@ -16977,9 +16995,9 @@
             "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0",
-                "kind-of": "6.0.2",
-                "math-random": "1.0.1"
+                "is-number": "^4.0.0",
+                "kind-of": "^6.0.0",
+                "math-random": "^1.0.1"
             },
             "dependencies": {
                 "is-number": {
@@ -17002,7 +17020,7 @@
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.1.0"
             }
         },
         "randomfill": {
@@ -17011,8 +17029,8 @@
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "dev": true,
             "requires": {
-                "randombytes": "2.0.6",
-                "safe-buffer": "5.1.2"
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
             }
         },
         "range-parser": {
@@ -17045,10 +17063,10 @@
             "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
             "dev": true,
             "requires": {
-                "deep-extend": "0.6.0",
-                "ini": "1.3.5",
-                "minimist": "1.2.0",
-                "strip-json-comments": "2.0.1"
+                "deep-extend": "^0.6.0",
+                "ini": "~1.3.0",
+                "minimist": "^1.2.0",
+                "strip-json-comments": "~2.0.1"
             }
         },
         "read-installed": {
@@ -17057,13 +17075,13 @@
             "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
             "dev": true,
             "requires": {
-                "debuglog": "1.0.1",
-                "graceful-fs": "4.1.11",
-                "read-package-json": "2.0.13",
-                "readdir-scoped-modules": "1.0.2",
-                "semver": "5.5.0",
-                "slide": "1.1.6",
-                "util-extend": "1.0.3"
+                "debuglog": "^1.0.1",
+                "graceful-fs": "^4.1.2",
+                "read-package-json": "^2.0.0",
+                "readdir-scoped-modules": "^1.0.0",
+                "semver": "2 || 3 || 4 || 5",
+                "slide": "~1.1.3",
+                "util-extend": "^1.0.1"
             }
         },
         "read-package-json": {
@@ -17072,11 +17090,11 @@
             "integrity": "sha512-/1dZ7TRZvGrYqE0UAfN6qQb5GYBsNcqS1C0tNK601CFOJmtHI7NIGXwetEPU/OtoFHZL3hDxm4rolFFVE9Bnmg==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "graceful-fs": "4.1.11",
-                "json-parse-better-errors": "1.0.2",
-                "normalize-package-data": "2.4.0",
-                "slash": "1.0.0"
+                "glob": "^7.1.1",
+                "graceful-fs": "^4.1.2",
+                "json-parse-better-errors": "^1.0.1",
+                "normalize-package-data": "^2.0.0",
+                "slash": "^1.0.0"
             }
         },
         "read-pkg": {
@@ -17085,9 +17103,9 @@
             "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
             "dev": true,
             "requires": {
-                "load-json-file": "4.0.0",
-                "normalize-package-data": "2.4.0",
-                "path-type": "3.0.0"
+                "load-json-file": "^4.0.0",
+                "normalize-package-data": "^2.3.2",
+                "path-type": "^3.0.0"
             }
         },
         "read-pkg-up": {
@@ -17096,8 +17114,8 @@
             "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
             "dev": true,
             "requires": {
-                "find-up": "2.1.0",
-                "read-pkg": "3.0.0"
+                "find-up": "^2.0.0",
+                "read-pkg": "^3.0.0"
             }
         },
         "readable-stream": {
@@ -17106,13 +17124,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.2",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             }
         },
         "readdir-scoped-modules": {
@@ -17121,10 +17139,10 @@
             "integrity": "sha1-n6+jfShr5dksuuve4DDcm19AZ0c=",
             "dev": true,
             "requires": {
-                "debuglog": "1.0.1",
-                "dezalgo": "1.0.3",
-                "graceful-fs": "4.1.11",
-                "once": "1.4.0"
+                "debuglog": "^1.0.1",
+                "dezalgo": "^1.0.0",
+                "graceful-fs": "^4.1.2",
+                "once": "^1.3.0"
             }
         },
         "readdirp": {
@@ -17133,10 +17151,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.6",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "rechoir": {
@@ -17145,7 +17163,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.8.1"
+                "resolve": "^1.1.6"
             }
         },
         "redent": {
@@ -17154,8 +17172,8 @@
             "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
             "dev": true,
             "requires": {
-                "indent-string": "3.2.0",
-                "strip-indent": "2.0.0"
+                "indent-string": "^3.0.0",
+                "strip-indent": "^2.0.0"
             }
         },
         "redis": {
@@ -17165,9 +17183,9 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "double-ended-queue": "2.1.0-0",
-                "redis-commands": "1.3.5",
-                "redis-parser": "2.6.0"
+                "double-ended-queue": "^2.1.0-0",
+                "redis-commands": "^1.2.0",
+                "redis-parser": "^2.6.0"
             }
         },
         "redis-commands": {
@@ -17202,7 +17220,7 @@
             "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3"
+                "is-equal-shallow": "^0.1.3"
             }
         },
         "regex-not": {
@@ -17211,8 +17229,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "regex-parser": {
@@ -17233,11 +17251,11 @@
             "integrity": "sha512-gsNQXs5kJLhErICSyYhzVZ++C8LBW8dgwr874Y2QvzAUS75zBlD/juZgXs39nbYJ09fZDlX2AVLVJAY2jbFJoQ==",
             "dev": true,
             "requires": {
-                "amdefine": "1.0.1",
+                "amdefine": "^1.0.0",
                 "istanbul": "0.4.5",
-                "minimatch": "3.0.4",
-                "plugin-error": "0.1.2",
-                "source-map": "0.6.1",
+                "minimatch": "^3.0.3",
+                "plugin-error": "^0.1.2",
+                "source-map": "^0.6.1",
                 "through2": "2.0.1"
             },
             "dependencies": {
@@ -17253,12 +17271,12 @@
                     "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "0.10.31",
-                        "util-deprecate": "1.0.2"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~1.0.6",
+                        "string_decoder": "~0.10.x",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "string_decoder": {
@@ -17273,8 +17291,8 @@
                     "integrity": "sha1-OE51MU1J8y3hLuu4E2uOtrXVnak=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "2.0.6",
-                        "xtend": "4.0.1"
+                        "readable-stream": "~2.0.0",
+                        "xtend": "~4.0.0"
                     }
                 }
             }
@@ -17285,9 +17303,9 @@
             "integrity": "sha512-amw8rGdD5lHbMEakiEsllmkdBP+/KpjW/PRK6NSGPZKCQowh0BT4IWXDAkRMyG3SB9dKPXWMviFjNusXzXNn3A==",
             "dev": true,
             "requires": {
-                "remark-parse": "5.0.0",
-                "remark-stringify": "5.0.0",
-                "unified": "6.2.0"
+                "remark-parse": "^5.0.0",
+                "remark-stringify": "^5.0.0",
+                "unified": "^6.0.0"
             }
         },
         "remark-parse": {
@@ -17296,21 +17314,21 @@
             "integrity": "sha512-b3iXszZLH1TLoyUzrATcTQUZrwNl1rE70rVdSruJFlDaJ9z5aMkhrG43Pp68OgfHndL/ADz6V69Zow8cTQu+JA==",
             "dev": true,
             "requires": {
-                "collapse-white-space": "1.0.4",
-                "is-alphabetical": "1.0.2",
-                "is-decimal": "1.0.2",
-                "is-whitespace-character": "1.0.2",
-                "is-word-character": "1.0.2",
-                "markdown-escapes": "1.0.2",
-                "parse-entities": "1.1.2",
-                "repeat-string": "1.6.1",
-                "state-toggle": "1.0.1",
+                "collapse-white-space": "^1.0.2",
+                "is-alphabetical": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-whitespace-character": "^1.0.0",
+                "is-word-character": "^1.0.0",
+                "markdown-escapes": "^1.0.0",
+                "parse-entities": "^1.1.0",
+                "repeat-string": "^1.5.4",
+                "state-toggle": "^1.0.0",
                 "trim": "0.0.1",
-                "trim-trailing-lines": "1.1.1",
-                "unherit": "1.1.1",
-                "unist-util-remove-position": "1.1.2",
-                "vfile-location": "2.0.3",
-                "xtend": "4.0.1"
+                "trim-trailing-lines": "^1.0.0",
+                "unherit": "^1.0.4",
+                "unist-util-remove-position": "^1.0.0",
+                "vfile-location": "^2.0.0",
+                "xtend": "^4.0.1"
             }
         },
         "remark-stringify": {
@@ -17319,20 +17337,20 @@
             "integrity": "sha512-Ws5MdA69ftqQ/yhRF9XhVV29mhxbfGhbz0Rx5bQH+oJcNhhSM6nCu1EpLod+DjrFGrU0BMPs+czVmJZU7xiS7w==",
             "dev": true,
             "requires": {
-                "ccount": "1.0.3",
-                "is-alphanumeric": "1.0.0",
-                "is-decimal": "1.0.2",
-                "is-whitespace-character": "1.0.2",
-                "longest-streak": "2.0.2",
-                "markdown-escapes": "1.0.2",
-                "markdown-table": "1.1.2",
-                "mdast-util-compact": "1.0.1",
-                "parse-entities": "1.1.2",
-                "repeat-string": "1.6.1",
-                "state-toggle": "1.0.1",
-                "stringify-entities": "1.3.2",
-                "unherit": "1.1.1",
-                "xtend": "4.0.1"
+                "ccount": "^1.0.0",
+                "is-alphanumeric": "^1.0.0",
+                "is-decimal": "^1.0.0",
+                "is-whitespace-character": "^1.0.0",
+                "longest-streak": "^2.0.1",
+                "markdown-escapes": "^1.0.0",
+                "markdown-table": "^1.1.0",
+                "mdast-util-compact": "^1.0.0",
+                "parse-entities": "^1.0.2",
+                "repeat-string": "^1.5.4",
+                "state-toggle": "^1.0.0",
+                "stringify-entities": "^1.0.1",
+                "unherit": "^1.0.4",
+                "xtend": "^4.0.1"
             }
         },
         "remove-trailing-separator": {
@@ -17347,11 +17365,11 @@
             "integrity": "sha1-iYyr/Ivt5Le5ETWj/9Mj5YwNsxk=",
             "dev": true,
             "requires": {
-                "css-select": "1.2.0",
-                "dom-converter": "0.1.4",
-                "htmlparser2": "3.3.0",
-                "strip-ansi": "3.0.1",
-                "utila": "0.3.3"
+                "css-select": "^1.1.0",
+                "dom-converter": "~0.1",
+                "htmlparser2": "~3.3.0",
+                "strip-ansi": "^3.0.0",
+                "utila": "~0.3"
             },
             "dependencies": {
                 "domhandler": {
@@ -17360,7 +17378,7 @@
                     "integrity": "sha1-0mRvXlf2w7qxHPbLBdPArPdBJZQ=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0"
+                        "domelementtype": "1"
                     }
                 },
                 "domutils": {
@@ -17369,7 +17387,7 @@
                     "integrity": "sha1-vdw94Jm5ou+sxRxiPyj0FuzFdIU=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0"
+                        "domelementtype": "1"
                     }
                 },
                 "htmlparser2": {
@@ -17378,10 +17396,10 @@
                     "integrity": "sha1-zHDQWln2VC5D8OaFyYLhTJJKnv4=",
                     "dev": true,
                     "requires": {
-                        "domelementtype": "1.3.0",
-                        "domhandler": "2.1.0",
-                        "domutils": "1.1.6",
-                        "readable-stream": "1.0.34"
+                        "domelementtype": "1",
+                        "domhandler": "2.1",
+                        "domutils": "1.1",
+                        "readable-stream": "1.0"
                     }
                 },
                 "isarray": {
@@ -17396,10 +17414,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -17434,7 +17452,7 @@
             "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
             "dev": true,
             "requires": {
-                "is-finite": "1.0.2"
+                "is-finite": "^1.0.0"
             }
         },
         "replace-ext": {
@@ -17449,9 +17467,9 @@
             "integrity": "sha1-6H9tUTuSjd6AgmDBK+f+xv9ueYw=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1",
-                "is-absolute": "1.0.0",
-                "remove-trailing-separator": "1.1.0"
+                "homedir-polyfill": "^1.0.1",
+                "is-absolute": "^1.0.0",
+                "remove-trailing-separator": "^1.1.0"
             }
         },
         "request": {
@@ -17460,26 +17478,26 @@
             "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
             "dev": true,
             "requires": {
-                "aws-sign2": "0.7.0",
-                "aws4": "1.8.0",
-                "caseless": "0.12.0",
-                "combined-stream": "1.0.6",
-                "extend": "3.0.2",
-                "forever-agent": "0.6.1",
-                "form-data": "2.3.2",
-                "har-validator": "5.0.3",
-                "http-signature": "1.2.0",
-                "is-typedarray": "1.0.0",
-                "isstream": "0.1.2",
-                "json-stringify-safe": "5.0.1",
-                "mime-types": "2.1.19",
-                "oauth-sign": "0.8.2",
-                "performance-now": "2.1.0",
-                "qs": "6.5.2",
-                "safe-buffer": "5.1.2",
-                "tough-cookie": "2.3.4",
-                "tunnel-agent": "0.6.0",
-                "uuid": "3.3.2"
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.6.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.5",
+                "extend": "~3.0.1",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.1",
+                "har-validator": "~5.0.3",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.17",
+                "oauth-sign": "~0.8.2",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.1",
+                "safe-buffer": "^5.1.1",
+                "tough-cookie": "~2.3.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.1.0"
             },
             "dependencies": {
                 "punycode": {
@@ -17494,7 +17512,7 @@
                     "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
                     "dev": true,
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": "^1.4.1"
                     }
                 }
             }
@@ -17506,10 +17524,10 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "extend": "3.0.2",
-                "lodash": "4.17.10",
-                "request": "2.87.0",
-                "when": "3.7.8"
+                "extend": "^3.0.0",
+                "lodash": "^4.15.0",
+                "request": "^2.74.0",
+                "when": "^3.7.7"
             }
         },
         "require-directory": {
@@ -17536,8 +17554,8 @@
             "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
             "dev": true,
             "requires": {
-                "caller-path": "0.1.0",
-                "resolve-from": "1.0.1"
+                "caller-path": "^0.1.0",
+                "resolve-from": "^1.0.0"
             },
             "dependencies": {
                 "resolve-from": {
@@ -17560,9 +17578,9 @@
             "integrity": "sha512-pssKfw0KhafnpOHA1+qWlDXcCEgf0p+qfTI8xOhqOhhdtz7m7VqhEorauKZOqv1GGA8ML3eKFU3sxGq5p4ZaEw==",
             "dev": true,
             "requires": {
-                "esprima": "4.0.1",
-                "fs-extra": "5.0.0",
-                "stringify-object": "3.2.2"
+                "esprima": "^4.0.0",
+                "fs-extra": "^5.0.0",
+                "stringify-object": "^3.2.1"
             }
         },
         "requires-port": {
@@ -17577,7 +17595,7 @@
             "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.6"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-bin": {
@@ -17586,7 +17604,7 @@
             "integrity": "sha1-RxMiSYkRAa+xmZH+k3ywpfBy5dk=",
             "dev": true,
             "requires": {
-                "find-parent-dir": "0.3.0"
+                "find-parent-dir": "~0.3.0"
             }
         },
         "resolve-cwd": {
@@ -17595,7 +17613,7 @@
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
             "dev": true,
             "requires": {
-                "resolve-from": "3.0.0"
+                "resolve-from": "^3.0.0"
             },
             "dependencies": {
                 "resolve-from": {
@@ -17618,8 +17636,8 @@
             "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "global-modules": "1.0.0"
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
             }
         },
         "resolve-from": {
@@ -17634,7 +17652,7 @@
             "integrity": "sha1-j7As/Vt9sgEY6IYxHxWvlb0V+9k=",
             "dev": true,
             "requires": {
-                "global-dirs": "0.1.1"
+                "global-dirs": "^0.1.0"
             }
         },
         "resolve-url": {
@@ -17649,15 +17667,15 @@
             "integrity": "sha512-RaEUWgF/B6aTg9VKaOv2o6dfm5f75/lGh8S+SQwoMcBm48WkA2nhLR+V7KEawkxXjU4lLB16IVeHCe7F69nyVw==",
             "dev": true,
             "requires": {
-                "adjust-sourcemap-loader": "1.2.0",
-                "camelcase": "4.1.0",
-                "convert-source-map": "1.5.1",
-                "loader-utils": "1.1.0",
-                "lodash.defaults": "4.2.0",
-                "rework": "1.0.1",
-                "rework-visit": "1.0.0",
-                "source-map": "0.5.7",
-                "urix": "0.1.0"
+                "adjust-sourcemap-loader": "^1.1.0",
+                "camelcase": "^4.1.0",
+                "convert-source-map": "^1.5.1",
+                "loader-utils": "^1.1.0",
+                "lodash.defaults": "^4.0.0",
+                "rework": "^1.0.1",
+                "rework-visit": "^1.0.0",
+                "source-map": "^0.5.7",
+                "urix": "^0.1.0"
             },
             "dependencies": {
                 "loader-utils": {
@@ -17666,9 +17684,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 },
                 "source-map": {
@@ -17685,8 +17703,8 @@
             "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
             "dev": true,
             "requires": {
-                "exit-hook": "1.1.1",
-                "onetime": "1.1.0"
+                "exit-hook": "^1.0.0",
+                "onetime": "^1.0.0"
             }
         },
         "ret": {
@@ -17701,8 +17719,8 @@
             "integrity": "sha1-MIBqhBNCtUUQqkEQhQzUhTQUSqc=",
             "dev": true,
             "requires": {
-                "convert-source-map": "0.3.5",
-                "css": "2.2.3"
+                "convert-source-map": "^0.3.3",
+                "css": "^2.0.0"
             },
             "dependencies": {
                 "convert-source-map": {
@@ -17725,7 +17743,7 @@
             "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
             "dev": true,
             "requires": {
-                "align-text": "0.1.4"
+                "align-text": "^0.1.1"
             }
         },
         "rimraf": {
@@ -17734,7 +17752,7 @@
             "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             }
         },
         "ripemd160": {
@@ -17743,8 +17761,8 @@
             "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
             "dev": true,
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "rollup": {
@@ -17759,7 +17777,7 @@
             "integrity": "sha512-lB094zdi19FS+1bVarVp9kBN0Zk41PdTGoCk0z8xesKO7RGjOo18cp1hUzEqrOQ4bM9+KLD9nbnu/XUxQm9pbg==",
             "dev": true,
             "requires": {
-                "slash": "1.0.0"
+                "slash": "^1.0.0"
             }
         },
         "rollup-plugin-node-resolve": {
@@ -17768,9 +17786,9 @@
             "integrity": "sha512-9zHGr3oUJq6G+X0oRMYlzid9fXicBdiydhwGChdyeNRGPcN/majtegApRKHLR5drboUvEWU+QeUmGTyEZQs3WA==",
             "dev": true,
             "requires": {
-                "builtin-modules": "2.0.0",
-                "is-module": "1.0.0",
-                "resolve": "1.8.1"
+                "builtin-modules": "^2.0.0",
+                "is-module": "^1.0.0",
+                "resolve": "^1.1.6"
             },
             "dependencies": {
                 "builtin-modules": {
@@ -17787,7 +17805,7 @@
             "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
             "dev": true,
             "requires": {
-                "is-promise": "2.1.0"
+                "is-promise": "^2.1.0"
             }
         },
         "run-queue": {
@@ -17796,7 +17814,7 @@
             "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
             "dev": true,
             "requires": {
-                "aproba": "1.2.0"
+                "aproba": "^1.1.1"
             }
         },
         "run-sequence": {
@@ -17805,9 +17823,9 @@
             "integrity": "sha512-qkzZnQWMZjcKbh3CNly2srtrkaO/2H/SI5f2eliMCapdRD3UhMrwjfOAZJAnZ2H8Ju4aBzFZkBGXUqFs9V0yxw==",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "fancy-log": "1.3.2",
-                "plugin-error": "0.1.2"
+                "chalk": "^1.1.3",
+                "fancy-log": "^1.3.2",
+                "plugin-error": "^0.1.2"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -17822,11 +17840,11 @@
                     "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "2.2.1",
-                        "escape-string-regexp": "1.0.5",
-                        "has-ansi": "2.0.0",
-                        "strip-ansi": "3.0.1",
-                        "supports-color": "2.0.0"
+                        "ansi-styles": "^2.2.1",
+                        "escape-string-regexp": "^1.0.2",
+                        "has-ansi": "^2.0.0",
+                        "strip-ansi": "^3.0.0",
+                        "supports-color": "^2.0.0"
                     }
                 },
                 "supports-color": {
@@ -17842,7 +17860,7 @@
             "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.0.0.tgz",
             "integrity": "sha512-2MgLQr1zvks8+Kip4T6hcJdiBhV+SIvxguoWjhwtSpNPTp/5e09HJbgclCwR/nW0yWzhubM+6Q0prl8G5RuoBA==",
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.9.0"
             }
         },
         "safe-buffer": {
@@ -17857,7 +17875,7 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
         },
         "safer-buffer": {
@@ -17872,10 +17890,10 @@
             "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
             "dev": true,
             "requires": {
-                "es6-promise": "3.3.1",
-                "graceful-fs": "4.1.11",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.2"
+                "es6-promise": "^3.1.2",
+                "graceful-fs": "^4.1.3",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.2"
             },
             "dependencies": {
                 "es6-promise": {
@@ -17892,10 +17910,10 @@
             "integrity": "sha1-E/vWPNHK8JCLn9k0dq1DpR0eC0k=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "lodash": "4.17.10",
-                "scss-tokenizer": "0.2.3",
-                "yargs": "7.1.0"
+                "glob": "^7.0.0",
+                "lodash": "^4.0.0",
+                "scss-tokenizer": "^0.2.3",
+                "yargs": "^7.0.0"
             },
             "dependencies": {
                 "camelcase": {
@@ -17910,9 +17928,9 @@
                     "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "dev": true,
                     "requires": {
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "find-up": {
@@ -17921,8 +17939,8 @@
                     "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
                     "dev": true,
                     "requires": {
-                        "path-exists": "2.1.0",
-                        "pinkie-promise": "2.0.1"
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "load-json-file": {
@@ -17931,11 +17949,11 @@
                     "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "parse-json": "2.2.0",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1",
-                        "strip-bom": "2.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "parse-json": "^2.2.0",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0",
+                        "strip-bom": "^2.0.0"
                     }
                 },
                 "parse-json": {
@@ -17944,7 +17962,7 @@
                     "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
                     "dev": true,
                     "requires": {
-                        "error-ex": "1.3.2"
+                        "error-ex": "^1.2.0"
                     }
                 },
                 "path-exists": {
@@ -17953,7 +17971,7 @@
                     "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
                     "dev": true,
                     "requires": {
-                        "pinkie-promise": "2.0.1"
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "path-type": {
@@ -17962,9 +17980,9 @@
                     "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "graceful-fs": "^4.1.2",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     }
                 },
                 "pify": {
@@ -17979,9 +17997,9 @@
                     "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
                     "dev": true,
                     "requires": {
-                        "load-json-file": "1.1.0",
-                        "normalize-package-data": "2.4.0",
-                        "path-type": "1.1.0"
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
                     }
                 },
                 "read-pkg-up": {
@@ -17990,8 +18008,8 @@
                     "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
                     "dev": true,
                     "requires": {
-                        "find-up": "1.1.2",
-                        "read-pkg": "1.1.0"
+                        "find-up": "^1.0.0",
+                        "read-pkg": "^1.0.0"
                     }
                 },
                 "strip-bom": {
@@ -18000,7 +18018,7 @@
                     "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
                     "dev": true,
                     "requires": {
-                        "is-utf8": "0.2.1"
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "yargs": {
@@ -18009,19 +18027,19 @@
                     "integrity": "sha1-a6MY6xaWFyf10oT46gA+jWFU0Mg=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0",
-                        "cliui": "3.2.0",
-                        "decamelize": "1.2.0",
-                        "get-caller-file": "1.0.3",
-                        "os-locale": "1.4.0",
-                        "read-pkg-up": "1.0.1",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "1.0.2",
-                        "which-module": "1.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "5.0.0"
+                        "camelcase": "^3.0.0",
+                        "cliui": "^3.2.0",
+                        "decamelize": "^1.1.1",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^1.4.0",
+                        "read-pkg-up": "^1.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^1.0.2",
+                        "which-module": "^1.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^5.0.0"
                     }
                 },
                 "yargs-parser": {
@@ -18030,7 +18048,7 @@
                     "integrity": "sha1-J17PDX/+Bcd+ZOfIbkzZS/DhIoo=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "3.0.0"
+                        "camelcase": "^3.0.0"
                     }
                 }
             }
@@ -18041,12 +18059,12 @@
             "integrity": "sha512-+G+BKGglmZM2GUSfT9TLuEp6tzehHPjAMoRRItOojWIqIGPloVCMhNIQuG639eJ+y033PaGTSjLaTHts8Kw79w==",
             "dev": true,
             "requires": {
-                "clone-deep": "2.0.2",
-                "loader-utils": "1.1.0",
-                "lodash.tail": "4.1.1",
-                "neo-async": "2.5.1",
-                "pify": "3.0.0",
-                "semver": "5.5.0"
+                "clone-deep": "^2.0.1",
+                "loader-utils": "^1.0.1",
+                "lodash.tail": "^4.1.1",
+                "neo-async": "^2.5.0",
+                "pify": "^3.0.0",
+                "semver": "^5.5.0"
             },
             "dependencies": {
                 "loader-utils": {
@@ -18055,9 +18073,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 }
             }
@@ -18068,7 +18086,7 @@
             "integrity": "sha512-DZEg7g605XNZX3rxQMkndPmlSzaGR3ld33Rvx3XPTxP8hXBPErmCTrL2CPItzjCJqvjgt9kXhxQrzkbdJZToaA==",
             "dev": true,
             "requires": {
-                "commander": "2.17.1"
+                "commander": "^2.16.0"
             }
         },
         "sauce-connect-launcher": {
@@ -18077,11 +18095,11 @@
             "integrity": "sha512-X2vfwulR6brUGiicXKxPm1GJ7dBEeP1II450Uv4bHGrcGOapZNgzJvn9aioea5IC5BPp/7qjKdE3xbbTBIVXMA==",
             "dev": true,
             "requires": {
-                "adm-zip": "0.4.11",
-                "async": "2.6.1",
-                "https-proxy-agent": "2.2.1",
-                "lodash": "4.17.10",
-                "rimraf": "2.6.2"
+                "adm-zip": "~0.4.3",
+                "async": "^2.1.2",
+                "https-proxy-agent": "^2.2.1",
+                "lodash": "^4.16.6",
+                "rimraf": "^2.5.4"
             },
             "dependencies": {
                 "async": {
@@ -18090,7 +18108,7 @@
                     "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.10"
+                        "lodash": "^4.17.10"
                     }
                 }
             }
@@ -18101,7 +18119,7 @@
             "integrity": "sha512-jlX3FGdWvYf4Q3LFfFWS1QvPg3IGCGWxIc8QBFdPTbpTJnt/v17FHXYVAn7C8sHf1yUXo2c7yIM0isDryfYtHQ==",
             "dev": true,
             "requires": {
-                "https-proxy-agent": "2.2.1"
+                "https-proxy-agent": "^2.2.1"
             }
         },
         "sax": {
@@ -18116,8 +18134,8 @@
             "integrity": "sha512-v/iwU6wvwGK8HbU9yi3/nhGzP0yGSuhQMzL6ySiec1FSrZZDkhm4noOSWzrNFo/jEc+SJY6jRTwuwbSXJPDUnQ==",
             "dev": true,
             "requires": {
-                "ajv": "6.5.2",
-                "ajv-keywords": "3.2.0"
+                "ajv": "^6.1.0",
+                "ajv-keywords": "^3.1.0"
             }
         },
         "script-ext-html-webpack-plugin": {
@@ -18126,7 +18144,7 @@
             "integrity": "sha512-kUH+XhpjG95ABMnWeKCguM7NCOqSrGlYEnJQKgvPIyq5+FzQuACMLzWOB/Lp7t0sKqKLWNLu8i6MmLRKRo1IUw==",
             "dev": true,
             "requires": {
-                "debug": "3.1.0"
+                "debug": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -18146,13 +18164,13 @@
             "integrity": "sha512-Mp12Wa/PbTBY5E6zlN4Vq8ccK4Ex4WX9dvc8QP3BXzatfo9VvQijZIAsMQ4nT+vD0oM1I4m6Cy9twJWYr9oBew==",
             "dev": true,
             "requires": {
-                "archy": "1.0.0",
-                "fs-extra": "5.0.0",
-                "globs": "0.1.4",
-                "node-sass": "4.9.2",
-                "pretty-bytes": "4.0.2",
-                "promise": "8.0.1",
-                "yargs": "11.1.0"
+                "archy": "^1.0.0",
+                "fs-extra": "^5.0.0",
+                "globs": "^0.1.3",
+                "node-sass": "^4.9.0",
+                "pretty-bytes": "^4.0.2",
+                "promise": "^8.0.1",
+                "yargs": "^11.0.0"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -18167,35 +18185,35 @@
                     "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "cross-spawn": {
                     "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/cross-spawn/-/cross-spawn-5.1.0.tgz",
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "4.1.3",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "execa": {
                     "version": "0.7.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/execa/-/execa-0.7.0.tgz",
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -18210,8 +18228,8 @@
                     "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 },
                 "os-locale": {
@@ -18220,9 +18238,9 @@
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "dev": true,
                     "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
                     }
                 },
                 "string-width": {
@@ -18231,17 +18249,17 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
                     "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "which-module": {
@@ -18256,18 +18274,18 @@
                     "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.1.0",
-                        "decamelize": "1.2.0",
-                        "find-up": "2.1.0",
-                        "get-caller-file": "1.0.3",
-                        "os-locale": "2.1.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "9.0.2"
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
                     }
                 },
                 "yargs-parser": {
@@ -18276,7 +18294,7 @@
                     "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0"
+                        "camelcase": "^4.1.0"
                     }
                 }
             }
@@ -18287,8 +18305,8 @@
             "integrity": "sha1-jrBtualyMzOCTT9VMGQRSYR85dE=",
             "dev": true,
             "requires": {
-                "js-base64": "2.4.8",
-                "source-map": "0.4.4"
+                "js-base64": "^2.1.8",
+                "source-map": "^0.4.2"
             },
             "dependencies": {
                 "source-map": {
@@ -18297,7 +18315,7 @@
                     "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
                     "dev": true,
                     "requires": {
-                        "amdefine": "1.0.1"
+                        "amdefine": ">=0.0.4"
                     }
                 }
             }
@@ -18335,7 +18353,7 @@
             "integrity": "sha1-E+jCZYq5aRywzXEJMkAoDTb3els=",
             "dev": true,
             "requires": {
-                "sver-compat": "1.5.0"
+                "sver-compat": "^1.5.0"
             }
         },
         "send": {
@@ -18345,18 +18363,18 @@
             "dev": true,
             "requires": {
                 "debug": "2.6.9",
-                "depd": "1.1.2",
-                "destroy": "1.0.4",
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "etag": "1.8.1",
+                "depd": "~1.1.2",
+                "destroy": "~1.0.4",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "etag": "~1.8.1",
                 "fresh": "0.5.2",
-                "http-errors": "1.6.3",
+                "http-errors": "~1.6.2",
                 "mime": "1.4.1",
                 "ms": "2.0.0",
-                "on-finished": "2.3.0",
-                "range-parser": "1.2.0",
-                "statuses": "1.4.0"
+                "on-finished": "~2.3.0",
+                "range-parser": "~1.2.0",
+                "statuses": "~1.4.0"
             },
             "dependencies": {
                 "mime": {
@@ -18379,8 +18397,8 @@
             "integrity": "sha1-H24t2jnBaL+S0T+G1KkYkz9mftQ=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2",
-                "upper-case-first": "1.1.2"
+                "no-case": "^2.2.0",
+                "upper-case-first": "^1.1.2"
             }
         },
         "sequencify": {
@@ -18401,13 +18419,13 @@
             "integrity": "sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=",
             "dev": true,
             "requires": {
-                "accepts": "1.3.5",
+                "accepts": "~1.3.4",
                 "batch": "0.6.1",
                 "debug": "2.6.9",
-                "escape-html": "1.0.3",
-                "http-errors": "1.6.3",
-                "mime-types": "2.1.19",
-                "parseurl": "1.3.2"
+                "escape-html": "~1.0.3",
+                "http-errors": "~1.6.2",
+                "mime-types": "~2.1.17",
+                "parseurl": "~1.3.2"
             }
         },
         "serve-static": {
@@ -18416,9 +18434,9 @@
             "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
             "dev": true,
             "requires": {
-                "encodeurl": "1.0.2",
-                "escape-html": "1.0.3",
-                "parseurl": "1.3.2",
+                "encodeurl": "~1.0.2",
+                "escape-html": "~1.0.3",
+                "parseurl": "~1.3.2",
                 "send": "0.16.2"
             }
         },
@@ -18440,10 +18458,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -18452,7 +18470,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -18475,8 +18493,8 @@
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.2"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "shallow-clone": {
@@ -18485,9 +18503,9 @@
             "integrity": "sha512-oeXreoKR/SyNJtRJMAKPDSvd28OqEwG4eR/xc856cRGBII7gX9lvAqDxusPm0846z/w/hWYjI1NpKwJ00NHzRA==",
             "dev": true,
             "requires": {
-                "is-extendable": "0.1.1",
-                "kind-of": "5.1.0",
-                "mixin-object": "2.0.1"
+                "is-extendable": "^0.1.1",
+                "kind-of": "^5.0.0",
+                "mixin-object": "^2.0.1"
             },
             "dependencies": {
                 "kind-of": {
@@ -18504,7 +18522,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -18519,9 +18537,9 @@
             "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "interpret": "1.1.0",
-                "rechoir": "0.6.2"
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
             }
         },
         "sigmund": {
@@ -18543,7 +18561,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "requestretry": "1.13.0"
+                "requestretry": "^1.2.2"
             }
         },
         "slash": {
@@ -18554,7 +18572,7 @@
         },
         "slice-ansi": {
             "version": "0.0.4",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/slice-ansi/-/slice-ansi-0.0.4.tgz",
             "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
             "dev": true
         },
@@ -18587,7 +18605,7 @@
             "integrity": "sha1-Qb2xtz8w7GagTU4srRt2OH1NbZ8=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2"
+                "no-case": "^2.2.0"
             }
         },
         "snapdragon": {
@@ -18596,14 +18614,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.2",
-                "use": "3.1.1"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -18612,7 +18630,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -18621,7 +18639,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "source-map": {
@@ -18638,9 +18656,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -18649,7 +18667,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -18658,7 +18676,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -18667,7 +18685,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -18676,9 +18694,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "isobject": {
@@ -18701,7 +18719,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             }
         },
         "sntp": {
@@ -18710,7 +18728,7 @@
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "socket.io": {
@@ -18719,11 +18737,11 @@
             "integrity": "sha1-waRZDO/4fs8TxyZS8Eb3FrKeYBQ=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "engine.io": "3.1.5",
-                "socket.io-adapter": "1.1.1",
+                "debug": "~2.6.6",
+                "engine.io": "~3.1.0",
+                "socket.io-adapter": "~1.1.0",
                 "socket.io-client": "2.0.4",
-                "socket.io-parser": "3.1.3"
+                "socket.io-parser": "~3.1.1"
             }
         },
         "socket.io-adapter": {
@@ -18742,14 +18760,14 @@
                 "base64-arraybuffer": "0.1.5",
                 "component-bind": "1.0.0",
                 "component-emitter": "1.2.1",
-                "debug": "2.6.9",
-                "engine.io-client": "3.1.6",
+                "debug": "~2.6.4",
+                "engine.io-client": "~3.1.0",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
                 "object-component": "0.0.3",
                 "parseqs": "0.0.5",
                 "parseuri": "0.0.5",
-                "socket.io-parser": "3.1.3",
+                "socket.io-parser": "~3.1.1",
                 "to-array": "0.1.4"
             }
         },
@@ -18760,8 +18778,8 @@
             "dev": true,
             "requires": {
                 "component-emitter": "1.2.1",
-                "debug": "3.1.0",
-                "has-binary2": "1.0.3",
+                "debug": "~3.1.0",
+                "has-binary2": "~1.0.2",
                 "isarray": "2.0.1"
             },
             "dependencies": {
@@ -18788,8 +18806,8 @@
             "integrity": "sha512-V48klKZl8T6MzatbLlzzRNhMepEys9Y4oGFpypBFFn1gLI/QQ9HtLLyWJNbPlwGLelOVOEijUbTTJeLLI59jLw==",
             "dev": true,
             "requires": {
-                "faye-websocket": "0.10.0",
-                "uuid": "3.3.2"
+                "faye-websocket": "^0.10.0",
+                "uuid": "^3.0.1"
             }
         },
         "sockjs-client": {
@@ -18798,12 +18816,12 @@
             "integrity": "sha1-G7fA9yIsQPQq3xT0RCy9Eml3GoM=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
+                "debug": "^2.6.6",
                 "eventsource": "0.1.6",
-                "faye-websocket": "0.11.1",
-                "inherits": "2.0.3",
-                "json3": "3.3.2",
-                "url-parse": "1.4.3"
+                "faye-websocket": "~0.11.0",
+                "inherits": "^2.0.1",
+                "json3": "^3.3.2",
+                "url-parse": "^1.1.8"
             },
             "dependencies": {
                 "faye-websocket": {
@@ -18812,7 +18830,7 @@
                     "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
                     "dev": true,
                     "requires": {
-                        "websocket-driver": "0.7.0"
+                        "websocket-driver": ">=0.5.1"
                     }
                 }
             }
@@ -18824,8 +18842,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "ip": "1.1.5",
-                "smart-buffer": "1.1.15"
+                "ip": "^1.1.4",
+                "smart-buffer": "^1.0.13"
             }
         },
         "socks-proxy-agent": {
@@ -18835,8 +18853,8 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "agent-base": "4.2.1",
-                "socks": "2.2.1"
+                "agent-base": "~4.2.0",
+                "socks": "~2.2.0"
             },
             "dependencies": {
                 "smart-buffer": {
@@ -18853,8 +18871,8 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "ip": "1.1.5",
-                        "smart-buffer": "4.0.1"
+                        "ip": "^1.1.5",
+                        "smart-buffer": "^4.0.1"
                     }
                 }
             }
@@ -18865,10 +18883,10 @@
             "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "minimist": "1.2.0",
-                "sander": "0.5.1",
-                "sourcemap-codec": "1.4.1"
+                "buffer-crc32": "^0.2.5",
+                "minimist": "^1.2.0",
+                "sander": "^0.5.0",
+                "sourcemap-codec": "^1.3.0"
             }
         },
         "source-list-map": {
@@ -18889,11 +18907,11 @@
             "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "2.1.1",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-support": {
@@ -18902,8 +18920,8 @@
             "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.1.1",
-                "source-map": "0.6.1"
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
             }
         },
         "source-map-url": {
@@ -18930,8 +18948,8 @@
             "integrity": "sha512-WQbfCQT2uKLsDllnO9ItpcGUiiF1O/ZvBGCyqFZRg122HgiZubpwpZiM7BkmH19HC3XR3Z+DFMGJNzXSPebG8A==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "1.0.5",
-                "spdx-license-ids": "1.2.2"
+                "spdx-exceptions": "^1.0.0",
+                "spdx-license-ids": "^1.0.0"
             },
             "dependencies": {
                 "spdx-exceptions": {
@@ -18954,8 +18972,8 @@
             "integrity": "sha1-sGrz6jSvdDfZGp9Enq8tLpPDyPs=",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "1.0.4",
-                "spdx-ranges": "1.0.1"
+                "spdx-expression-parse": "^1.0.0",
+                "spdx-ranges": "^1.0.0"
             },
             "dependencies": {
                 "spdx-expression-parse": {
@@ -18972,8 +18990,8 @@
             "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
             "dev": true,
             "requires": {
-                "spdx-expression-parse": "3.0.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-expression-parse": "^3.0.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-exceptions": {
@@ -18988,8 +19006,8 @@
             "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
             "dev": true,
             "requires": {
-                "spdx-exceptions": "2.1.0",
-                "spdx-license-ids": "3.0.0"
+                "spdx-exceptions": "^2.1.0",
+                "spdx-license-ids": "^3.0.0"
             }
         },
         "spdx-license-ids": {
@@ -19016,8 +19034,8 @@
             "integrity": "sha1-Z6HydOYRXUquKK/kdNt2FkvhC9w=",
             "dev": true,
             "requires": {
-                "spdx-compare": "0.1.2",
-                "spdx-expression-parse": "1.0.4"
+                "spdx-compare": "^0.1.2",
+                "spdx-expression-parse": "^1.0.0"
             },
             "dependencies": {
                 "spdx-expression-parse": {
@@ -19034,12 +19052,12 @@
             "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "handle-thing": "1.2.5",
-                "http-deceiver": "1.2.7",
-                "safe-buffer": "5.1.2",
-                "select-hose": "2.0.0",
-                "spdy-transport": "2.1.0"
+                "debug": "^2.6.8",
+                "handle-thing": "^1.2.5",
+                "http-deceiver": "^1.2.7",
+                "safe-buffer": "^5.0.1",
+                "select-hose": "^2.0.0",
+                "spdy-transport": "^2.0.18"
             }
         },
         "spdy-transport": {
@@ -19048,13 +19066,13 @@
             "integrity": "sha512-bpUeGpZcmZ692rrTiqf9/2EUakI6/kXX1Rpe0ib/DyOzbiexVfXkw6GnvI9hVGvIwVaUhkaBojjCZwLNRGQg1g==",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "detect-node": "2.0.3",
-                "hpack.js": "2.1.6",
-                "obuf": "1.1.2",
-                "readable-stream": "2.3.6",
-                "safe-buffer": "5.1.2",
-                "wbuf": "1.7.3"
+                "debug": "^2.6.8",
+                "detect-node": "^2.0.3",
+                "hpack.js": "^2.1.6",
+                "obuf": "^1.1.1",
+                "readable-stream": "^2.2.9",
+                "safe-buffer": "^5.0.1",
+                "wbuf": "^1.7.2"
             }
         },
         "specificity": {
@@ -19069,7 +19087,7 @@
             "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "split-string": {
@@ -19078,7 +19096,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "split2": {
@@ -19087,7 +19105,7 @@
             "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
             "dev": true,
             "requires": {
-                "through2": "2.0.3"
+                "through2": "^2.0.2"
             }
         },
         "sprintf-js": {
@@ -19102,15 +19120,15 @@
             "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
             "dev": true,
             "requires": {
-                "asn1": "0.2.4",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.2",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.2",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "safer-buffer": "2.1.2",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "safer-buffer": "^2.0.2",
+                "tweetnacl": "~0.14.0"
             }
         },
         "ssri": {
@@ -19119,7 +19137,7 @@
             "integrity": "sha512-XRSIPqLij52MtgoQavH/x/dU1qVKtWUAAZeOHsR9c2Ddi4XerFy3mc1alf+dLJKl9EUIm/Ht+EowFkTUOA6GAQ==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.1.1"
             }
         },
         "stack-trace": {
@@ -19146,8 +19164,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -19156,7 +19174,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -19173,7 +19191,7 @@
             "integrity": "sha1-osfIWH5U2UJ+qe2zrD8s1SLfN4s=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.1"
             }
         },
         "stream-browserify": {
@@ -19182,8 +19200,8 @@
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "stream-consume": {
@@ -19198,8 +19216,8 @@
             "integrity": "sha512-vlMC2f8I2u/bZGqkdfLQW/13Zihpej/7PmSiMQsbYddxuTsJp8vRe2x2FvVExZg7FaOds43ROAuFJwPR4MTZLw==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.1.0",
+                "stream-shift": "^1.0.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -19208,7 +19226,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 }
             }
@@ -19219,11 +19237,11 @@
             "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "3.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "to-arraybuffer": "1.0.1",
-                "xtend": "4.0.1"
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.3.6",
+                "to-arraybuffer": "^1.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "stream-shift": {
@@ -19238,10 +19256,10 @@
             "integrity": "sha512-WREzfy0r0zUqp3lGO096wRuUp7ho1X6uo/7DJfTlEi0Iv/4gT7YHqXDjKC2ioVGBZtE8QzsQD9nx1nIuoZ57jQ==",
             "dev": true,
             "requires": {
-                "date-format": "1.2.0",
-                "debug": "3.1.0",
-                "mkdirp": "0.5.1",
-                "readable-stream": "2.3.6"
+                "date-format": "^1.2.0",
+                "debug": "^3.1.0",
+                "mkdirp": "^0.5.1",
+                "readable-stream": "^2.3.0"
             },
             "dependencies": {
                 "debug": {
@@ -19267,9 +19285,9 @@
             "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
             "dev": true,
             "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
             }
         },
         "string_decoder": {
@@ -19278,7 +19296,7 @@
             "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringify-entities": {
@@ -19287,10 +19305,10 @@
             "integrity": "sha512-nrBAQClJAPN2p+uGCVJRPIPakKeKWZ9GtBCmormE7pWOSlHat7+x5A8gx85M7HM5Dt0BP3pP5RhVW77WdbJJ3A==",
             "dev": true,
             "requires": {
-                "character-entities-html4": "1.1.2",
-                "character-entities-legacy": "1.1.2",
-                "is-alphanumerical": "1.0.2",
-                "is-hexadecimal": "1.0.2"
+                "character-entities-html4": "^1.0.0",
+                "character-entities-legacy": "^1.0.0",
+                "is-alphanumerical": "^1.0.0",
+                "is-hexadecimal": "^1.0.0"
             }
         },
         "stringify-object": {
@@ -19299,9 +19317,9 @@
             "integrity": "sha512-O696NF21oLiDy8PhpWu8AEqoZHw++QW6mUv0UvKZe8gWSdSvMXkiLufK7OmnP27Dro4GU5kb9U7JIO0mBuCRQg==",
             "dev": true,
             "requires": {
-                "get-own-enumerable-property-symbols": "2.0.1",
-                "is-obj": "1.0.1",
-                "is-regexp": "1.0.0"
+                "get-own-enumerable-property-symbols": "^2.0.1",
+                "is-obj": "^1.0.1",
+                "is-regexp": "^1.0.0"
             }
         },
         "stringmap": {
@@ -19322,7 +19340,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -19355,8 +19373,8 @@
             "integrity": "sha512-WXUrLeinPIR1Oat3PfCDro7qTniwNTJqGqv1KcQiL3JR5PzrVLTyNsd9wTsPXG/qNCJ7lzR2NY/QDjFsP7nuSQ==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "schema-utils": "0.4.7"
+                "loader-utils": "^1.1.0",
+                "schema-utils": "^0.4.5"
             },
             "dependencies": {
                 "loader-utils": {
@@ -19365,9 +19383,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 }
             }
@@ -19384,50 +19402,50 @@
             "integrity": "sha512-pcw0Dpb4Ib/OfgONhaeF+myA+5iZdsI8dYgWs1++IYN/dgvo90O0FhgMDKb1bMgZVy/A2Q1CCN/PFZ0FLnnRnQ==",
             "dev": true,
             "requires": {
-                "autoprefixer": "9.1.0",
-                "balanced-match": "1.0.0",
-                "chalk": "2.4.1",
-                "cosmiconfig": "5.0.5",
-                "debug": "3.1.0",
-                "execall": "1.0.0",
-                "file-entry-cache": "2.0.0",
-                "get-stdin": "6.0.0",
-                "globby": "8.0.1",
-                "globjoin": "0.1.4",
-                "html-tags": "2.0.0",
-                "ignore": "4.0.3",
-                "import-lazy": "3.1.0",
-                "imurmurhash": "0.1.4",
-                "known-css-properties": "0.6.1",
-                "lodash": "4.17.10",
-                "log-symbols": "2.2.0",
-                "mathml-tag-names": "2.1.0",
-                "meow": "5.0.0",
-                "micromatch": "2.3.11",
-                "normalize-selector": "0.2.0",
-                "pify": "3.0.0",
-                "postcss": "7.0.2",
-                "postcss-html": "0.31.0",
-                "postcss-less": "2.0.0",
-                "postcss-markdown": "0.31.0",
-                "postcss-media-query-parser": "0.2.3",
-                "postcss-reporter": "5.0.0",
-                "postcss-resolve-nested-selector": "0.1.1",
-                "postcss-safe-parser": "4.0.1",
-                "postcss-sass": "0.3.2",
-                "postcss-scss": "2.0.0",
-                "postcss-selector-parser": "3.1.1",
-                "postcss-styled": "0.31.0",
-                "postcss-syntax": "0.31.0",
-                "postcss-value-parser": "3.3.0",
-                "resolve-from": "4.0.0",
-                "signal-exit": "3.0.2",
-                "specificity": "0.4.0",
-                "string-width": "2.1.1",
-                "style-search": "0.1.0",
-                "sugarss": "1.0.1",
-                "svg-tags": "1.0.0",
-                "table": "4.0.3"
+                "autoprefixer": "^9.0.0",
+                "balanced-match": "^1.0.0",
+                "chalk": "^2.4.1",
+                "cosmiconfig": "^5.0.0",
+                "debug": "^3.0.0",
+                "execall": "^1.0.0",
+                "file-entry-cache": "^2.0.0",
+                "get-stdin": "^6.0.0",
+                "globby": "^8.0.0",
+                "globjoin": "^0.1.4",
+                "html-tags": "^2.0.0",
+                "ignore": "^4.0.0",
+                "import-lazy": "^3.1.0",
+                "imurmurhash": "^0.1.4",
+                "known-css-properties": "^0.6.0",
+                "lodash": "^4.17.4",
+                "log-symbols": "^2.0.0",
+                "mathml-tag-names": "^2.0.1",
+                "meow": "^5.0.0",
+                "micromatch": "^2.3.11",
+                "normalize-selector": "^0.2.0",
+                "pify": "^3.0.0",
+                "postcss": "^7.0.0",
+                "postcss-html": "^0.31.0",
+                "postcss-less": "^2.0.0",
+                "postcss-markdown": "^0.31.0",
+                "postcss-media-query-parser": "^0.2.3",
+                "postcss-reporter": "^5.0.0",
+                "postcss-resolve-nested-selector": "^0.1.1",
+                "postcss-safe-parser": "^4.0.0",
+                "postcss-sass": "^0.3.0",
+                "postcss-scss": "^2.0.0",
+                "postcss-selector-parser": "^3.1.0",
+                "postcss-styled": "^0.31.0",
+                "postcss-syntax": "^0.31.0",
+                "postcss-value-parser": "^3.3.0",
+                "resolve-from": "^4.0.0",
+                "signal-exit": "^3.0.2",
+                "specificity": "^0.4.0",
+                "string-width": "^2.1.0",
+                "style-search": "^0.1.0",
+                "sugarss": "^1.0.0",
+                "svg-tags": "^1.0.0",
+                "table": "^4.0.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -19442,12 +19460,12 @@
                     "integrity": "sha512-BbAIdxNdptG/x4DiGGfpkDVYyqu4nUyNdBB0Utr49Gn3+0RERV1MdHik2FSbbWwhMAuk1KrfVJHe7nEMheGdBA==",
                     "dev": true,
                     "requires": {
-                        "browserslist": "4.0.1",
-                        "caniuse-lite": "1.0.30000874",
-                        "normalize-range": "0.1.2",
-                        "num2fraction": "1.2.2",
-                        "postcss": "7.0.2",
-                        "postcss-value-parser": "3.3.0"
+                        "browserslist": "^4.0.1",
+                        "caniuse-lite": "^1.0.30000872",
+                        "normalize-range": "^0.1.2",
+                        "num2fraction": "^1.2.2",
+                        "postcss": "^7.0.2",
+                        "postcss-value-parser": "^3.2.3"
                     }
                 },
                 "browserslist": {
@@ -19456,9 +19474,9 @@
                     "integrity": "sha512-QqiiIWchEIkney3wY53/huI7ZErouNAdvOkjorUALAwRcu3tEwOV3Sh6He0DnP38mz1JjBpCBb50jQBmaYuHPw==",
                     "dev": true,
                     "requires": {
-                        "caniuse-lite": "1.0.30000874",
-                        "electron-to-chromium": "1.3.55",
-                        "node-releases": "1.0.0-alpha.10"
+                        "caniuse-lite": "^1.0.30000865",
+                        "electron-to-chromium": "^1.3.52",
+                        "node-releases": "^1.0.0-alpha.10"
                     }
                 },
                 "cosmiconfig": {
@@ -19467,9 +19485,9 @@
                     "integrity": "sha512-94j37OtvxS5w7qr7Ta6dt67tWdnOxigBVN4VnSxNXFez9o18PGQ0D33SchKP17r9LAcWVTYV72G6vDayAUBFIg==",
                     "dev": true,
                     "requires": {
-                        "is-directory": "0.3.1",
-                        "js-yaml": "3.12.0",
-                        "parse-json": "4.0.0"
+                        "is-directory": "^0.3.1",
+                        "js-yaml": "^3.9.0",
+                        "parse-json": "^4.0.0"
                     }
                 },
                 "debug": {
@@ -19487,7 +19505,7 @@
                     "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
                     "dev": true,
                     "requires": {
-                        "is-obj": "1.0.1"
+                        "is-obj": "^1.0.0"
                     }
                 },
                 "get-stdin": {
@@ -19514,9 +19532,9 @@
                     "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.1",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.4.0"
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
                     }
                 },
                 "postcss-selector-parser": {
@@ -19525,9 +19543,9 @@
                     "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
                     "dev": true,
                     "requires": {
-                        "dot-prop": "4.2.0",
-                        "indexes-of": "1.0.1",
-                        "uniq": "1.0.1"
+                        "dot-prop": "^4.1.1",
+                        "indexes-of": "^1.0.1",
+                        "uniq": "^1.0.1"
                     }
                 },
                 "string-width": {
@@ -19536,8 +19554,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -19546,7 +19564,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -19563,7 +19581,7 @@
             "integrity": "sha512-07x0TaSIzvXlbOioUU4ORkCIM07kyIuojkbSVCyFWNVgXMXYHfhnQSCkqu+oHWJf3YADAnPGWzdJ53NxkoJ7RA==",
             "dev": true,
             "requires": {
-                "stylelint-config-recommended": "2.1.0"
+                "stylelint-config-recommended": "^2.1.0"
             }
         },
         "stylelint-scss": {
@@ -19572,11 +19590,11 @@
             "integrity": "sha512-SWT+73lzpWYtUF6HHKBSsAkGP9kQWFnjAyXbUjuUGLMUTaWQ4Lpf8cEYSJcnh1qCqlFA7AQyle8bZwZaZiFyAQ==",
             "dev": true,
             "requires": {
-                "lodash": "4.17.10",
-                "postcss-media-query-parser": "0.2.3",
-                "postcss-resolve-nested-selector": "0.1.1",
-                "postcss-selector-parser": "4.0.0",
-                "postcss-value-parser": "3.3.0"
+                "lodash": "^4.17.10",
+                "postcss-media-query-parser": "^0.2.3",
+                "postcss-resolve-nested-selector": "^0.1.1",
+                "postcss-selector-parser": "^4.0.0",
+                "postcss-value-parser": "^3.3.0"
             },
             "dependencies": {
                 "cssesc": {
@@ -19591,9 +19609,9 @@
                     "integrity": "sha512-5h+MvEjnzu1qy6MabjuoPatsGAjjDV9B24e7Cktjl+ClNtjVjmvAXjOFQr1u7RlWULKNGYaYVE4s+DIIQ4bOGA==",
                     "dev": true,
                     "requires": {
-                        "cssesc": "1.0.1",
-                        "indexes-of": "1.0.1",
-                        "uniq": "1.0.1"
+                        "cssesc": "^1.0.1",
+                        "indexes-of": "^1.0.1",
+                        "uniq": "^1.0.1"
                     }
                 }
             }
@@ -19604,8 +19622,8 @@
             "integrity": "sha512-ZPwVUITlzCIgq1NBNl1xVX1grfFnJUBq9zzG9YOj/V3GrOCnpWuxGh6zUL8JTaVs0nMS9Eyok1qgOW9mUFx9kg==",
             "dev": true,
             "requires": {
-                "commander": "2.17.1",
-                "debug": "3.1.0"
+                "commander": "^2.8.1",
+                "debug": "^3.1.0"
             },
             "dependencies": {
                 "debug": {
@@ -19625,7 +19643,7 @@
             "integrity": "sha512-3qgLZytikQQEVn1/FrhY7B68gPUUGY3R1Q1vTiD5xT+Ti1DP/8iZuwFet9ONs5+bmL8pZoDQ6JrQHVgrNlK6mA==",
             "dev": true,
             "requires": {
-                "postcss": "6.0.23"
+                "postcss": "^6.0.14"
             },
             "dependencies": {
                 "postcss": {
@@ -19634,9 +19652,9 @@
                     "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
                     "dev": true,
                     "requires": {
-                        "chalk": "2.4.1",
-                        "source-map": "0.6.1",
-                        "supports-color": "5.4.0"
+                        "chalk": "^2.4.1",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^5.4.0"
                     }
                 }
             }
@@ -19647,7 +19665,7 @@
             "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
             "dev": true,
             "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
             }
         },
         "sver-compat": {
@@ -19656,8 +19674,8 @@
             "integrity": "sha1-PPh9/rTQe0o/FIJ7wYaz/QxkXNg=",
             "dev": true,
             "requires": {
-                "es6-iterator": "2.0.3",
-                "es6-symbol": "3.1.1"
+                "es6-iterator": "^2.0.1",
+                "es6-symbol": "^3.1.1"
             }
         },
         "svg-tags": {
@@ -19672,8 +19690,8 @@
             "integrity": "sha1-w5IDpFhzhfrTyFCgvRvK+ggZdOM=",
             "dev": true,
             "requires": {
-                "lower-case": "1.1.4",
-                "upper-case": "1.1.3"
+                "lower-case": "^1.1.1",
+                "upper-case": "^1.1.1"
             }
         },
         "symbol-observable": {
@@ -19693,7 +19711,7 @@
             "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.19.43.tgz",
             "integrity": "sha1-mQLOW9qroDQTV1kCxrsYutLdq44=",
             "requires": {
-                "when": "3.7.8"
+                "when": "^3.7.5"
             }
         },
         "table": {
@@ -19702,12 +19720,12 @@
             "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
             "dev": true,
             "requires": {
-                "ajv": "6.5.2",
-                "ajv-keywords": "3.2.0",
-                "chalk": "2.4.1",
-                "lodash": "4.17.10",
+                "ajv": "^6.0.1",
+                "ajv-keywords": "^3.0.0",
+                "chalk": "^2.1.0",
+                "lodash": "^4.17.4",
                 "slice-ansi": "1.0.0",
-                "string-width": "2.1.1"
+                "string-width": "^2.1.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -19728,7 +19746,7 @@
                     "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0"
+                        "is-fullwidth-code-point": "^2.0.0"
                     }
                 },
                 "string-width": {
@@ -19737,8 +19755,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -19747,7 +19765,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 }
             }
@@ -19764,9 +19782,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "tar-stream": {
@@ -19775,13 +19793,13 @@
             "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
             "dev": true,
             "requires": {
-                "bl": "1.1.2",
-                "buffer-alloc": "1.2.0",
-                "end-of-stream": "1.4.1",
-                "fs-constants": "1.0.0",
-                "readable-stream": "2.3.6",
-                "to-buffer": "1.1.1",
-                "xtend": "4.0.1"
+                "bl": "^1.0.0",
+                "buffer-alloc": "^1.1.0",
+                "end-of-stream": "^1.0.0",
+                "fs-constants": "^1.0.0",
+                "readable-stream": "^2.3.0",
+                "to-buffer": "^1.1.0",
+                "xtend": "^4.0.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -19790,7 +19808,7 @@
                     "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
                     "dev": true,
                     "requires": {
-                        "once": "1.4.0"
+                        "once": "^1.4.0"
                     }
                 }
             }
@@ -19807,10 +19825,10 @@
             "integrity": "sha1-Bk5Im0tb9gumpre8fy9cJ07Pgmk=",
             "dev": true,
             "requires": {
-                "duplexify": "3.6.0",
-                "fork-stream": "0.0.4",
-                "merge-stream": "1.0.1",
-                "through2": "2.0.3"
+                "duplexify": "^3.5.0",
+                "fork-stream": "^0.0.4",
+                "merge-stream": "^1.0.0",
+                "through2": "^2.0.1"
             }
         },
         "text-extensions": {
@@ -19831,8 +19849,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "thunkify": {
@@ -19854,7 +19872,7 @@
             "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.0"
             }
         },
         "time-stamp": {
@@ -19869,7 +19887,7 @@
             "integrity": "sha512-YvC1SV1XdOUaL6gx5CoGroT3Gu49pK9+TZ38ErPldOWW4j49GI1HKs9DV+KGq/w6y+LZ72W1c8cKz2vzY+qpzg==",
             "dev": true,
             "requires": {
-                "setimmediate": "1.0.5"
+                "setimmediate": "^1.0.4"
             }
         },
         "timespan": {
@@ -19885,8 +19903,8 @@
             "integrity": "sha1-PhJyFtpY0rxb7PE3q5Ha46fNj6o=",
             "dev": true,
             "requires": {
-                "no-case": "2.3.2",
-                "upper-case": "1.1.3"
+                "no-case": "^2.2.0",
+                "upper-case": "^1.0.3"
             }
         },
         "tmp": {
@@ -19895,7 +19913,7 @@
             "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2"
+                "os-tmpdir": "~1.0.2"
             }
         },
         "to-array": {
@@ -19922,7 +19940,7 @@
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "to-regex": {
@@ -19931,10 +19949,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -19943,8 +19961,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             },
             "dependencies": {
                 "is-number": {
@@ -19953,7 +19971,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     }
                 }
             }
@@ -19970,8 +19988,8 @@
             "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
             "dev": true,
             "requires": {
-                "psl": "1.1.29",
-                "punycode": "1.4.1"
+                "psl": "^1.1.24",
+                "punycode": "^1.4.1"
             },
             "dependencies": {
                 "punycode": {
@@ -20042,7 +20060,7 @@
             "integrity": "sha1-fskRMJJHZsf1c74wIMNPj9/QDWI=",
             "dev": true,
             "requires": {
-                "glob": "6.0.4"
+                "glob": "^6.0.4"
             },
             "dependencies": {
                 "glob": {
@@ -20051,11 +20069,11 @@
                     "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 }
             }
@@ -20072,16 +20090,16 @@
             "integrity": "sha512-xcZH12oVg9PShKhy3UHyDmuDLV3y7iKwX25aMVPt1SIXSuAfWkFiGPEkg+th8R4YKW/QCxDoW7lJdb15lx6QWg==",
             "dev": true,
             "requires": {
-                "arrify": "1.0.1",
-                "chalk": "2.4.1",
-                "diff": "3.5.0",
-                "make-error": "1.3.4",
-                "minimist": "1.2.0",
-                "mkdirp": "0.5.1",
-                "source-map-support": "0.5.6",
-                "tsconfig": "7.0.0",
-                "v8flags": "3.1.1",
-                "yn": "2.0.0"
+                "arrify": "^1.0.0",
+                "chalk": "^2.3.0",
+                "diff": "^3.1.0",
+                "make-error": "^1.1.1",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map-support": "^0.5.0",
+                "tsconfig": "^7.0.0",
+                "v8flags": "^3.0.0",
+                "yn": "^2.0.0"
             },
             "dependencies": {
                 "v8flags": {
@@ -20090,7 +20108,7 @@
                     "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
                     "dev": true,
                     "requires": {
-                        "homedir-polyfill": "1.0.1"
+                        "homedir-polyfill": "^1.0.1"
                     }
                 }
             }
@@ -20101,10 +20119,10 @@
             "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
             "dev": true,
             "requires": {
-                "@types/strip-bom": "3.0.0",
+                "@types/strip-bom": "^3.0.0",
                 "@types/strip-json-comments": "0.0.30",
-                "strip-bom": "3.0.0",
-                "strip-json-comments": "2.0.1"
+                "strip-bom": "^3.0.0",
+                "strip-json-comments": "^2.0.0"
             }
         },
         "tsconfig-paths": {
@@ -20113,11 +20131,11 @@
             "integrity": "sha512-JYbN2zK2mxsv+bDVJCvSTxmdrD4R1qkG908SsqqD8TWjPNbSOtko1mnpQFFJo5Rbbc2/oJgDU9Cpkg/ZD7wNYg==",
             "dev": true,
             "requires": {
-                "@types/json5": "0.0.29",
-                "deepmerge": "2.1.1",
-                "json5": "1.0.1",
-                "minimist": "1.2.0",
-                "strip-bom": "3.0.0"
+                "@types/json5": "^0.0.29",
+                "deepmerge": "^2.0.1",
+                "json5": "^1.0.1",
+                "minimist": "^1.2.0",
+                "strip-bom": "^3.0.0"
             },
             "dependencies": {
                 "json5": {
@@ -20126,7 +20144,7 @@
                     "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
                     "dev": true,
                     "requires": {
-                        "minimist": "1.2.0"
+                        "minimist": "^1.2.0"
                     }
                 }
             }
@@ -20137,9 +20155,9 @@
             "integrity": "sha512-S/gOOPOkV8rIL4LurZ1vUdYCVgo15iX9ZMJ6wx6w2OgcpT/G4wMyHB6WM+xheSqGMrWKuxFul+aXpCju3wmj/g==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "enhanced-resolve": "4.1.0",
-                "tsconfig-paths": "3.5.0"
+                "chalk": "^2.3.0",
+                "enhanced-resolve": "^4.0.0",
+                "tsconfig-paths": "^3.4.0"
             }
         },
         "tsickle": {
@@ -20148,10 +20166,10 @@
             "integrity": "sha512-NP+CjM1EXza/M8mOXBLH3vkFEJiu1zfEAlC5WdJxHPn8l96QPz5eooP6uAgYtw1CcKfuSyIiheNUdKxtDWCNeg==",
             "dev": true,
             "requires": {
-                "minimist": "1.2.0",
-                "mkdirp": "0.5.1",
-                "source-map": "0.6.1",
-                "source-map-support": "0.5.6"
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "source-map": "^0.6.0",
+                "source-map-support": "^0.5.0"
             }
         },
         "tslib": {
@@ -20161,22 +20179,22 @@
         },
         "tslint": {
             "version": "5.11.0",
-            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/tslint/-/tslint-5.11.0.tgz",
             "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "builtin-modules": "1.1.1",
-                "chalk": "2.4.1",
-                "commander": "2.17.1",
-                "diff": "3.5.0",
-                "glob": "7.1.2",
-                "js-yaml": "3.12.0",
-                "minimatch": "3.0.4",
-                "resolve": "1.8.1",
-                "semver": "5.5.0",
-                "tslib": "1.9.3",
-                "tsutils": "2.29.0"
+                "babel-code-frame": "^6.22.0",
+                "builtin-modules": "^1.1.1",
+                "chalk": "^2.3.0",
+                "commander": "^2.12.1",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "js-yaml": "^3.7.0",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.8.0",
+                "tsutils": "^2.27.2"
             }
         },
         "tslint-eslint-rules": {
@@ -20198,13 +20216,22 @@
                 },
                 "tsutils": {
                     "version": "2.8.0",
-                    "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.0.tgz",
+                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/tsutils/-/tsutils-2.8.0.tgz",
                     "integrity": "sha1-AWAXNymzvxOGKN0UoVN+AIUdgUo=",
                     "dev": true,
                     "requires": {
-                        "tslib": "1.9.0"
+                        "tslib": "^1.7.1"
                     }
                 }
+            }
+        },
+        "tslint-language-service": {
+            "version": "0.9.9",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/tslint-language-service/-/tslint-language-service-0.9.9.tgz",
+            "integrity": "sha1-9UbcOEg5eeb7PPpZWErYUls61No=",
+            "dev": true,
+            "requires": {
+                "mock-require": "^2.0.2"
             }
         },
         "tslint-microsoft-contrib": {
@@ -20213,7 +20240,7 @@
             "integrity": "sha512-gHVEIkTcMB9lS6UPEgEznV5ZmyhDs/aHyBS9E89S8aJiK1qLv22DmfCcda53S024T+WQkGAhLHUQF4Qn4nzCAA==",
             "dev": true,
             "requires": {
-                "tsutils": "2.28.0"
+                "tsutils": "^2.12.1 <2.29.0"
             },
             "dependencies": {
                 "tsutils": {
@@ -20222,7 +20249,7 @@
                     "integrity": "sha512-bh5nAtW0tuhvOJnx1GLRn5ScraRLICGyJV5wJhtRWOLsxW70Kk5tZtpK3O/hW6LDnqKS9mlUMPZj9fEMJ0gxqA==",
                     "dev": true,
                     "requires": {
-                        "tslib": "1.9.3"
+                        "tslib": "^1.8.1"
                     }
                 }
             }
@@ -20240,7 +20267,7 @@
             "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
             "dev": true,
             "requires": {
-                "tslib": "1.9.3"
+                "tslib": "^1.8.1"
             }
         },
         "tty-browserify": {
@@ -20255,7 +20282,7 @@
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.2"
+                "safe-buffer": "^5.0.1"
             }
         },
         "tweetnacl": {
@@ -20271,7 +20298,7 @@
             "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
             "dev": true,
             "requires": {
-                "prelude-ls": "1.1.2"
+                "prelude-ls": "~1.1.2"
             }
         },
         "type-is": {
@@ -20281,7 +20308,7 @@
             "dev": true,
             "requires": {
                 "media-typer": "0.3.0",
-                "mime-types": "2.1.19"
+                "mime-types": "~2.1.18"
             }
         },
         "typedarray": {
@@ -20320,9 +20347,9 @@
             "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7",
-                "uglify-to-browserify": "1.0.2",
-                "yargs": "3.10.0"
+                "source-map": "~0.5.1",
+                "uglify-to-browserify": "~1.0.0",
+                "yargs": "~3.10.0"
             },
             "dependencies": {
                 "source-map": {
@@ -20346,14 +20373,14 @@
             "integrity": "sha512-1VicfKhCYHLS8m1DCApqBhoulnASsEoJ/BvpUpP4zoNAPpKzdH+ghk0olGJMmwX2/jprK2j3hAHdUbczBSy2FA==",
             "dev": true,
             "requires": {
-                "cacache": "10.0.4",
-                "find-cache-dir": "1.0.0",
-                "schema-utils": "0.4.7",
-                "serialize-javascript": "1.5.0",
-                "source-map": "0.6.1",
-                "uglify-es": "3.3.9",
-                "webpack-sources": "1.1.0",
-                "worker-farm": "1.6.0"
+                "cacache": "^10.0.4",
+                "find-cache-dir": "^1.0.0",
+                "schema-utils": "^0.4.5",
+                "serialize-javascript": "^1.4.0",
+                "source-map": "^0.6.1",
+                "uglify-es": "^3.3.4",
+                "webpack-sources": "^1.1.0",
+                "worker-farm": "^1.5.2"
             },
             "dependencies": {
                 "commander": {
@@ -20368,8 +20395,8 @@
                     "integrity": "sha512-r+MU0rfv4L/0eeW3xZrd16t4NZfK8Ld4SWVglYBb7ez5uXFWHuVRs6xCTrf1yirs9a4j4Y27nn7SRfO6v67XsQ==",
                     "dev": true,
                     "requires": {
-                        "commander": "2.13.0",
-                        "source-map": "0.6.1"
+                        "commander": "~2.13.0",
+                        "source-map": "~0.6.1"
                     }
                 }
             }
@@ -20388,7 +20415,7 @@
         },
         "underscore": {
             "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/underscore/-/underscore-1.6.0.tgz",
             "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
             "dev": true
         },
@@ -20407,8 +20434,8 @@
             "integrity": "sha512-+XZuV691Cn4zHsK0vkKYwBEwB74T3IZIcxrgn2E4rKwTfFyI1zCh7X7grwh9Re08fdPlarIdyWgI8aVB3F5A5g==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "xtend": "4.0.1"
+                "inherits": "^2.0.1",
+                "xtend": "^4.0.1"
             }
         },
         "unified": {
@@ -20417,12 +20444,12 @@
             "integrity": "sha512-1k+KPhlVtqmG99RaTbAv/usu85fcSRu3wY8X+vnsEhIxNP5VbVIDiXnLqyKIG+UMdyTg0ZX9EI6k2AfjJkHPtA==",
             "dev": true,
             "requires": {
-                "bail": "1.0.3",
-                "extend": "3.0.2",
-                "is-plain-obj": "1.1.0",
-                "trough": "1.0.3",
-                "vfile": "2.3.0",
-                "x-is-string": "0.1.0"
+                "bail": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^1.1.0",
+                "trough": "^1.0.0",
+                "vfile": "^2.0.0",
+                "x-is-string": "^0.1.0"
             }
         },
         "union-value": {
@@ -20431,10 +20458,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -20443,7 +20470,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -20452,10 +20479,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -20472,7 +20499,7 @@
             "integrity": "sha1-0F8v5AMlYIcfMOk8vnNe6iAVFPM=",
             "dev": true,
             "requires": {
-                "unique-slug": "2.0.0"
+                "unique-slug": "^2.0.0"
             }
         },
         "unique-slug": {
@@ -20481,7 +20508,7 @@
             "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
             "dev": true,
             "requires": {
-                "imurmurhash": "0.1.4"
+                "imurmurhash": "^0.1.4"
             }
         },
         "unique-stream": {
@@ -20496,7 +20523,7 @@
             "integrity": "sha512-nDl79mKpffXojLpCimVXnxhlH/jjaTnDuScznU9J4jjsaUtBdDbxmlc109XtcqxY4SDO0SwzngsxxW8DIISt1w==",
             "dev": true,
             "requires": {
-                "unist-util-is": "2.1.2"
+                "unist-util-is": "^2.0.0"
             }
         },
         "unist-util-is": {
@@ -20511,7 +20538,7 @@
             "integrity": "sha512-GRi04yhng1WqBf5RBzPkOtWAadcZS2gvuOgNn/cyJBYNxtTuyYqTKN0eg4rC1YJwGnzrqfRB3dSKm8cNCjNirg==",
             "dev": true,
             "requires": {
-                "array-iterate": "1.1.2"
+                "array-iterate": "^1.0.0"
             }
         },
         "unist-util-remove-position": {
@@ -20520,7 +20547,7 @@
             "integrity": "sha512-XxoNOBvq1WXRKXxgnSYbtCF76TJrRoe5++pD4cCBsssSiWSnPEktyFrFLE8LTk3JW5mt9hB0Sk5zn4x/JeWY7Q==",
             "dev": true,
             "requires": {
-                "unist-util-visit": "1.4.0"
+                "unist-util-visit": "^1.1.0"
             }
         },
         "unist-util-stringify-position": {
@@ -20535,7 +20562,7 @@
             "integrity": "sha512-FiGu34ziNsZA3ZUteZxSFaczIjGmksfSgdKqBfOejrrfzyUy5b7YrlzT1Bcvi+djkYDituJDy2XB7tGTeBieKw==",
             "dev": true,
             "requires": {
-                "unist-util-visit-parents": "2.0.1"
+                "unist-util-visit-parents": "^2.0.0"
             }
         },
         "unist-util-visit-parents": {
@@ -20544,7 +20571,7 @@
             "integrity": "sha512-6B0UTiMfdWql4cQ03gDTCSns+64Zkfo2OCbK31Ov0uMizEz+CJeAp0cgZVb5Fhmcd7Bct2iRNywejT0orpbqUA==",
             "dev": true,
             "requires": {
-                "unist-util-is": "2.1.2"
+                "unist-util-is": "^2.1.2"
             }
         },
         "universalify": {
@@ -20565,8 +20592,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -20575,9 +20602,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -20623,7 +20650,7 @@
             "integrity": "sha1-XXm+3P8UQZUY/S7bCgUHybaFkRU=",
             "dev": true,
             "requires": {
-                "upper-case": "1.1.3"
+                "upper-case": "^1.1.1"
             }
         },
         "uri-js": {
@@ -20632,7 +20659,7 @@
             "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
             "dev": true,
             "requires": {
-                "punycode": "2.1.1"
+                "punycode": "^2.1.0"
             }
         },
         "urix": {
@@ -20671,9 +20698,9 @@
             "integrity": "sha512-rAonpHy7231fmweBKUFe0bYnlGDty77E+fm53NZdij7j/YOpyGzc7ttqG1nAXl3aRs0k41o0PC3TvGXQiw2Zvw==",
             "dev": true,
             "requires": {
-                "loader-utils": "1.1.0",
-                "mime": "2.3.1",
-                "schema-utils": "0.4.7"
+                "loader-utils": "^1.1.0",
+                "mime": "^2.0.3",
+                "schema-utils": "^0.4.3"
             },
             "dependencies": {
                 "loader-utils": {
@@ -20682,9 +20709,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 },
                 "mime": {
@@ -20701,8 +20728,8 @@
             "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
             "dev": true,
             "requires": {
-                "querystringify": "2.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "^2.0.0",
+                "requires-port": "^1.0.0"
             }
         },
         "urlencode": {
@@ -20711,7 +20738,7 @@
             "integrity": "sha1-HyuibwE8hfATP3o61v8nMK33y7c=",
             "dev": true,
             "requires": {
-                "iconv-lite": "0.4.23"
+                "iconv-lite": "~0.4.11"
             }
         },
         "use": {
@@ -20732,8 +20759,8 @@
             "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
             "dev": true,
             "requires": {
-                "lru-cache": "2.2.4",
-                "tmp": "0.0.33"
+                "lru-cache": "2.2.x",
+                "tmp": "0.0.x"
             },
             "dependencies": {
                 "lru-cache": {
@@ -20779,8 +20806,8 @@
             "integrity": "sha512-i+6qA2MPhvoKLuxnJNpXAGhg7HphQOSUq2LKMZD0m15EiskXUkMvKdF4Uui0WYeCUGea+o2cw/ZuwehtfsrNkA==",
             "dev": true,
             "requires": {
-                "define-properties": "1.1.2",
-                "object.getownpropertydescriptors": "2.0.3"
+                "define-properties": "^1.1.2",
+                "object.getownpropertydescriptors": "^2.0.3"
             }
         },
         "utila": {
@@ -20820,7 +20847,7 @@
             "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
             "dev": true,
             "requires": {
-                "user-home": "1.1.1"
+                "user-home": "^1.1.1"
             }
         },
         "validate-npm-package-license": {
@@ -20829,8 +20856,8 @@
             "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
             "dev": true,
             "requires": {
-                "spdx-correct": "3.0.0",
-                "spdx-expression-parse": "3.0.0"
+                "spdx-correct": "^3.0.0",
+                "spdx-expression-parse": "^3.0.0"
             }
         },
         "validate.js": {
@@ -20857,9 +20884,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             }
         },
         "vfile": {
@@ -20868,10 +20895,10 @@
             "integrity": "sha512-ASt4mBUHcTpMKD/l5Q+WJXNtshlWxOogYyGYYrg4lt/vuRjC1EFQtlAofL5VmtVNIZJzWYFJjzGWZ0Gw8pzW1w==",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.6",
+                "is-buffer": "^1.1.4",
                 "replace-ext": "1.0.0",
-                "unist-util-stringify-position": "1.1.2",
-                "vfile-message": "1.0.1"
+                "unist-util-stringify-position": "^1.0.0",
+                "vfile-message": "^1.0.0"
             },
             "dependencies": {
                 "replace-ext": {
@@ -20894,7 +20921,7 @@
             "integrity": "sha512-vSGCkhNvJzO6VcWC6AlJW4NtYOVtS+RgCaqFIYUjoGIlHnFL+i0LbtYvonDWOMcB97uTPT4PRsyYY7REWC9vug==",
             "dev": true,
             "requires": {
-                "unist-util-stringify-position": "1.1.2"
+                "unist-util-stringify-position": "^1.1.1"
             }
         },
         "vinyl": {
@@ -20903,8 +20930,8 @@
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "dev": true,
             "requires": {
-                "clone": "1.0.4",
-                "clone-stats": "0.0.1",
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -20914,14 +20941,14 @@
             "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
             "dev": true,
             "requires": {
-                "defaults": "1.0.3",
-                "glob-stream": "3.1.18",
-                "glob-watcher": "0.0.6",
-                "graceful-fs": "3.0.11",
-                "mkdirp": "0.5.1",
-                "strip-bom": "1.0.0",
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "defaults": "^1.0.0",
+                "glob-stream": "^3.1.5",
+                "glob-watcher": "^0.0.6",
+                "graceful-fs": "^3.0.0",
+                "mkdirp": "^0.5.0",
+                "strip-bom": "^1.0.0",
+                "through2": "^0.6.1",
+                "vinyl": "^0.4.0"
             },
             "dependencies": {
                 "clone": {
@@ -20936,7 +20963,7 @@
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "dev": true,
                     "requires": {
-                        "natives": "1.1.4"
+                        "natives": "^1.1.0"
                     }
                 },
                 "isarray": {
@@ -20951,10 +20978,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -20969,8 +20996,8 @@
                     "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
                     "dev": true,
                     "requires": {
-                        "first-chunk-stream": "1.0.0",
-                        "is-utf8": "0.2.1"
+                        "first-chunk-stream": "^1.0.0",
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "through2": {
@@ -20979,8 +21006,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "vinyl": {
@@ -20989,8 +21016,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -21001,7 +21028,7 @@
             "integrity": "sha1-q2VJ1h0XLCsbh75cUI0jnI74dwU=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "^0.5.1"
             },
             "dependencies": {
                 "source-map": {
@@ -21045,8 +21072,8 @@
             "integrity": "sha512-sJ2OFYv2Xvu2lXdg2U9ojfAjRDVomkkg/dYea4tU4vb3b0nUNMtQmI3uwimB3GJEsqug2wz+Ba0ig2mfgY89UA==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "lodash": "4.17.10",
+                "graceful-fs": "^4.1.3",
+                "lodash": "^4.17.10",
                 "minimatch": "3.0.3"
             },
             "dependencies": {
@@ -21056,7 +21083,7 @@
                     "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.11"
+                        "brace-expansion": "^1.0.0"
                     }
                 }
             }
@@ -21067,9 +21094,9 @@
             "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
             "dev": true,
             "requires": {
-                "chokidar": "2.0.4",
-                "graceful-fs": "4.1.11",
-                "neo-async": "2.5.1"
+                "chokidar": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "neo-async": "^2.5.0"
             },
             "dependencies": {
                 "anymatch": {
@@ -21078,8 +21105,8 @@
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "3.1.10",
-                        "normalize-path": "2.1.1"
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
                     }
                 },
                 "arr-diff": {
@@ -21100,16 +21127,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -21118,7 +21145,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -21129,19 +21156,19 @@
                     "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "2.0.0",
-                        "async-each": "1.0.1",
-                        "braces": "2.3.2",
-                        "fsevents": "1.2.4",
-                        "glob-parent": "3.1.0",
-                        "inherits": "2.0.3",
-                        "is-binary-path": "1.0.1",
-                        "is-glob": "4.0.0",
-                        "lodash.debounce": "4.0.8",
-                        "normalize-path": "2.1.1",
-                        "path-is-absolute": "1.0.1",
-                        "readdirp": "2.1.0",
-                        "upath": "1.1.0"
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.0",
+                        "braces": "^2.3.0",
+                        "fsevents": "^1.2.2",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.1",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "lodash.debounce": "^4.0.8",
+                        "normalize-path": "^2.1.1",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.0.0",
+                        "upath": "^1.0.5"
                     }
                 },
                 "expand-brackets": {
@@ -21150,13 +21177,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -21165,7 +21192,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -21174,7 +21201,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -21183,7 +21210,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -21192,7 +21219,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -21203,7 +21230,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -21212,7 +21239,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -21223,9 +21250,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -21242,14 +21269,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -21258,7 +21285,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -21267,7 +21294,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -21278,10 +21305,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -21290,7 +21317,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -21301,8 +21328,8 @@
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
                     },
                     "dependencies": {
                         "is-glob": {
@@ -21311,7 +21338,7 @@
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "requires": {
-                                "is-extglob": "2.1.1"
+                                "is-extglob": "^2.1.0"
                             }
                         }
                     }
@@ -21322,7 +21349,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -21331,7 +21358,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -21340,9 +21367,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-extglob": {
@@ -21357,7 +21384,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 },
                 "is-number": {
@@ -21366,7 +21393,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -21375,7 +21402,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -21398,19 +21425,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -21421,7 +21448,7 @@
             "integrity": "sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==",
             "dev": true,
             "requires": {
-                "minimalistic-assert": "1.0.1"
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "wcwidth": {
@@ -21430,7 +21457,7 @@
             "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
             "dev": true,
             "requires": {
-                "defaults": "1.0.3"
+                "defaults": "^1.0.3"
             }
         },
         "wd": {
@@ -21442,7 +21469,7 @@
                 "archiver": "2.1.1",
                 "async": "2.0.1",
                 "lodash": "4.17.10",
-                "mkdirp": "0.5.1",
+                "mkdirp": "^0.5.1",
                 "q": "1.4.1",
                 "request": "2.85.0",
                 "vargs": "0.1.0"
@@ -21454,7 +21481,7 @@
                     "integrity": "sha1-twnMAoCpw28J9FNr6CPIOKkEniU=",
                     "dev": true,
                     "requires": {
-                        "lodash": "4.17.10"
+                        "lodash": "^4.8.0"
                     }
                 },
                 "boom": {
@@ -21463,7 +21490,7 @@
                     "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
                     "dev": true,
                     "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                     }
                 },
                 "cryptiles": {
@@ -21472,7 +21499,7 @@
                     "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
                     "dev": true,
                     "requires": {
-                        "boom": "5.2.0"
+                        "boom": "5.x.x"
                     },
                     "dependencies": {
                         "boom": {
@@ -21481,7 +21508,7 @@
                             "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                             "dev": true,
                             "requires": {
-                                "hoek": "4.2.1"
+                                "hoek": "4.x.x"
                             }
                         }
                     }
@@ -21492,10 +21519,10 @@
                     "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
                     "dev": true,
                     "requires": {
-                        "boom": "4.3.1",
-                        "cryptiles": "3.1.2",
-                        "hoek": "4.2.1",
-                        "sntp": "2.1.0"
+                        "boom": "4.x.x",
+                        "cryptiles": "3.x.x",
+                        "hoek": "4.x.x",
+                        "sntp": "2.x.x"
                     }
                 },
                 "hoek": {
@@ -21522,28 +21549,28 @@
                     "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.7.0",
-                        "aws4": "1.8.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.6",
-                        "extend": "3.0.2",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.3.2",
-                        "har-validator": "5.0.3",
-                        "hawk": "6.0.2",
-                        "http-signature": "1.2.0",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.19",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "2.1.0",
-                        "qs": "6.5.2",
-                        "safe-buffer": "5.1.2",
-                        "stringstream": "0.0.6",
-                        "tough-cookie": "2.3.4",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.3.2"
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.6.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.1",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.1",
+                        "har-validator": "~5.0.3",
+                        "hawk": "~6.0.2",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.17",
+                        "oauth-sign": "~0.8.2",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.1",
+                        "safe-buffer": "^5.1.1",
+                        "stringstream": "~0.0.5",
+                        "tough-cookie": "~2.3.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.1.0"
                     }
                 },
                 "sntp": {
@@ -21552,7 +21579,7 @@
                     "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
                     "dev": true,
                     "requires": {
-                        "hoek": "4.2.1"
+                        "hoek": "4.x.x"
                     }
                 },
                 "tough-cookie": {
@@ -21561,7 +21588,7 @@
                     "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
                     "dev": true,
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": "^1.4.1"
                     }
                 }
             }
@@ -21583,26 +21610,26 @@
                 "@webassemblyjs/wasm-edit": "1.5.13",
                 "@webassemblyjs/wasm-opt": "1.5.13",
                 "@webassemblyjs/wasm-parser": "1.5.13",
-                "acorn": "5.7.1",
-                "acorn-dynamic-import": "3.0.0",
-                "ajv": "6.5.2",
-                "ajv-keywords": "3.2.0",
-                "chrome-trace-event": "1.0.0",
-                "enhanced-resolve": "4.1.0",
-                "eslint-scope": "4.0.0",
-                "json-parse-better-errors": "1.0.2",
-                "loader-runner": "2.3.0",
-                "loader-utils": "1.1.0",
-                "memory-fs": "0.4.1",
-                "micromatch": "3.1.10",
-                "mkdirp": "0.5.1",
-                "neo-async": "2.5.1",
-                "node-libs-browser": "2.1.0",
-                "schema-utils": "0.4.7",
-                "tapable": "1.0.0",
-                "uglifyjs-webpack-plugin": "1.2.7",
-                "watchpack": "1.6.0",
-                "webpack-sources": "1.1.0"
+                "acorn": "^5.6.2",
+                "acorn-dynamic-import": "^3.0.0",
+                "ajv": "^6.1.0",
+                "ajv-keywords": "^3.1.0",
+                "chrome-trace-event": "^1.0.0",
+                "enhanced-resolve": "^4.1.0",
+                "eslint-scope": "^4.0.0",
+                "json-parse-better-errors": "^1.0.2",
+                "loader-runner": "^2.3.0",
+                "loader-utils": "^1.1.0",
+                "memory-fs": "~0.4.1",
+                "micromatch": "^3.1.8",
+                "mkdirp": "~0.5.0",
+                "neo-async": "^2.5.0",
+                "node-libs-browser": "^2.0.0",
+                "schema-utils": "^0.4.4",
+                "tapable": "^1.0.0",
+                "uglifyjs-webpack-plugin": "^1.2.4",
+                "watchpack": "^1.5.0",
+                "webpack-sources": "^1.0.1"
             },
             "dependencies": {
                 "acorn": {
@@ -21629,16 +21656,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -21647,7 +21674,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -21658,13 +21685,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -21673,7 +21700,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -21682,7 +21709,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -21691,7 +21718,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -21700,7 +21727,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -21711,7 +21738,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -21720,7 +21747,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -21731,9 +21758,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -21750,14 +21777,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -21766,7 +21793,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -21775,7 +21802,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -21786,10 +21813,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -21798,7 +21825,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -21809,7 +21836,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -21818,7 +21845,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -21827,9 +21854,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-number": {
@@ -21838,7 +21865,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -21847,7 +21874,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -21870,9 +21897,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 },
                 "micromatch": {
@@ -21881,19 +21908,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 }
             }
@@ -21904,17 +21931,17 @@
             "integrity": "sha512-p5NeKDtYwjZozUWq6kGNs9w+Gtw/CPvyuXjXn2HMdz8Tie+krjEg8oAtonvIyITZdvpF7XG9xDHwscLr2c+ugQ==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "cross-spawn": "6.0.5",
-                "enhanced-resolve": "4.1.0",
-                "global-modules-path": "2.3.0",
-                "import-local": "1.0.0",
-                "inquirer": "6.1.0",
-                "interpret": "1.1.0",
-                "loader-utils": "1.1.0",
-                "supports-color": "5.4.0",
-                "v8-compile-cache": "2.0.2",
-                "yargs": "12.0.1"
+                "chalk": "^2.4.1",
+                "cross-spawn": "^6.0.5",
+                "enhanced-resolve": "^4.0.0",
+                "global-modules-path": "^2.1.0",
+                "import-local": "^1.0.0",
+                "inquirer": "^6.0.0",
+                "interpret": "^1.1.0",
+                "loader-utils": "^1.1.0",
+                "supports-color": "^5.4.0",
+                "v8-compile-cache": "^2.0.0",
+                "yargs": "^12.0.1"
             },
             "dependencies": {
                 "ansi-regex": {
@@ -21929,9 +21956,9 @@
                     "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     }
                 },
                 "cross-spawn": {
@@ -21940,11 +21967,11 @@
                     "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
                     "dev": true,
                     "requires": {
-                        "nice-try": "1.0.4",
-                        "path-key": "2.0.1",
-                        "semver": "5.5.0",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "decamelize": {
@@ -21962,9 +21989,9 @@
                     "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "4.1.11",
-                        "memory-fs": "0.4.1",
-                        "tapable": "1.0.0"
+                        "graceful-fs": "^4.1.2",
+                        "memory-fs": "^0.4.0",
+                        "tapable": "^1.0.0"
                     }
                 },
                 "execa": {
@@ -21973,13 +22000,13 @@
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     },
                     "dependencies": {
                         "cross-spawn": {
@@ -21988,9 +22015,9 @@
                             "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                             "dev": true,
                             "requires": {
-                                "lru-cache": "4.1.3",
-                                "shebang-command": "1.2.0",
-                                "which": "1.3.1"
+                                "lru-cache": "^4.0.1",
+                                "shebang-command": "^1.2.0",
+                                "which": "^1.2.9"
                             }
                         }
                     }
@@ -22001,7 +22028,7 @@
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "dev": true,
                     "requires": {
-                        "locate-path": "3.0.0"
+                        "locate-path": "^3.0.0"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -22016,9 +22043,9 @@
                     "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
                     "dev": true,
                     "requires": {
-                        "big.js": "3.2.0",
-                        "emojis-list": "2.1.0",
-                        "json5": "0.5.1"
+                        "big.js": "^3.1.3",
+                        "emojis-list": "^2.0.0",
+                        "json5": "^0.5.0"
                     }
                 },
                 "locate-path": {
@@ -22027,8 +22054,8 @@
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
                     "dev": true,
                     "requires": {
-                        "p-locate": "3.0.0",
-                        "path-exists": "3.0.0"
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
                     }
                 },
                 "lru-cache": {
@@ -22037,8 +22064,8 @@
                     "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 },
                 "os-locale": {
@@ -22047,9 +22074,9 @@
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "dev": true,
                     "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
                     }
                 },
                 "p-limit": {
@@ -22058,7 +22085,7 @@
                     "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
                     "dev": true,
                     "requires": {
-                        "p-try": "2.0.0"
+                        "p-try": "^2.0.0"
                     }
                 },
                 "p-locate": {
@@ -22067,7 +22094,7 @@
                     "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
                     "dev": true,
                     "requires": {
-                        "p-limit": "2.0.0"
+                        "p-limit": "^2.0.0"
                     }
                 },
                 "p-try": {
@@ -22082,8 +22109,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     }
                 },
                 "strip-ansi": {
@@ -22092,7 +22119,7 @@
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "3.0.0"
+                        "ansi-regex": "^3.0.0"
                     }
                 },
                 "tapable": {
@@ -22119,18 +22146,18 @@
                     "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.1.0",
-                        "decamelize": "2.0.0",
-                        "find-up": "3.0.0",
-                        "get-caller-file": "1.0.3",
-                        "os-locale": "2.1.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "10.1.0"
+                        "cliui": "^4.0.0",
+                        "decamelize": "^2.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1 || ^4.0.0",
+                        "yargs-parser": "^10.1.0"
                     }
                 }
             }
@@ -22142,32 +22169,32 @@
             "dev": true,
             "requires": {
                 "ansi-html": "0.0.7",
-                "array-includes": "3.0.3",
-                "bonjour": "3.5.0",
-                "chokidar": "2.0.4",
-                "compression": "1.7.3",
-                "connect-history-api-fallback": "1.5.0",
-                "debug": "3.1.0",
-                "del": "3.0.0",
-                "express": "4.16.3",
-                "html-entities": "1.2.1",
-                "http-proxy-middleware": "0.18.0",
-                "import-local": "1.0.0",
+                "array-includes": "^3.0.3",
+                "bonjour": "^3.5.0",
+                "chokidar": "^2.0.0",
+                "compression": "^1.5.2",
+                "connect-history-api-fallback": "^1.3.0",
+                "debug": "^3.1.0",
+                "del": "^3.0.0",
+                "express": "^4.16.2",
+                "html-entities": "^1.2.0",
+                "http-proxy-middleware": "~0.18.0",
+                "import-local": "^1.0.0",
                 "internal-ip": "1.2.0",
-                "ip": "1.1.5",
-                "killable": "1.0.0",
-                "loglevel": "1.6.1",
-                "opn": "5.3.0",
-                "portfinder": "1.0.16",
-                "selfsigned": "1.10.3",
-                "serve-index": "1.9.1",
+                "ip": "^1.1.5",
+                "killable": "^1.0.0",
+                "loglevel": "^1.4.1",
+                "opn": "^5.1.0",
+                "portfinder": "^1.0.9",
+                "selfsigned": "^1.9.1",
+                "serve-index": "^1.7.2",
                 "sockjs": "0.3.19",
                 "sockjs-client": "1.1.5",
-                "spdy": "3.4.7",
-                "strip-ansi": "3.0.1",
-                "supports-color": "5.4.0",
+                "spdy": "^3.4.1",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^5.1.0",
                 "webpack-dev-middleware": "3.1.3",
-                "webpack-log": "1.2.0",
+                "webpack-log": "^1.1.2",
                 "yargs": "11.0.0"
             },
             "dependencies": {
@@ -22183,8 +22210,8 @@
                     "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
                     "dev": true,
                     "requires": {
-                        "micromatch": "3.1.10",
-                        "normalize-path": "2.1.1"
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
                     }
                 },
                 "arr-diff": {
@@ -22205,16 +22232,16 @@
                     "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
                     "dev": true,
                     "requires": {
-                        "arr-flatten": "1.1.0",
-                        "array-unique": "0.3.2",
-                        "extend-shallow": "2.0.1",
-                        "fill-range": "4.0.0",
-                        "isobject": "3.0.1",
-                        "repeat-element": "1.1.2",
-                        "snapdragon": "0.8.2",
-                        "snapdragon-node": "2.1.1",
-                        "split-string": "3.1.0",
-                        "to-regex": "3.0.2"
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -22223,7 +22250,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -22234,19 +22261,19 @@
                     "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
                     "dev": true,
                     "requires": {
-                        "anymatch": "2.0.0",
-                        "async-each": "1.0.1",
-                        "braces": "2.3.2",
-                        "fsevents": "1.2.4",
-                        "glob-parent": "3.1.0",
-                        "inherits": "2.0.3",
-                        "is-binary-path": "1.0.1",
-                        "is-glob": "4.0.0",
-                        "lodash.debounce": "4.0.8",
-                        "normalize-path": "2.1.1",
-                        "path-is-absolute": "1.0.1",
-                        "readdirp": "2.1.0",
-                        "upath": "1.1.0"
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.0",
+                        "braces": "^2.3.0",
+                        "fsevents": "^1.2.2",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.1",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "lodash.debounce": "^4.0.8",
+                        "normalize-path": "^2.1.1",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.0.0",
+                        "upath": "^1.0.5"
                     }
                 },
                 "cliui": {
@@ -22255,9 +22282,9 @@
                     "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
                     "dev": true,
                     "requires": {
-                        "string-width": "2.1.1",
-                        "strip-ansi": "4.0.0",
-                        "wrap-ansi": "2.1.0"
+                        "string-width": "^2.1.1",
+                        "strip-ansi": "^4.0.0",
+                        "wrap-ansi": "^2.0.0"
                     },
                     "dependencies": {
                         "strip-ansi": {
@@ -22266,7 +22293,7 @@
                             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "3.0.0"
+                                "ansi-regex": "^3.0.0"
                             }
                         }
                     }
@@ -22277,9 +22304,9 @@
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "4.1.3",
-                        "shebang-command": "1.2.0",
-                        "which": "1.3.1"
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
                     }
                 },
                 "debug": {
@@ -22297,12 +22324,12 @@
                     "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
                     "dev": true,
                     "requires": {
-                        "globby": "6.1.0",
-                        "is-path-cwd": "1.0.0",
-                        "is-path-in-cwd": "1.0.1",
-                        "p-map": "1.2.0",
-                        "pify": "3.0.0",
-                        "rimraf": "2.6.2"
+                        "globby": "^6.1.0",
+                        "is-path-cwd": "^1.0.0",
+                        "is-path-in-cwd": "^1.0.0",
+                        "p-map": "^1.1.1",
+                        "pify": "^3.0.0",
+                        "rimraf": "^2.2.8"
                     }
                 },
                 "execa": {
@@ -22311,13 +22338,13 @@
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "dev": true,
                     "requires": {
-                        "cross-spawn": "5.1.0",
-                        "get-stream": "3.0.0",
-                        "is-stream": "1.1.0",
-                        "npm-run-path": "2.0.2",
-                        "p-finally": "1.0.0",
-                        "signal-exit": "3.0.2",
-                        "strip-eof": "1.0.0"
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
                     }
                 },
                 "expand-brackets": {
@@ -22326,13 +22353,13 @@
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
-                        "debug": "2.6.9",
-                        "define-property": "0.2.5",
-                        "extend-shallow": "2.0.1",
-                        "posix-character-classes": "0.1.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "debug": "^2.3.3",
+                        "define-property": "^0.2.5",
+                        "extend-shallow": "^2.0.1",
+                        "posix-character-classes": "^0.1.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "debug": {
@@ -22350,7 +22377,7 @@
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "0.1.6"
+                                "is-descriptor": "^0.1.0"
                             }
                         },
                         "extend-shallow": {
@@ -22359,7 +22386,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         },
                         "is-accessor-descriptor": {
@@ -22368,7 +22395,7 @@
                             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -22377,7 +22404,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -22388,7 +22415,7 @@
                             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                             "dev": true,
                             "requires": {
-                                "kind-of": "3.2.2"
+                                "kind-of": "^3.0.2"
                             },
                             "dependencies": {
                                 "kind-of": {
@@ -22397,7 +22424,7 @@
                                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                                     "dev": true,
                                     "requires": {
-                                        "is-buffer": "1.1.6"
+                                        "is-buffer": "^1.1.5"
                                     }
                                 }
                             }
@@ -22408,9 +22435,9 @@
                             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                             "dev": true,
                             "requires": {
-                                "is-accessor-descriptor": "0.1.6",
-                                "is-data-descriptor": "0.1.4",
-                                "kind-of": "5.1.0"
+                                "is-accessor-descriptor": "^0.1.6",
+                                "is-data-descriptor": "^0.1.4",
+                                "kind-of": "^5.0.0"
                             }
                         },
                         "kind-of": {
@@ -22427,14 +22454,14 @@
                     "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
                     "dev": true,
                     "requires": {
-                        "array-unique": "0.3.2",
-                        "define-property": "1.0.0",
-                        "expand-brackets": "2.1.4",
-                        "extend-shallow": "2.0.1",
-                        "fragment-cache": "0.2.1",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "array-unique": "^0.3.2",
+                        "define-property": "^1.0.0",
+                        "expand-brackets": "^2.1.4",
+                        "extend-shallow": "^2.0.1",
+                        "fragment-cache": "^0.2.1",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.1"
                     },
                     "dependencies": {
                         "define-property": {
@@ -22443,7 +22470,7 @@
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
-                                "is-descriptor": "1.0.2"
+                                "is-descriptor": "^1.0.0"
                             }
                         },
                         "extend-shallow": {
@@ -22452,7 +22479,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -22463,10 +22490,10 @@
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-number": "3.0.0",
-                        "repeat-string": "1.6.1",
-                        "to-regex-range": "2.1.1"
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
                     },
                     "dependencies": {
                         "extend-shallow": {
@@ -22475,7 +22502,7 @@
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
-                                "is-extendable": "0.1.1"
+                                "is-extendable": "^0.1.0"
                             }
                         }
                     }
@@ -22486,8 +22513,8 @@
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "3.1.0",
-                        "path-dirname": "1.0.2"
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
                     },
                     "dependencies": {
                         "is-glob": {
@@ -22496,7 +22523,7 @@
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "requires": {
-                                "is-extglob": "2.1.1"
+                                "is-extglob": "^2.1.0"
                             }
                         }
                     }
@@ -22507,11 +22534,11 @@
                     "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
                     "dev": true,
                     "requires": {
-                        "array-union": "1.0.2",
-                        "glob": "7.1.2",
-                        "object-assign": "4.1.1",
-                        "pify": "2.3.0",
-                        "pinkie-promise": "2.0.1"
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
                     },
                     "dependencies": {
                         "pify": {
@@ -22528,7 +22555,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -22537,7 +22564,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -22546,9 +22573,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 },
                 "is-extglob": {
@@ -22569,7 +22596,7 @@
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.1"
                     }
                 },
                 "is-number": {
@@ -22578,7 +22605,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -22587,7 +22614,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.6"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -22610,8 +22637,8 @@
                     "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
                     "dev": true,
                     "requires": {
-                        "pseudomap": "1.0.2",
-                        "yallist": "2.1.2"
+                        "pseudomap": "^1.0.2",
+                        "yallist": "^2.1.2"
                     }
                 },
                 "micromatch": {
@@ -22620,19 +22647,19 @@
                     "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
                     "dev": true,
                     "requires": {
-                        "arr-diff": "4.0.0",
-                        "array-unique": "0.3.2",
-                        "braces": "2.3.2",
-                        "define-property": "2.0.2",
-                        "extend-shallow": "3.0.2",
-                        "extglob": "2.0.4",
-                        "fragment-cache": "0.2.1",
-                        "kind-of": "6.0.2",
-                        "nanomatch": "1.2.13",
-                        "object.pick": "1.3.0",
-                        "regex-not": "1.0.2",
-                        "snapdragon": "0.8.2",
-                        "to-regex": "3.0.2"
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
                     }
                 },
                 "mime": {
@@ -22647,9 +22674,9 @@
                     "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
                     "dev": true,
                     "requires": {
-                        "execa": "0.7.0",
-                        "lcid": "1.0.0",
-                        "mem": "1.1.0"
+                        "execa": "^0.7.0",
+                        "lcid": "^1.0.0",
+                        "mem": "^1.1.0"
                     }
                 },
                 "string-width": {
@@ -22658,8 +22685,8 @@
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
                     "dev": true,
                     "requires": {
-                        "is-fullwidth-code-point": "2.0.0",
-                        "strip-ansi": "4.0.0"
+                        "is-fullwidth-code-point": "^2.0.0",
+                        "strip-ansi": "^4.0.0"
                     },
                     "dependencies": {
                         "strip-ansi": {
@@ -22668,7 +22695,7 @@
                             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                             "dev": true,
                             "requires": {
-                                "ansi-regex": "3.0.0"
+                                "ansi-regex": "^3.0.0"
                             }
                         }
                     }
@@ -22679,13 +22706,13 @@
                     "integrity": "sha512-I6Mmy/QjWU/kXwCSFGaiOoL5YEQIVmbb0o45xMoCyQAg/mClqZVTcsX327sPfekDyJWpCxb+04whNyLOIxpJdQ==",
                     "dev": true,
                     "requires": {
-                        "loud-rejection": "1.6.0",
-                        "memory-fs": "0.4.1",
-                        "mime": "2.3.1",
-                        "path-is-absolute": "1.0.1",
-                        "range-parser": "1.2.0",
-                        "url-join": "4.0.0",
-                        "webpack-log": "1.2.0"
+                        "loud-rejection": "^1.6.0",
+                        "memory-fs": "~0.4.1",
+                        "mime": "^2.1.0",
+                        "path-is-absolute": "^1.0.0",
+                        "range-parser": "^1.0.3",
+                        "url-join": "^4.0.0",
+                        "webpack-log": "^1.0.1"
                     }
                 },
                 "which-module": {
@@ -22700,18 +22727,18 @@
                     "integrity": "sha512-Rjp+lMYQOWtgqojx1dEWorjCofi1YN7AoFvYV7b1gx/7dAAeuI4kN5SZiEvr0ZmsZTOpDRcCqrpI10L31tFkBw==",
                     "dev": true,
                     "requires": {
-                        "cliui": "4.1.0",
-                        "decamelize": "1.2.0",
-                        "find-up": "2.1.0",
-                        "get-caller-file": "1.0.3",
-                        "os-locale": "2.1.0",
-                        "require-directory": "2.1.1",
-                        "require-main-filename": "1.0.1",
-                        "set-blocking": "2.0.0",
-                        "string-width": "2.1.1",
-                        "which-module": "2.0.0",
-                        "y18n": "3.2.1",
-                        "yargs-parser": "9.0.2"
+                        "cliui": "^4.0.0",
+                        "decamelize": "^1.1.1",
+                        "find-up": "^2.1.0",
+                        "get-caller-file": "^1.0.1",
+                        "os-locale": "^2.0.0",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^1.0.1",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^2.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^3.2.1",
+                        "yargs-parser": "^9.0.2"
                     }
                 },
                 "yargs-parser": {
@@ -22720,7 +22747,7 @@
                     "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
                     "dev": true,
                     "requires": {
-                        "camelcase": "4.1.0"
+                        "camelcase": "^4.1.0"
                     }
                 }
             }
@@ -22731,10 +22758,10 @@
             "integrity": "sha512-U9AnICnu50HXtiqiDxuli5gLB5PGBo7VvcHx36jRZHwK4vzOYLbImqT4lwWwoMHdQWwEKw736fCHEekokTEKHA==",
             "dev": true,
             "requires": {
-                "chalk": "2.4.1",
-                "log-symbols": "2.2.0",
-                "loglevelnext": "1.0.5",
-                "uuid": "3.3.2"
+                "chalk": "^2.1.0",
+                "log-symbols": "^2.1.0",
+                "loglevelnext": "^1.0.1",
+                "uuid": "^3.1.0"
             }
         },
         "webpack-sources": {
@@ -22743,8 +22770,8 @@
             "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
             "dev": true,
             "requires": {
-                "source-list-map": "2.0.0",
-                "source-map": "0.6.1"
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
             }
         },
         "websocket-driver": {
@@ -22753,8 +22780,8 @@
             "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
             "dev": true,
             "requires": {
-                "http-parser-js": "0.4.13",
-                "websocket-extensions": "0.1.3"
+                "http-parser-js": ">=0.4.0",
+                "websocket-extensions": ">=0.1.1"
             }
         },
         "websocket-extensions": {
@@ -22786,8 +22813,8 @@
             "integrity": "sha1-e9yuSQ+SGu9kUftnOexrvY6Qe/Y=",
             "dev": true,
             "requires": {
-                "tr46": "0.0.3",
-                "webidl-conversions": "3.0.1"
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "when": {
@@ -22801,7 +22828,7 @@
             "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "which-module": {
@@ -22816,7 +22843,7 @@
             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2"
+                "string-width": "^1.0.2 || 2"
             }
         },
         "window-size": {
@@ -22831,12 +22858,12 @@
             "integrity": "sha512-GYKuysPz2pxYAVJD2NPsDLP5Z79SDEzPm9/j4tCjkF/n89iBNGBMJcR+dMUqxgPNgoSs6fVygPi+Vl2oxIpBuw==",
             "dev": true,
             "requires": {
-                "async": "1.0.0",
-                "colors": "1.0.3",
-                "cycle": "1.0.3",
-                "eyes": "0.1.8",
-                "isstream": "0.1.2",
-                "stack-trace": "0.0.10"
+                "async": "~1.0.0",
+                "colors": "1.0.x",
+                "cycle": "1.0.x",
+                "eyes": "0.1.x",
+                "isstream": "0.1.x",
+                "stack-trace": "0.0.x"
             },
             "dependencies": {
                 "async": {
@@ -22855,7 +22882,7 @@
         },
         "with-callback": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/with-callback/-/with-callback-1.0.2.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/with-callback/-/with-callback-1.0.2.tgz",
             "integrity": "sha1-oJYpuakgAo1yFAT7Q1vc/1yRvCE=",
             "dev": true,
             "optional": true
@@ -22872,7 +22899,7 @@
             "integrity": "sha512-6w+3tHbM87WnSWnENBUvA2pxJPLhQUg5LKwUQHq3r+XPhIM+Gh2R5ycbwPCyuGbNg+lPgdcnQUhuC02kJCvffQ==",
             "dev": true,
             "requires": {
-                "errno": "0.1.7"
+                "errno": "~0.1.7"
             }
         },
         "wrap-ansi": {
@@ -22881,8 +22908,8 @@
             "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
             "dev": true,
             "requires": {
-                "string-width": "1.0.2",
-                "strip-ansi": "3.0.1"
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1"
             }
         },
         "wrappy": {
@@ -22897,7 +22924,7 @@
             "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
             "dev": true,
             "requires": {
-                "mkdirp": "0.5.1"
+                "mkdirp": "^0.5.1"
             }
         },
         "ws": {
@@ -22906,9 +22933,9 @@
             "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
             "dev": true,
             "requires": {
-                "async-limiter": "1.0.0",
-                "safe-buffer": "5.1.2",
-                "ultron": "1.1.1"
+                "async-limiter": "~1.0.0",
+                "safe-buffer": "~5.1.0",
+                "ultron": "~1.1.0"
             }
         },
         "x-is-string": {
@@ -22931,7 +22958,7 @@
         },
         "xmlbuilder": {
             "version": "8.2.2",
-            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
             "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
             "dev": true
         },
@@ -22972,9 +22999,9 @@
             "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
             "dev": true,
             "requires": {
-                "camelcase": "1.2.1",
-                "cliui": "2.1.0",
-                "decamelize": "1.2.0",
+                "camelcase": "^1.0.2",
+                "cliui": "^2.1.0",
+                "decamelize": "^1.0.0",
                 "window-size": "0.1.0"
             },
             "dependencies": {
@@ -22992,7 +23019,7 @@
             "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
             "dev": true,
             "requires": {
-                "camelcase": "4.1.0"
+                "camelcase": "^4.1.0"
             }
         },
         "yeast": {
@@ -23013,10 +23040,10 @@
             "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
             "dev": true,
             "requires": {
-                "archiver-utils": "1.3.0",
-                "compress-commons": "1.2.2",
-                "lodash": "4.17.10",
-                "readable-stream": "2.3.6"
+                "archiver-utils": "^1.3.0",
+                "compress-commons": "^1.2.0",
+                "lodash": "^4.8.0",
+                "readable-stream": "^2.0.0"
             }
         },
         "zone.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
     "requires": true,
     "dependencies": {
         "@angular-devkit/core": {
-            "version": "0.7.2",
-            "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.7.2.tgz",
-            "integrity": "sha512-1Es9oNpabOukutBe+0txXUHyhI6ypuc7WrxTutZH7Lr3n3+CTG6oEv42rOcot1aXi1n97wNqcdY3lrENFu9vhQ==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-0.7.3.tgz",
+            "integrity": "sha512-2fKNmv4sJ6EEONp6QJ2VcHlR0O2TAXWm6jQsWxJjfVvROhAY7eJkzhqi0pUoWhUiamxCk5ssl8p9KkhtOiTa4Q==",
             "dev": true,
             "requires": {
                 "ajv": "~6.4.0",
@@ -16,18 +16,6 @@
                 "source-map": "^0.5.6"
             },
             "dependencies": {
-                "ajv": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
-                    "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^1.0.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.3.0",
-                        "uri-js": "^3.0.2"
-                    }
-                },
                 "anymatch": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
@@ -228,12 +216,6 @@
                         }
                     }
                 },
-                "fast-deep-equal": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-                    "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-                    "dev": true
-                },
                 "fill-range": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
@@ -348,12 +330,6 @@
                     "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
                     "dev": true
                 },
-                "json-schema-traverse": {
-                    "version": "0.3.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-                    "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-                    "dev": true
-                },
                 "kind-of": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -386,15 +362,6 @@
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
                     "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
                     "dev": true
-                },
-                "uri-js": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
-                    "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
-                    "dev": true,
-                    "requires": {
-                        "punycode": "^2.1.0"
-                    }
                 }
             }
         },
@@ -506,7 +473,7 @@
         },
         "@commitlint/cli": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/cli/-/cli-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-7.0.0.tgz",
             "integrity": "sha1-O/htirL71QdMMRS3uj9LQbd189w=",
             "dev": true,
             "requires": {
@@ -537,13 +504,13 @@
         },
         "@commitlint/config-conventional": {
             "version": "7.0.1",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/config-conventional/-/config-conventional-7.0.1.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/config-conventional/-/config-conventional-7.0.1.tgz",
             "integrity": "sha1-J2l3+O5g2MVtf91DKWr3bf7ptfc=",
             "dev": true
         },
         "@commitlint/ensure": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/ensure/-/ensure-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-7.0.0.tgz",
             "integrity": "sha1-PVIQu5iEFoRJJolaeCpVgVcxd50=",
             "dev": true,
             "requires": {
@@ -556,7 +523,7 @@
         },
         "@commitlint/execute-rule": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/execute-rule/-/execute-rule-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-7.0.0.tgz",
             "integrity": "sha1-y8ZTFPqeu5zSxbjN1NymGFs6ykw=",
             "dev": true,
             "requires": {
@@ -565,7 +532,7 @@
         },
         "@commitlint/format": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/format/-/format-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/format/-/format-7.0.0.tgz",
             "integrity": "sha1-O+H98MPEH+uY4nW09gXFmMUJuSA=",
             "dev": true,
             "requires": {
@@ -575,7 +542,7 @@
         },
         "@commitlint/is-ignored": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/is-ignored/-/is-ignored-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-7.0.0.tgz",
             "integrity": "sha1-0yiil2J0yfEG4xmxysdd2Eg2D8k=",
             "dev": true,
             "requires": {
@@ -584,7 +551,7 @@
         },
         "@commitlint/lint": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/lint/-/lint-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-7.0.0.tgz",
             "integrity": "sha1-rt6eFfVRuCKvfZ2lXfSIGtODkNk=",
             "dev": true,
             "requires": {
@@ -597,7 +564,7 @@
         },
         "@commitlint/load": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/load/-/load-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/load/-/load-7.0.0.tgz",
             "integrity": "sha1-2ST0xcBtiEWxalC1Y4Kaf/+iMKg=",
             "dev": true,
             "requires": {
@@ -614,13 +581,13 @@
         },
         "@commitlint/message": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/message/-/message-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/message/-/message-7.0.0.tgz",
             "integrity": "sha1-b7IlY+MZAf9dpDkdsTRv2nEV+lM=",
             "dev": true
         },
         "@commitlint/parse": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/parse/-/parse-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-7.0.0.tgz",
             "integrity": "sha1-7QJMxNjwh0QhqN1tFmdCM7aFktQ=",
             "dev": true,
             "requires": {
@@ -630,7 +597,7 @@
         },
         "@commitlint/read": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/read/-/read-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/read/-/read-7.0.0.tgz",
             "integrity": "sha1-yb8iLjfgTDPB4ltJhlf+9oN34sg=",
             "dev": true,
             "requires": {
@@ -642,7 +609,7 @@
         },
         "@commitlint/resolve-extends": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/resolve-extends/-/resolve-extends-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-7.0.0.tgz",
             "integrity": "sha1-NJN1Jeo7wDc2XFMLzpscc+9Ot00=",
             "dev": true,
             "requires": {
@@ -656,7 +623,7 @@
         },
         "@commitlint/rules": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/rules/-/rules-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-7.0.0.tgz",
             "integrity": "sha1-mnEIkcNQwQ1vYt67gg/uT97x4CY=",
             "dev": true,
             "requires": {
@@ -668,13 +635,13 @@
         },
         "@commitlint/to-lines": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/to-lines/-/to-lines-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-7.0.0.tgz",
             "integrity": "sha1-rbIpNo4rbHplfJCXVPtA7Ec2POI=",
             "dev": true
         },
         "@commitlint/top-level": {
             "version": "7.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/@commitlint/top-level/-/top-level-7.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-7.0.0.tgz",
             "integrity": "sha1-/yhYCrjBQxKQ43sdUH4O83DDjZk=",
             "dev": true,
             "requires": {
@@ -703,12 +670,12 @@
             }
         },
         "@ngtools/webpack": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-6.1.2.tgz",
-            "integrity": "sha512-MkQmt9VL1QvtrC1WNzfEXkk2JdCWrQO2m1lB/A86jj5TsKc4NLObY2a9tNttq3mEsLxkEcOWPLDMiCHJlM+f9Q==",
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/@ngtools/webpack/-/webpack-6.1.3.tgz",
+            "integrity": "sha512-wPviLDR8snkEz43tre9Rr4DoV8WE7GQ+LyfoAzvPgg9pumFpPvQsR7OizLoO0cUFMSZA3JvuPxza3MFtl94dXA==",
             "dev": true,
             "requires": {
-                "@angular-devkit/core": "0.7.2",
+                "@angular-devkit/core": "0.7.3",
                 "rxjs": "^6.0.0",
                 "tree-kill": "^1.0.0",
                 "webpack-sources": "^1.1.0"
@@ -1252,9 +1219,9 @@
             }
         },
         "JSONStream": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
-            "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.4.tgz",
+            "integrity": "sha512-Y7vfi3I5oMOYIr+WxV8NZxDSwcbNgzdKYsTNInmycOq9bUYwGg9ryu57Wg5NLmCjqdFPNUmpMBo3kSJN9tCbXg==",
             "dev": true,
             "requires": {
                 "jsonparse": "^1.2.0",
@@ -1610,7 +1577,7 @@
         },
         "add-stream": {
             "version": "1.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/add-stream/-/add-stream-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/add-stream/-/add-stream-1.0.0.tgz",
             "integrity": "sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=",
             "dev": true
         },
@@ -1700,16 +1667,22 @@
             }
         },
         "ajv": {
-            "version": "6.5.2",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-            "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.4.0.tgz",
+            "integrity": "sha1-06/3jpJ3VJdx2vAWTP9ISCt1T8Y=",
             "dev": true,
             "requires": {
-                "fast-deep-equal": "^2.0.1",
+                "fast-deep-equal": "^1.0.0",
                 "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
-                "uri-js": "^4.2.1"
+                "json-schema-traverse": "^0.3.0",
+                "uri-js": "^3.0.2"
             }
+        },
+        "ajv-errors": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.0.tgz",
+            "integrity": "sha1-7PAh+hCP0X37Xms4Py3SM+Mf/Fk=",
+            "dev": true
         },
         "ajv-keywords": {
             "version": "3.2.0",
@@ -1875,12 +1848,6 @@
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/app-module-path/-/app-module-path-2.2.0.tgz",
             "integrity": "sha1-ZBqlXft9am8KgUHEucCqULbCTdU=",
-            "dev": true
-        },
-        "app-root-path": {
-            "version": "2.1.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/app-root-path/-/app-root-path-2.1.0.tgz",
-            "integrity": "sha1-mL9lmTJ+zqGZMJhm6BQDaP0uZGo=",
             "dev": true
         },
         "aproba": {
@@ -2140,9 +2107,9 @@
             "dev": true
         },
         "ast-types": {
-            "version": "0.9.6",
-            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.9.6.tgz",
-            "integrity": "sha1-ECyenpAF0+fjgpvwxPok7oYu6bk=",
+            "version": "0.11.5",
+            "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.5.tgz",
+            "integrity": "sha512-oJjo+5e7/vEc2FBK8gUalV0pba4L3VdBIs2EKhOLHLcOd2FgQIVQN9xb0eZ9IjEWyAL7vq6fGJxOvVvdCHNyMw==",
             "dev": true,
             "optional": true
         },
@@ -2183,30 +2150,17 @@
             "dev": true
         },
         "autoprefixer": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.1.0.tgz",
-            "integrity": "sha512-BbAIdxNdptG/x4DiGGfpkDVYyqu4nUyNdBB0Utr49Gn3+0RERV1MdHik2FSbbWwhMAuk1KrfVJHe7nEMheGdBA==",
+            "version": "9.1.1",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.1.1.tgz",
+            "integrity": "sha512-Q/2zhVEglXXCBNCOFfnihQcQystPYJt4GrIopeWhPjFxRPXya8eOstB89AafW0nWhSscByp+rSXp9EE5X4zgXQ==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.0.1",
-                "caniuse-lite": "^1.0.30000872",
+                "browserslist": "^4.0.2",
+                "caniuse-lite": "^1.0.30000876",
                 "normalize-range": "^0.1.2",
                 "num2fraction": "^1.2.2",
                 "postcss": "^7.0.2",
                 "postcss-value-parser": "^3.2.3"
-            },
-            "dependencies": {
-                "postcss": {
-                    "version": "7.0.2",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
-                    "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
-                    }
-                }
             }
         },
         "awesome-typescript-loader": {
@@ -2985,14 +2939,14 @@
             }
         },
         "browserslist": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.1.tgz",
-            "integrity": "sha512-QqiiIWchEIkney3wY53/huI7ZErouNAdvOkjorUALAwRcu3tEwOV3Sh6He0DnP38mz1JjBpCBb50jQBmaYuHPw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.2.tgz",
+            "integrity": "sha512-lpujC4zv1trcKUUwfD4pFVNga4YSpB3sLB+/I+A8gvGQxno1c0dMB2aCQy0FE5oUNIDjD9puFiFF0zeS6Ji48w==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30000865",
-                "electron-to-chromium": "^1.3.52",
-                "node-releases": "^1.0.0-alpha.10"
+                "caniuse-lite": "^1.0.30000876",
+                "electron-to-chromium": "^1.3.57",
+                "node-releases": "^1.0.0-alpha.11"
             }
         },
         "buffer": {
@@ -3181,7 +3135,7 @@
         },
         "caller-id": {
             "version": "0.1.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/caller-id/-/caller-id-0.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/caller-id/-/caller-id-0.1.0.tgz",
             "integrity": "sha1-Wb2sCJPRLDhxQIJ5Ix+XRYNk8Hs=",
             "dev": true,
             "requires": {
@@ -3205,7 +3159,7 @@
         },
         "callsites": {
             "version": "0.2.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/callsites/-/callsites-0.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
             "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
             "dev": true
         },
@@ -3237,9 +3191,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30000874",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000874.tgz",
-            "integrity": "sha512-29nr1EPiHwrJTAHHsEmTt2h+55L8j2GNFdAcYPlRy2NX6iFz7ZZiepVI7kP/QqlnHLq3KvfWpbmGa0d063U09w==",
+            "version": "1.0.30000877",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000877.tgz",
+            "integrity": "sha512-h04kV/lcuhItU1CZTJOxUEk/9R+1XeJqgc67E+XC8J9TjPM8kzVgOn27ZtRdDUo8O5F8U4QRCzDWJrVym3w3Cg==",
             "dev": true
         },
         "canonical-path": {
@@ -3379,9 +3333,9 @@
             }
         },
         "ci-info": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
-            "integrity": "sha512-SK/846h/Rcy8q9Z9CAwGBLfCJ6EkjJWdpelWDufQpqVDYq2Wnnv8zlSO6AMQap02jvhVruKKpEtQOufo3pFhLg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.3.0.tgz",
+            "integrity": "sha512-mPdvoljUhH3Feai3dakD3bwYl/8I0tSo16Ge2W+tY88yfYDKGVnXV2vFxZC8VGME01CYp+DaAZnE93VHYVapnA==",
             "dev": true
         },
         "cipher-base": {
@@ -3430,20 +3384,12 @@
             }
         },
         "clean-css": {
-            "version": "4.1.11",
-            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
-            "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.1.tgz",
+            "integrity": "sha512-4ZxI6dy4lrY6FHzfiy1aEOXgu4LIsW2MhwG0VBKdcoGoH/XLFgaHSdLTGr4O8Be6A8r3MOphEiI8Gc1n0ecf3g==",
             "dev": true,
             "requires": {
-                "source-map": "0.5.x"
-            },
-            "dependencies": {
-                "source-map": {
-                    "version": "0.5.7",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                    "dev": true
-                }
+                "source-map": "~0.6.0"
             }
         },
         "cli-cursor": {
@@ -3614,9 +3560,9 @@
             "dev": true
         },
         "colors": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+            "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
             "dev": true
         },
         "combine-lists": {
@@ -4324,6 +4270,7 @@
             "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "boom": "2.x.x"
             }
@@ -4398,6 +4345,12 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
             "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+            "dev": true
+        },
+        "cssesc": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-1.0.1.tgz",
+            "integrity": "sha512-S2hzrpWvE6G/rW7i7IxJfWBYn27QWfOIncUW++8Rbo1VB5zsJDSVPcnI+Q8z7rhxT6/yZeLOCja4cZnghJrNGA==",
             "dev": true
         },
         "cssom": {
@@ -4602,13 +4555,12 @@
             }
         },
         "define-properties": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-            "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
+            "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
             "dev": true,
             "requires": {
-                "foreach": "^2.0.5",
-                "object-keys": "^1.0.8"
+                "object-keys": "^1.0.12"
             }
         },
         "define-property": {
@@ -4741,9 +4693,9 @@
             "dev": true
         },
         "dependency-graph": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.4.1.tgz",
-            "integrity": "sha1-MC5YIY2FxRqXY4cw2/m32FKhlpM=",
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/dependency-graph/-/dependency-graph-0.7.1.tgz",
+            "integrity": "sha512-2s2uojwu7aq0K94DwrnJwo/mTkGiPqy2cU7z5BVXmhb564WgITZR3ruZMUIJ8Ymb5ruew244odZCR23/lZoxXg==",
             "dev": true
         },
         "dependency-tree": {
@@ -4982,34 +4934,20 @@
             }
         },
         "dgeni": {
-            "version": "0.4.9",
-            "resolved": "https://registry.npmjs.org/dgeni/-/dgeni-0.4.9.tgz",
-            "integrity": "sha1-nkJ3WxOGyl64JHU6ws0WnY9hztE=",
+            "version": "0.4.10",
+            "resolved": "https://registry.npmjs.org/dgeni/-/dgeni-0.4.10.tgz",
+            "integrity": "sha512-In8huU+6W+Rd7MdfzhQoRbntF4AsJgtbwRUTyfPgvhaC3RGJX/YOEkMnn7vLLk3zaCrEkIQGW6eADoudpnBceg==",
             "dev": true,
             "requires": {
                 "canonical-path": "~0.0.2",
-                "dependency-graph": "~0.4.1",
+                "dependency-graph": "^0.7.0",
                 "di": "0.0.1",
-                "lodash": "^3.10.1",
+                "lodash": "^4.17.10",
                 "objectdiff": "^1.1.0",
                 "optimist": "~0.6.1",
-                "q": "~1.4.1",
-                "validate.js": "^0.9.0",
+                "q": "^1.5.1",
+                "validate.js": "^0.12.0",
                 "winston": "^2.1.1"
-            },
-            "dependencies": {
-                "lodash": {
-                    "version": "3.10.1",
-                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
-                    "dev": true
-                },
-                "q": {
-                    "version": "1.4.1",
-                    "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-                    "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
-                    "dev": true
-                }
             }
         },
         "dgeni-packages": {
@@ -5216,9 +5154,9 @@
             }
         },
         "domino": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/domino/-/domino-2.0.3.tgz",
-            "integrity": "sha512-QkW2THVtKJw9FmV6awFQbcpaJPIqQtF+F1PMO5EXIdULVit9IaU3w+ZQgBjrR6hSHgP97TKyo/tcFqkgwfYenA==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.0.tgz",
+            "integrity": "sha512-xINSODvrnuQcm3eXJN4IkBR+JxqLrJN8Ge4fd00y1b7HsY0A4huKN5BflSS/oo8quBWmocTfWdFvrw2H8TjGqQ==",
             "dev": true
         },
         "domutils": {
@@ -5342,9 +5280,9 @@
             "dev": true
         },
         "electron-to-chromium": {
-            "version": "1.3.55",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.55.tgz",
-            "integrity": "sha1-8VDhCyC3fZ1Br8yjEu/gw7Gn/c4=",
+            "version": "1.3.58",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.58.tgz",
+            "integrity": "sha512-AGJxlBEn2wOohxqWZkISVsOjZueKTQljfEODTDSEiMqSpH0S+xzV+/5oEM9AGaqhu7DzrpKOgU7ocQRjj0nJmg==",
             "dev": true
         },
         "elegant-spinner": {
@@ -5354,9 +5292,9 @@
             "dev": true
         },
         "elliptic": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
-            "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.1.tgz",
+            "integrity": "sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==",
             "dev": true,
             "requires": {
                 "bn.js": "^4.4.0",
@@ -5535,9 +5473,9 @@
             }
         },
         "es5-ext": {
-            "version": "0.10.45",
-            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
-            "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
+            "version": "0.10.46",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.46.tgz",
+            "integrity": "sha512-24XxRvJXNFwEMpJb3nOkiRJKRoupmjYmOPVlI65Qy2SrtxwOTB+g6ODjBKOtwEHbYrhWRty9xxOWLNdClT2djw==",
             "dev": true,
             "requires": {
                 "es6-iterator": "~2.0.3",
@@ -5564,7 +5502,7 @@
         },
         "es6-promisify": {
             "version": "5.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/es6-promisify/-/es6-promisify-5.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
             "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
             "dev": true,
             "requires": {
@@ -5987,9 +5925,9 @@
             }
         },
         "external-editor": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.0.tgz",
-            "integrity": "sha512-mpkfj0FEdxrIhOC04zk85X7StNtr0yXnG7zCb+8ikO8OJi2jsHh5YGoknNTyXgsbHOf1WOOcVU3kPFWT2WgCkQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.1.tgz",
+            "integrity": "sha512-e1neqvSt5pSwQcFnYc6yfGuJD2Q4336cdbHs5VeUO0zTkqPbrHMyw2q1r47fpfLWbvIG8H8A6YO3sck7upTV6Q==",
             "dev": true,
             "requires": {
                 "chardet": "^0.5.0",
@@ -6030,9 +5968,9 @@
             }
         },
         "fast-deep-equal": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-            "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
             "dev": true
         },
         "fast-glob": {
@@ -6449,23 +6387,6 @@
                     "requires": {
                         "ms": "2.0.0"
                     }
-                },
-                "enhanced-resolve": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-                    "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "memory-fs": "^0.4.0",
-                        "tapable": "^1.0.0"
-                    }
-                },
-                "tapable": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
-                    "integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==",
-                    "dev": true
                 }
             }
         },
@@ -6911,9 +6832,9 @@
             }
         },
         "follow-redirects": {
-            "version": "1.5.2",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.2.tgz",
-            "integrity": "sha512-kssLorP/9acIdpQ2udQVTiCS5LQmdEz9mvdIfDcl1gYX2tPKFADHSyFdvJS040XdFsPzemWtgI3q8mFVCxtX8A==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.5.tgz",
+            "integrity": "sha512-GHjtHDlY/ehslqv0Gr5N0PUJppgg/q0rOBvX0na1s7y1A3LWxPqCYU76s3Z1bM4+UZB4QF0usaXLT5wFpof5PA==",
             "dev": true,
             "requires": {
                 "debug": "^3.1.0"
@@ -6944,12 +6865,6 @@
             "requires": {
                 "for-in": "^1.0.1"
             }
-        },
-        "foreach": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-            "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
-            "dev": true
         },
         "forever-agent": {
             "version": "0.6.1",
@@ -8405,12 +8320,12 @@
             }
         },
         "gulp-clean-css": {
-            "version": "3.9.4",
-            "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-3.9.4.tgz",
-            "integrity": "sha512-jsbAj65WM08H1jCFOKpIvA1OlACk7OHS2FFTeeBZrSJ5OR1PJzAqi0I2R2LTWYN3oMd/N1JYN9cN2IS/8eYqdg==",
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/gulp-clean-css/-/gulp-clean-css-3.10.0.tgz",
+            "integrity": "sha512-7Isf9Y690o/Q5MVjEylH1H7L8WeZ89woW7DnhD5unTintOdZb67KdOayRgp9trUFo+f9UyJtuatV42e/+kghPg==",
             "dev": true,
             "requires": {
-                "clean-css": "4.1.11",
+                "clean-css": "4.2.1",
                 "plugin-error": "1.0.1",
                 "through2": "2.0.3",
                 "vinyl-sourcemaps-apply": "0.2.1"
@@ -8631,239 +8546,8 @@
             "dependencies": {
                 "arr-diff": {
                     "version": "4.0.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
                     "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-                    "dev": true
-                },
-                "conventional-changelog": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog/-/conventional-changelog-2.0.1.tgz",
-                    "integrity": "sha512-WeWcEcR7uBtRZ/uG6DRIlVqsm7UTnxrixaAPoPvfQP7FRPf1qIXL76nGKy4wXq+wO3zOpqYubWUqrYLIL3+xww==",
-                    "dev": true,
-                    "requires": {
-                        "conventional-changelog-angular": "^1.6.6",
-                        "conventional-changelog-atom": "^2.0.0",
-                        "conventional-changelog-codemirror": "^2.0.0",
-                        "conventional-changelog-core": "^3.0.0",
-                        "conventional-changelog-ember": "^2.0.0",
-                        "conventional-changelog-eslint": "^3.0.0",
-                        "conventional-changelog-express": "^2.0.0",
-                        "conventional-changelog-jquery": "^0.1.0",
-                        "conventional-changelog-jscs": "^0.1.0",
-                        "conventional-changelog-jshint": "^2.0.0",
-                        "conventional-changelog-preset-loader": "^2.0.0"
-                    }
-                },
-                "conventional-changelog-atom": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog-atom/-/conventional-changelog-atom-2.0.0.tgz",
-                    "integrity": "sha512-ygwkwyTQYAm4S0tsDt+1yg8tHhRrv7qu9SOWPhNQlVrInFLsfKc0FActCA3de2ChknxpVPY2B53yhKvCAtkBCg==",
-                    "dev": true,
-                    "requires": {
-                        "q": "^1.5.1"
-                    }
-                },
-                "conventional-changelog-codemirror": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog-codemirror/-/conventional-changelog-codemirror-2.0.0.tgz",
-                    "integrity": "sha512-pZt/YynJ5m8C9MGV5wkBuhM1eX+8a84fmNrdOylxg/lJV+lgtAiNhnpskNuixtf71iKVWSlEqMQ6z6CH7/Uo5A==",
-                    "dev": true,
-                    "requires": {
-                        "q": "^1.5.1"
-                    }
-                },
-                "conventional-changelog-core": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog-core/-/conventional-changelog-core-3.0.0.tgz",
-                    "integrity": "sha512-D2hApWWsdh4tkNgDjn1KtRapxUJ70Sd+V84btTVJJJ96S3cVRES8Ty3ih0TRkOZmDkw/uS0mxrHSskQ/P/Gvsg==",
-                    "dev": true,
-                    "requires": {
-                        "conventional-changelog-writer": "^4.0.0",
-                        "conventional-commits-parser": "^3.0.0",
-                        "dateformat": "^3.0.0",
-                        "get-pkg-repo": "^1.0.0",
-                        "git-raw-commits": "^2.0.0",
-                        "git-remote-origin-url": "^2.0.0",
-                        "git-semver-tags": "^2.0.0",
-                        "lodash": "^4.2.1",
-                        "normalize-package-data": "^2.3.5",
-                        "q": "^1.5.1",
-                        "read-pkg": "^1.1.0",
-                        "read-pkg-up": "^1.0.1",
-                        "through2": "^2.0.0"
-                    }
-                },
-                "conventional-changelog-ember": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog-ember/-/conventional-changelog-ember-2.0.0.tgz",
-                    "integrity": "sha512-s9ZYf3VMdYe8ca8bw1X+he050HZNy9Pm3dBpYA+BunDGFE4Fy7whOvYhWah2U9+j9l6y/whfa0+eHANvZytE9A==",
-                    "dev": true,
-                    "requires": {
-                        "q": "^1.5.1"
-                    }
-                },
-                "conventional-changelog-eslint": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog-eslint/-/conventional-changelog-eslint-3.0.0.tgz",
-                    "integrity": "sha512-Acn20v+13c+o1OAWKvc9sCCl73Nj2vOMyn+G82euiMZwgYNE9CcBkTnw/GKdBi9KiZMK9uy+SCQ/QyAEE+8vZA==",
-                    "dev": true,
-                    "requires": {
-                        "q": "^1.5.1"
-                    }
-                },
-                "conventional-changelog-express": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog-express/-/conventional-changelog-express-2.0.0.tgz",
-                    "integrity": "sha512-2svPjeXCrjwwqnzu/f3qU5LWoLO0jmUIEbtbbSRXAAP9Ag+137b484eJsiRt9DPYXSVzog0Eoek3rvCzfHcphQ==",
-                    "dev": true,
-                    "requires": {
-                        "q": "^1.5.1"
-                    }
-                },
-                "conventional-changelog-jshint": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog-jshint/-/conventional-changelog-jshint-2.0.0.tgz",
-                    "integrity": "sha512-+4fCln755N0ZzRUEdcDWR5Due71Dsqkbov6K/UmVCnljZvhVh0/wpT4YROoSsAnhfZO8shyWDPFKm6EP20pLQg==",
-                    "dev": true,
-                    "requires": {
-                        "compare-func": "^1.3.1",
-                        "q": "^1.5.1"
-                    }
-                },
-                "conventional-changelog-preset-loader": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog-preset-loader/-/conventional-changelog-preset-loader-2.0.0.tgz",
-                    "integrity": "sha512-hEWm9o6TxjS9aO1AKaHpl8avSXaUHiUXBT25vJ4ToaDi/gPDqt3OnZkwhIgubADUF+lPqcXpjFTOYcOL4AwyvA==",
-                    "dev": true
-                },
-                "conventional-changelog-writer": {
-                    "version": "4.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.0.tgz",
-                    "integrity": "sha512-hMZPe0AQ6Bi05epeK/7hz80xxk59nPA5z/b63TOHq2wigM0/akreOc8N4Jam5b9nFgKWX1e9PdPv2ewgW6bcfg==",
-                    "dev": true,
-                    "requires": {
-                        "compare-func": "^1.3.1",
-                        "conventional-commits-filter": "^2.0.0",
-                        "dateformat": "^3.0.0",
-                        "handlebars": "^4.0.2",
-                        "json-stringify-safe": "^5.0.1",
-                        "lodash": "^4.2.1",
-                        "meow": "^4.0.0",
-                        "semver": "^5.5.0",
-                        "split": "^1.0.0",
-                        "through2": "^2.0.0"
-                    }
-                },
-                "conventional-commits-filter": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-2.0.0.tgz",
-                    "integrity": "sha512-Cfl0j1/NquB/TMVx7Wrmyq7uRM+/rPQbtVVGwzfkhZ6/yH6fcMmP0Q/9044TBZPTNdGzm46vXFXL14wbET0/Mg==",
-                    "dev": true,
-                    "requires": {
-                        "is-subset": "^0.1.1",
-                        "modify-values": "^1.0.0"
-                    }
-                },
-                "conventional-commits-parser": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.0.0.tgz",
-                    "integrity": "sha512-GWh71U26BLWgMykCp+VghZ4s64wVbtseECcKQ/PvcPZR2cUnz+FUc2J9KjxNl7/ZbCxST8R03c9fc+Vi0umS9Q==",
-                    "dev": true,
-                    "requires": {
-                        "JSONStream": "^1.0.4",
-                        "is-text-path": "^1.0.0",
-                        "lodash": "^4.2.1",
-                        "meow": "^4.0.0",
-                        "split2": "^2.0.0",
-                        "through2": "^2.0.0",
-                        "trim-off-newlines": "^1.0.0"
-                    }
-                },
-                "git-raw-commits": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.0.tgz",
-                    "integrity": "sha512-w4jFEJFgKXMQJ0H0ikBk2S+4KP2VEjhCvLCNqbNRQC8BgGWgLKNCO7a9K9LI+TVT7Gfoloje502sEnctibffgg==",
-                    "dev": true,
-                    "requires": {
-                        "dargs": "^4.0.1",
-                        "lodash.template": "^4.0.2",
-                        "meow": "^4.0.0",
-                        "split2": "^2.0.0",
-                        "through2": "^2.0.0"
-                    }
-                },
-                "git-semver-tags": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/git-semver-tags/-/git-semver-tags-2.0.0.tgz",
-                    "integrity": "sha512-lSgFc3zQTul31nFje2Q8XdNcTOI6B4I3mJRPCgFzHQQLfxfqdWTYzdtCaynkK5Xmb2wQlSJoKolhXJ1VhKROnQ==",
-                    "dev": true,
-                    "requires": {
-                        "meow": "^4.0.0",
-                        "semver": "^5.5.0"
-                    }
-                },
-                "meow": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.1.tgz",
-                    "integrity": "sha512-xcSBHD5Z86zaOc+781KrupuHAzeGXSLtiAOmBsiLDiPSaYSB6hdew2ng9EBAnZ62jagG9MHAOdxpDi/lWBFJ/A==",
-                    "dev": true,
-                    "requires": {
-                        "camelcase-keys": "^4.0.0",
-                        "decamelize-keys": "^1.0.0",
-                        "loud-rejection": "^1.0.0",
-                        "minimist": "^1.1.3",
-                        "minimist-options": "^3.0.1",
-                        "normalize-package-data": "^2.3.4",
-                        "read-pkg-up": "^3.0.0",
-                        "redent": "^2.0.0",
-                        "trim-newlines": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "read-pkg": {
-                            "version": "3.0.0",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/read-pkg/-/read-pkg-3.0.0.tgz",
-                            "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-                            "dev": true,
-                            "requires": {
-                                "load-json-file": "^4.0.0",
-                                "normalize-package-data": "^2.3.2",
-                                "path-type": "^3.0.0"
-                            }
-                        },
-                        "read-pkg-up": {
-                            "version": "3.0.0",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
-                            "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
-                            "dev": true,
-                            "requires": {
-                                "find-up": "^2.0.0",
-                                "read-pkg": "^3.0.0"
-                            }
-                        }
-                    }
-                },
-                "parse-json": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                    "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-                    "dev": true,
-                    "requires": {
-                        "error-ex": "^1.2.0"
-                    }
-                },
-                "path-exists": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
-                    "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-                    "dev": true,
-                    "requires": {
-                        "pinkie-promise": "^2.0.0"
-                    }
-                },
-                "pify": {
-                    "version": "2.3.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-                    "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 },
                 "plugin-error": {
@@ -8876,74 +8560,6 @@
                         "arr-diff": "^4.0.0",
                         "arr-union": "^3.1.0",
                         "extend-shallow": "^3.0.2"
-                    }
-                },
-                "read-pkg": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                    "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-                    "dev": true,
-                    "requires": {
-                        "load-json-file": "^1.0.0",
-                        "normalize-package-data": "^2.3.2",
-                        "path-type": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "load-json-file": {
-                            "version": "1.1.0",
-                            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-                            "dev": true,
-                            "requires": {
-                                "graceful-fs": "^4.1.2",
-                                "parse-json": "^2.2.0",
-                                "pify": "^2.0.0",
-                                "pinkie-promise": "^2.0.0",
-                                "strip-bom": "^2.0.0"
-                            }
-                        },
-                        "path-type": {
-                            "version": "1.1.0",
-                            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-                            "dev": true,
-                            "requires": {
-                                "graceful-fs": "^4.1.2",
-                                "pify": "^2.0.0",
-                                "pinkie-promise": "^2.0.0"
-                            }
-                        }
-                    }
-                },
-                "read-pkg-up": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                    "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-                    "dev": true,
-                    "requires": {
-                        "find-up": "^1.0.0",
-                        "read-pkg": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "find-up": {
-                            "version": "1.1.2",
-                            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-                            "dev": true,
-                            "requires": {
-                                "path-exists": "^2.0.0",
-                                "pinkie-promise": "^2.0.0"
-                            }
-                        }
-                    }
-                },
-                "strip-bom": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                    "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-                    "dev": true,
-                    "requires": {
-                        "is-utf8": "^0.2.0"
                     }
                 }
             }
@@ -9488,27 +9104,6 @@
                     "requires": {
                         "amdefine": ">=0.0.4"
                     }
-                },
-                "uglify-js": {
-                    "version": "2.8.29",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
-                    "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "source-map": "~0.5.1",
-                        "uglify-to-browserify": "~1.0.0",
-                        "yargs": "~3.10.0"
-                    },
-                    "dependencies": {
-                        "source-map": {
-                            "version": "0.5.7",
-                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-                            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
                 }
             }
         },
@@ -9519,12 +9114,12 @@
             "dev": true
         },
         "har-validator": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
+            "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
             "dev": true,
             "requires": {
-                "ajv": "^5.1.0",
+                "ajv": "^5.3.0",
                 "har-schema": "^2.0.0"
             },
             "dependencies": {
@@ -9539,18 +9134,6 @@
                         "fast-json-stable-stringify": "^2.0.0",
                         "json-schema-traverse": "^0.3.0"
                     }
-                },
-                "fast-deep-equal": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-                    "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
-                    "dev": true
-                },
-                "json-schema-traverse": {
-                    "version": "0.3.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-                    "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
-                    "dev": true
                 }
             }
         },
@@ -9684,7 +9267,7 @@
         },
         "hash-base": {
             "version": "3.0.4",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/hash-base/-/hash-base-3.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "dev": true,
             "requires": {
@@ -9707,6 +9290,7 @@
             "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "boom": "2.x.x",
                 "cryptiles": "2.x.x",
@@ -9821,20 +9405,43 @@
                 "uglify-js": "3.4.x"
             },
             "dependencies": {
+                "clean-css": {
+                    "version": "4.1.11",
+                    "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.1.11.tgz",
+                    "integrity": "sha1-Ls3xRaujj1R0DybO/Q/z4D4SXWo=",
+                    "dev": true,
+                    "requires": {
+                        "source-map": "0.5.x"
+                    }
+                },
                 "commander": {
                     "version": "2.16.0",
                     "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
                     "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
                     "dev": true
                 },
+                "source-map": {
+                    "version": "0.5.7",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+                    "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+                    "dev": true
+                },
                 "uglify-js": {
-                    "version": "3.4.6",
-                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.6.tgz",
-                    "integrity": "sha512-O1D7L6WcOzS1qW2ehopEm4cWm5yA6bQBozlks8jO8ODxYCy4zv+bR/la4Lwp01tpkYGNonnpXvUpYtrvSu8Yzg==",
+                    "version": "3.4.7",
+                    "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.7.tgz",
+                    "integrity": "sha512-J0M2i1mQA+ze3EdN9SBi751DNdAXmeFLfJrd/MDIkRc3G3Gbb9OPVSx7GIQvVwfWxQARcYV2DTxIkMyDAk3o9Q==",
                     "dev": true,
                     "requires": {
                         "commander": "~2.16.0",
                         "source-map": "~0.6.1"
+                    },
+                    "dependencies": {
+                        "source-map": {
+                            "version": "0.6.1",
+                            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+                            "dev": true
+                        }
                     }
                 }
             }
@@ -10256,7 +9863,7 @@
             "dependencies": {
                 "underscore": {
                     "version": "1.7.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/underscore/-/underscore-1.7.0.tgz",
+                    "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
                     "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=",
                     "dev": true
                 }
@@ -10343,7 +9950,7 @@
         },
         "import-cwd": {
             "version": "2.1.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/import-cwd/-/import-cwd-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/import-cwd/-/import-cwd-2.1.0.tgz",
             "integrity": "sha1-qmzzbnInYShcs3HsZRn1PiQ1sKk=",
             "dev": true,
             "requires": {
@@ -10352,7 +9959,7 @@
         },
         "import-from": {
             "version": "2.1.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/import-from/-/import-from-2.1.0.tgz",
+            "resolved": "https://registry.npmjs.org/import-from/-/import-from-2.1.0.tgz",
             "integrity": "sha1-M1238qev/VOqpHHUuAId7ja387E=",
             "dev": true,
             "requires": {
@@ -10361,7 +9968,7 @@
             "dependencies": {
                 "resolve-from": {
                     "version": "3.0.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/resolve-from/-/resolve-from-3.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
                     "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
                     "dev": true
                 }
@@ -10415,7 +10022,7 @@
         },
         "inflection": {
             "version": "1.12.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/inflection/-/inflection-1.12.0.tgz",
+            "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.12.0.tgz",
             "integrity": "sha1-ogCTVlbW9fa8TcdQLhrstwMihBY=",
             "dev": true,
             "optional": true
@@ -10741,7 +10348,7 @@
         },
         "ip": {
             "version": "1.1.5",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/ip/-/ip-1.1.5.tgz",
+            "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
             "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=",
             "dev": true
         },
@@ -10966,9 +10573,9 @@
             "optional": true
         },
         "is-my-json-valid": {
-            "version": "2.17.2",
-            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.2.tgz",
-            "integrity": "sha512-IBhBslgngMQN8DDSppmgDv7RNrlFotuuDsKcrCP3+HbFaVivIBU7u9oiiErw8sH4ynx3+gOGQ3q2otkgiSi6kg==",
+            "version": "2.19.0",
+            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.19.0.tgz",
+            "integrity": "sha512-mG0f/unGX1HZ5ep4uhRaPOS8EkAY8/j6mDRMJrutq4CqhoJWYp7qAlonIPy3TV7p3ju4TK9fo/PbnoksWmsp5Q==",
             "dev": true,
             "optional": true,
             "requires": {
@@ -11352,15 +10959,15 @@
             "dev": true
         },
         "jest-validate": {
-            "version": "23.4.0",
-            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.4.0.tgz",
-            "integrity": "sha1-2W7t4B7wOskJwAnpyORVGX1IwgE=",
+            "version": "23.5.0",
+            "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-23.5.0.tgz",
+            "integrity": "sha512-XmStdYhfdiDKacXX5sNqEE61Zz4/yXaPcDsKvVA0429RBu2pkQyIltCVG7UitJIEAzSs3ociQTdyseAW8VGPiA==",
             "dev": true,
             "requires": {
                 "chalk": "^2.0.1",
                 "jest-get-type": "^22.1.0",
                 "leven": "^2.1.0",
-                "pretty-format": "^23.2.0"
+                "pretty-format": "^23.5.0"
             }
         },
         "js-base64": {
@@ -11433,19 +11040,10 @@
             "dev": true
         },
         "json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
             "dev": true
-        },
-        "json-stable-stringify": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-            "dev": true,
-            "requires": {
-                "jsonify": "~0.0.0"
-            }
         },
         "json-stringify-safe": {
             "version": "5.0.1",
@@ -11473,12 +11071,6 @@
             "requires": {
                 "graceful-fs": "^4.1.6"
             }
-        },
-        "jsonify": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-            "dev": true
         },
         "jsonparse": {
             "version": "1.3.1",
@@ -11552,13 +11144,13 @@
                 },
                 "arr-diff": {
                     "version": "4.0.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
                     "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
                     "dev": true
                 },
                 "array-unique": {
                     "version": "0.3.2",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/array-unique/-/array-unique-0.3.2.tgz",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
                     "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
                     "dev": true
                 },
@@ -11582,7 +11174,7 @@
                     "dependencies": {
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
@@ -11612,9 +11204,15 @@
                         "upath": "^1.0.5"
                     }
                 },
+                "colors": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
+                    "integrity": "sha512-jg/vxRmv430jixZrC+La5kMbUWqIg32/JsYNZb94+JEmzceYbWKTsv1OuTp+7EaqiaWRR2tPcykibwCRgclIsw==",
+                    "dev": true
+                },
                 "expand-brackets": {
                     "version": "2.1.4",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "requires": {
@@ -11629,7 +11227,7 @@
                     "dependencies": {
                         "define-property": {
                             "version": "0.2.5",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/define-property/-/define-property-0.2.5.tgz",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "requires": {
@@ -11638,7 +11236,7 @@
                         },
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
@@ -11722,7 +11320,7 @@
                     "dependencies": {
                         "define-property": {
                             "version": "1.0.0",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/define-property/-/define-property-1.0.0.tgz",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "requires": {
@@ -11731,7 +11329,7 @@
                         },
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
@@ -11742,7 +11340,7 @@
                 },
                 "fill-range": {
                     "version": "4.0.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/fill-range/-/fill-range-4.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
@@ -11754,7 +11352,7 @@
                     "dependencies": {
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
@@ -11765,7 +11363,7 @@
                 },
                 "glob-parent": {
                     "version": "3.1.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "requires": {
@@ -11775,7 +11373,7 @@
                     "dependencies": {
                         "is-glob": {
                             "version": "3.1.0",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-glob/-/is-glob-3.1.0.tgz",
+                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "requires": {
@@ -11815,13 +11413,13 @@
                 },
                 "is-extglob": {
                     "version": "2.1.1",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-extglob/-/is-extglob-2.1.1.tgz",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
                     "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
                     "dev": true
                 },
                 "is-glob": {
                     "version": "4.0.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-glob/-/is-glob-4.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "requires": {
@@ -11830,7 +11428,7 @@
                 },
                 "is-number": {
                     "version": "3.0.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-number/-/is-number-3.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
@@ -11839,7 +11437,7 @@
                     "dependencies": {
                         "kind-of": {
                             "version": "3.2.2",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/kind-of/-/kind-of-3.2.2.tgz",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
@@ -11850,7 +11448,7 @@
                 },
                 "isobject": {
                     "version": "3.0.1",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/isobject/-/isobject-3.0.1.tgz",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
                     "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
                     "dev": true
                 },
@@ -12100,7 +11698,7 @@
         },
         "karma-junit-reporter": {
             "version": "1.2.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/karma-junit-reporter/-/karma-junit-reporter-1.2.0.tgz",
+            "resolved": "https://registry.npmjs.org/karma-junit-reporter/-/karma-junit-reporter-1.2.0.tgz",
             "integrity": "sha1-T5xAzt+xo5X4rvh2q/lhiZF8Y5Y=",
             "dev": true,
             "requires": {
@@ -12145,6 +11743,14 @@
             "dev": true,
             "requires": {
                 "colors": "^1.1.2"
+            },
+            "dependencies": {
+                "colors": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.1.tgz",
+                    "integrity": "sha512-jg/vxRmv430jixZrC+La5kMbUWqIg32/JsYNZb94+JEmzceYbWKTsv1OuTp+7EaqiaWRR2tPcykibwCRgclIsw==",
+                    "dev": true
+                }
             }
         },
         "killable": {
@@ -12366,12 +11972,11 @@
             }
         },
         "lint-staged": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-7.2.0.tgz",
-            "integrity": "sha512-jPoIMbmgtWMUrz/l0rhBVa1j6H71zr0rEoxDWBA333PZcaqBvELdg0Sf4tdGHlwrBM0GXaXMVgTRkLTm2vA7Jg==",
+            "version": "7.2.2",
+            "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-7.2.2.tgz",
+            "integrity": "sha512-BWT3kx242hq5oaKJ8QiazPeHwJnEXImvjmgZfjljMI5HX6RrTxI3cTJXywre6GNafMONCD/suFnEiFmC69Gscg==",
             "dev": true,
             "requires": {
-                "app-root-path": "^2.0.1",
                 "chalk": "^2.3.1",
                 "commander": "^2.14.1",
                 "cosmiconfig": "^5.0.2",
@@ -12381,7 +11986,7 @@
                 "find-parent-dir": "^0.3.0",
                 "is-glob": "^4.0.0",
                 "is-windows": "^1.0.2",
-                "jest-validate": "^23.0.0",
+                "jest-validate": "^23.5.0",
                 "listr": "^0.14.1",
                 "lodash": "^4.17.5",
                 "log-symbols": "^2.2.0",
@@ -12438,9 +12043,9 @@
                     }
                 },
                 "cosmiconfig": {
-                    "version": "5.0.5",
-                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.5.tgz",
-                    "integrity": "sha512-94j37OtvxS5w7qr7Ta6dt67tWdnOxigBVN4VnSxNXFez9o18PGQ0D33SchKP17r9LAcWVTYV72G6vDayAUBFIg==",
+                    "version": "5.0.6",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
+                    "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
                     "dev": true,
                     "requires": {
                         "is-directory": "^0.3.1",
@@ -13038,7 +12643,7 @@
         },
         "lodash.debounce": {
             "version": "4.0.8",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+            "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
             "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
             "dev": true
         },
@@ -13317,6 +12922,13 @@
                     "version": "1.4.8",
                     "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
                     "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc=",
+                    "dev": true,
+                    "optional": true
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                    "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
                     "dev": true,
                     "optional": true
                 },
@@ -14266,7 +13878,7 @@
         },
         "mock-require": {
             "version": "2.0.2",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/mock-require/-/mock-require-2.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/mock-require/-/mock-require-2.0.2.tgz",
             "integrity": "sha1-HqpxqtIwE3c9En3H6Ro/u0g31g0=",
             "dev": true,
             "requires": {
@@ -14429,9 +14041,9 @@
             "dev": true
         },
         "neo-async": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.1.tgz",
-            "integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==",
+            "version": "2.5.2",
+            "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.5.2.tgz",
+            "integrity": "sha512-vdqTKI9GBIYcAEbFAcpKPErKINfPF5zIuz3/niBfq8WUZjpT2tytLlFVrBgWdOtqI4uaA/Rb6No0hux39XXDuw==",
             "dev": true
         },
         "netmask": {
@@ -14469,9 +14081,9 @@
             "dev": true
         },
         "node-gyp": {
-            "version": "3.7.0",
-            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.7.0.tgz",
-            "integrity": "sha512-qDQE/Ft9xXP6zphwx4sD0t+VhwV7yFaloMpfbL2QnnDZcyaiakWlLdtFGGQfTAwpFHdpbRhRxVhIHN1OKAjgbg==",
+            "version": "3.8.0",
+            "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-3.8.0.tgz",
+            "integrity": "sha512-3g8lYefrRRzvGeSowdJKAKyks8oUpLEd/DyPV4eMhVlhJ0aNaZqIrNUIPuEWWTAoPqyFkfGrM67MC69baqn6vA==",
             "dev": true,
             "requires": {
                 "fstream": "^1.0.0",
@@ -14481,135 +14093,18 @@
                 "nopt": "2 || 3",
                 "npmlog": "0 || 1 || 2 || 3 || 4",
                 "osenv": "0",
-                "request": ">=2.9.0 <2.82.0",
+                "request": "^2.87.0",
                 "rimraf": "2",
                 "semver": "~5.3.0",
                 "tar": "^2.0.0",
                 "which": "1"
             },
             "dependencies": {
-                "ajv": {
-                    "version": "4.11.8",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                    "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-                    "dev": true,
-                    "requires": {
-                        "co": "^4.6.0",
-                        "json-stable-stringify": "^1.0.1"
-                    }
-                },
-                "assert-plus": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-                    "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-                    "dev": true
-                },
-                "aws-sign2": {
-                    "version": "0.6.0",
-                    "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-                    "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-                    "dev": true
-                },
-                "form-data": {
-                    "version": "2.1.4",
-                    "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-                    "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-                    "dev": true,
-                    "requires": {
-                        "asynckit": "^0.4.0",
-                        "combined-stream": "^1.0.5",
-                        "mime-types": "^2.1.12"
-                    }
-                },
-                "har-schema": {
-                    "version": "1.0.5",
-                    "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-                    "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-                    "dev": true
-                },
-                "har-validator": {
-                    "version": "4.2.1",
-                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-                    "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-                    "dev": true,
-                    "requires": {
-                        "ajv": "^4.9.1",
-                        "har-schema": "^1.0.5"
-                    }
-                },
-                "http-signature": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-                    "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-                    "dev": true,
-                    "requires": {
-                        "assert-plus": "^0.2.0",
-                        "jsprim": "^1.2.2",
-                        "sshpk": "^1.7.0"
-                    }
-                },
-                "performance-now": {
-                    "version": "0.2.0",
-                    "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-                    "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-                    "dev": true
-                },
-                "punycode": {
-                    "version": "1.4.1",
-                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                    "dev": true
-                },
-                "qs": {
-                    "version": "6.4.0",
-                    "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-                    "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-                    "dev": true
-                },
-                "request": {
-                    "version": "2.81.0",
-                    "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-                    "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-                    "dev": true,
-                    "requires": {
-                        "aws-sign2": "~0.6.0",
-                        "aws4": "^1.2.1",
-                        "caseless": "~0.12.0",
-                        "combined-stream": "~1.0.5",
-                        "extend": "~3.0.0",
-                        "forever-agent": "~0.6.1",
-                        "form-data": "~2.1.1",
-                        "har-validator": "~4.2.1",
-                        "hawk": "~3.1.3",
-                        "http-signature": "~1.1.0",
-                        "is-typedarray": "~1.0.0",
-                        "isstream": "~0.1.2",
-                        "json-stringify-safe": "~5.0.1",
-                        "mime-types": "~2.1.7",
-                        "oauth-sign": "~0.8.1",
-                        "performance-now": "^0.2.0",
-                        "qs": "~6.4.0",
-                        "safe-buffer": "^5.0.1",
-                        "stringstream": "~0.0.4",
-                        "tough-cookie": "~2.3.0",
-                        "tunnel-agent": "^0.6.0",
-                        "uuid": "^3.0.0"
-                    }
-                },
                 "semver": {
                     "version": "5.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
                     "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
                     "dev": true
-                },
-                "tough-cookie": {
-                    "version": "2.3.4",
-                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-                    "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-                    "dev": true,
-                    "requires": {
-                        "punycode": "^1.4.1"
-                    }
                 }
             }
         },
@@ -14670,18 +14165,18 @@
             }
         },
         "node-releases": {
-            "version": "1.0.0-alpha.10",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.10.tgz",
-            "integrity": "sha512-BSQrRgOfN6L/MoKIa7pRUc7dHvflCXMcqyTBvphixcSsgJTuUd24vAFONuNfVsuwTyz28S1HEc9XN6ZKylk4Hg==",
+            "version": "1.0.0-alpha.11",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.0.0-alpha.11.tgz",
+            "integrity": "sha512-CaViu+2FqTNYOYNihXa5uPS/zry92I3vPU4nCB6JB3OeZ2UGtOpF5gRwuN4+m3hbEcL47bOXyun1jX2iC+3uEQ==",
             "dev": true,
             "requires": {
                 "semver": "^5.3.0"
             }
         },
         "node-sass": {
-            "version": "4.9.2",
-            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.2.tgz",
-            "integrity": "sha512-LdxoJLZutx0aQXHtWIYwJKMj+9pTjneTcLWJgzf2XbGu0q5pRNqW5QvFCEdm3mc5rJOdru/mzln5d0EZLacf6g==",
+            "version": "4.9.3",
+            "resolved": "https://registry.npmjs.org/node-sass/-/node-sass-4.9.3.tgz",
+            "integrity": "sha512-XzXyGjO+84wxyH7fV6IwBOTrEBe2f0a6SBze9QWWYR/cL74AcQUks2AsqcCZenl/Fp/JVbuEaLpgrLtocwBUww==",
             "dev": true,
             "requires": {
                 "async-foreach": "^0.1.3",
@@ -14697,7 +14192,7 @@
                 "meow": "^3.7.0",
                 "mkdirp": "^0.5.1",
                 "nan": "^2.10.0",
-                "node-gyp": "^3.3.1",
+                "node-gyp": "^3.8.0",
                 "npmlog": "^4.0.0",
                 "request": "2.87.0",
                 "sass-graph": "^2.2.4",
@@ -14705,6 +14200,18 @@
                 "true-case-path": "^1.0.2"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                    "dev": true,
+                    "requires": {
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
+                    }
+                },
                 "ansi-styles": {
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
@@ -14776,6 +14283,16 @@
                         "minimatch": "~3.0.2"
                     }
                 },
+                "har-validator": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+                    "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^5.1.0",
+                        "har-schema": "^2.0.0"
+                    }
+                },
                 "indent-string": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
@@ -14822,6 +14339,12 @@
                         "trim-newlines": "^1.0.0"
                     }
                 },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                    "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+                    "dev": true
+                },
                 "parse-json": {
                     "version": "2.2.0",
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
@@ -14857,6 +14380,12 @@
                     "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
                     "dev": true
                 },
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
+                },
                 "read-pkg": {
                     "version": "1.1.0",
                     "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
@@ -14888,6 +14417,34 @@
                         "strip-indent": "^1.0.1"
                     }
                 },
+                "request": {
+                    "version": "2.87.0",
+                    "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+                    "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+                    "dev": true,
+                    "requires": {
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.6.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.1",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.1",
+                        "har-validator": "~5.0.3",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.17",
+                        "oauth-sign": "~0.8.2",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.1",
+                        "safe-buffer": "^5.1.1",
+                        "tough-cookie": "~2.3.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.1.0"
+                    }
+                },
                 "strip-bom": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
@@ -14911,6 +14468,15 @@
                     "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
                     "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
                     "dev": true
+                },
+                "tough-cookie": {
+                    "version": "2.3.4",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+                    "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+                    "dev": true,
+                    "requires": {
+                        "punycode": "^1.4.1"
+                    }
                 },
                 "trim-newlines": {
                     "version": "1.0.0",
@@ -15150,14 +14716,14 @@
                 },
                 "arr-diff": {
                     "version": "4.0.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/arr-diff/-/arr-diff-4.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
                     "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
                     "dev": true,
                     "optional": true
                 },
                 "array-unique": {
                     "version": "0.3.2",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/array-unique/-/array-unique-0.3.2.tgz",
+                    "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
                     "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
                     "dev": true
                 },
@@ -15181,7 +14747,7 @@
                     "dependencies": {
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
@@ -15231,7 +14797,7 @@
                 },
                 "expand-brackets": {
                     "version": "2.1.4",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/expand-brackets/-/expand-brackets-2.1.4.tgz",
+                    "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
                     "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
                     "dev": true,
                     "optional": true,
@@ -15247,7 +14813,7 @@
                     "dependencies": {
                         "define-property": {
                             "version": "0.2.5",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/define-property/-/define-property-0.2.5.tgz",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                             "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                             "dev": true,
                             "optional": true,
@@ -15257,7 +14823,7 @@
                         },
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "optional": true,
@@ -15349,7 +14915,7 @@
                     "dependencies": {
                         "define-property": {
                             "version": "1.0.0",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/define-property/-/define-property-1.0.0.tgz",
+                            "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                             "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                             "dev": true,
                             "optional": true,
@@ -15359,7 +14925,7 @@
                         },
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "optional": true,
@@ -15371,7 +14937,7 @@
                 },
                 "fill-range": {
                     "version": "4.0.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/fill-range/-/fill-range-4.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
                     "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
                     "dev": true,
                     "requires": {
@@ -15383,7 +14949,7 @@
                     "dependencies": {
                         "extend-shallow": {
                             "version": "2.0.1",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                             "dev": true,
                             "requires": {
@@ -15394,7 +14960,7 @@
                 },
                 "glob-parent": {
                     "version": "3.1.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
                     "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
                     "dev": true,
                     "optional": true,
@@ -15405,7 +14971,7 @@
                     "dependencies": {
                         "is-glob": {
                             "version": "3.1.0",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-glob/-/is-glob-3.1.0.tgz",
+                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
                             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                             "dev": true,
                             "optional": true,
@@ -15449,13 +15015,13 @@
                 },
                 "is-extglob": {
                     "version": "2.1.1",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-extglob/-/is-extglob-2.1.1.tgz",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
                     "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
                     "dev": true
                 },
                 "is-glob": {
                     "version": "4.0.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-glob/-/is-glob-4.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
                     "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
                     "dev": true,
                     "optional": true,
@@ -15465,7 +15031,7 @@
                 },
                 "is-number": {
                     "version": "3.0.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/is-number/-/is-number-3.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
@@ -15474,7 +15040,7 @@
                     "dependencies": {
                         "kind-of": {
                             "version": "3.2.2",
-                            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/kind-of/-/kind-of-3.2.2.tgz",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
@@ -15485,7 +15051,7 @@
                 },
                 "isobject": {
                     "version": "3.0.1",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/isobject/-/isobject-3.0.1.tgz",
+                    "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
                     "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
                     "dev": true
                 },
@@ -15547,9 +15113,9 @@
             "dev": true
         },
         "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
             "dev": true
         },
         "object-assign": {
@@ -15752,7 +15318,7 @@
         },
         "onetime": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+            "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
             "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
             "dev": true
         },
@@ -16396,15 +15962,32 @@
             "dev": true
         },
         "postcss": {
-            "version": "5.2.18",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
-            "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
+            "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
             "dev": true,
             "requires": {
-                "chalk": "^1.1.3",
-                "js-base64": "^2.1.9",
-                "source-map": "^0.5.6",
-                "supports-color": "^3.2.3"
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+            }
+        },
+        "postcss-html": {
+            "version": "0.31.0",
+            "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.31.0.tgz",
+            "integrity": "sha512-5orIml7dVf17OrHyO39BXMGlklKT884FvkB+gdCtGJ63b1AAeGF7NuXGC1HM83TI0Ip1gZyBowrPuXCOPqqerA==",
+            "dev": true,
+            "requires": {
+                "htmlparser2": "^3.9.2"
+            }
+        },
+        "postcss-less": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-2.0.0.tgz",
+            "integrity": "sha512-pPNsVnpCB13nBMOcl5GVh8JGmB0JGFjqkLUDzKdVpptFFKEe9wFdEzvh2j4lD2AD+7qcrUfw9Ta+oi5+Fw7jjQ==",
+            "dev": true,
+            "requires": {
+                "postcss": "^5.2.16"
             },
             "dependencies": {
                 "ansi-styles": {
@@ -16440,6 +16023,18 @@
                     "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
                     "dev": true
                 },
+                "postcss": {
+                    "version": "5.2.18",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-5.2.18.tgz",
+                    "integrity": "sha512-zrUjRRe1bpXKsX1qAJNJjqZViErVuyEkMTRrwu4ud4sbTtIBRmtaYDrHmcGgmrbsW3MHfmtIf+vJumgQn+PrXg==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^1.1.3",
+                        "js-base64": "^2.1.9",
+                        "source-map": "^0.5.6",
+                        "supports-color": "^3.2.3"
+                    }
+                },
                 "source-map": {
                     "version": "0.5.7",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -16455,24 +16050,6 @@
                         "has-flag": "^1.0.0"
                     }
                 }
-            }
-        },
-        "postcss-html": {
-            "version": "0.31.0",
-            "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.31.0.tgz",
-            "integrity": "sha512-5orIml7dVf17OrHyO39BXMGlklKT884FvkB+gdCtGJ63b1AAeGF7NuXGC1HM83TI0Ip1gZyBowrPuXCOPqqerA==",
-            "dev": true,
-            "requires": {
-                "htmlparser2": "^3.9.2"
-            }
-        },
-        "postcss-less": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-less/-/postcss-less-2.0.0.tgz",
-            "integrity": "sha512-pPNsVnpCB13nBMOcl5GVh8JGmB0JGFjqkLUDzKdVpptFFKEe9wFdEzvh2j4lD2AD+7qcrUfw9Ta+oi5+Fw7jjQ==",
-            "dev": true,
-            "requires": {
-                "postcss": "^5.2.16"
             }
         },
         "postcss-load-config": {
@@ -16575,19 +16152,6 @@
             "dev": true,
             "requires": {
                 "postcss": "^7.0.0"
-            },
-            "dependencies": {
-                "postcss": {
-                    "version": "7.0.2",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
-                    "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
-                    }
-                }
             }
         },
         "postcss-sass": {
@@ -16635,17 +16199,26 @@
             "dev": true,
             "requires": {
                 "postcss": "^7.0.0"
+            }
+        },
+        "postcss-selector-parser": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
+            "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+            "dev": true,
+            "requires": {
+                "dot-prop": "^4.1.1",
+                "indexes-of": "^1.0.1",
+                "uniq": "^1.0.1"
             },
             "dependencies": {
-                "postcss": {
-                    "version": "7.0.2",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
-                    "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
+                "dot-prop": {
+                    "version": "4.2.0",
+                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
+                    "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
                     "dev": true,
                     "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
+                        "is-obj": "^1.0.0"
                     }
                 }
             }
@@ -16730,9 +16303,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "1.14.0",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.0.tgz",
-            "integrity": "sha512-KtQ2EGaUwf2EyDfp1fxyEb0PqGKakVm0WyXwDt6u+cAoxbO2Z2CwKvOe3+b4+F2IlO9lYHi1kqFuRM70ddBnow==",
+            "version": "1.14.2",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.2.tgz",
+            "integrity": "sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==",
             "dev": true
         },
         "pretty-bytes": {
@@ -16752,9 +16325,9 @@
             }
         },
         "pretty-format": {
-            "version": "23.2.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/pretty-format/-/pretty-format-23.2.0.tgz",
-            "integrity": "sha1-OwqqY8AYpTWDNzwcs6XZbMXoMBc=",
+            "version": "23.5.0",
+            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-23.5.0.tgz",
+            "integrity": "sha512-iFLvYTXOn+C/s7eV+pr4E8DD7lYa2/klXMEz+lvH14qSDWAJ7S+kFmMe1SIWesATHQxopHTxRcB2nrpExhzaBA==",
             "dev": true,
             "requires": {
                 "ansi-regex": "^3.0.0",
@@ -16813,7 +16386,7 @@
         },
         "promisify-call": {
             "version": "2.0.4",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/promisify-call/-/promisify-call-2.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/promisify-call/-/promisify-call-2.0.4.tgz",
             "integrity": "sha1-1IwtRWUszM1SgB3ey9UzptS9X7o=",
             "dev": true,
             "optional": true,
@@ -16873,7 +16446,7 @@
         },
         "proxy-from-env": {
             "version": "1.0.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.0.0.tgz",
             "integrity": "sha1-M8UDmPcOp+uW0h97gXYwpVeRx+4=",
             "dev": true,
             "optional": true
@@ -16990,9 +16563,9 @@
             "dev": true
         },
         "randomatic": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
-            "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
+            "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
             "dev": true,
             "requires": {
                 "is-number": "^4.0.0",
@@ -17473,48 +17046,31 @@
             }
         },
         "request": {
-            "version": "2.87.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-            "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
             "dev": true,
             "requires": {
                 "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
+                "aws4": "^1.8.0",
                 "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
                 "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
                 "http-signature": "~1.2.0",
                 "is-typedarray": "~1.0.0",
                 "isstream": "~0.1.2",
                 "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
                 "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "tough-cookie": "~2.3.3",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
                 "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
-            },
-            "dependencies": {
-                "punycode": {
-                    "version": "1.4.1",
-                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-                    "dev": true
-                },
-                "tough-cookie": {
-                    "version": "2.3.4",
-                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-                    "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
-                    "dev": true,
-                    "requires": {
-                        "punycode": "^1.4.1"
-                    }
-                }
+                "uuid": "^3.3.2"
             }
         },
         "requestretry": {
@@ -18159,9 +17715,9 @@
             }
         },
         "scss-bundle": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/scss-bundle/-/scss-bundle-2.3.2.tgz",
-            "integrity": "sha512-Mp12Wa/PbTBY5E6zlN4Vq8ccK4Ex4WX9dvc8QP3BXzatfo9VvQijZIAsMQ4nT+vD0oM1I4m6Cy9twJWYr9oBew==",
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/scss-bundle/-/scss-bundle-2.3.3.tgz",
+            "integrity": "sha512-xRM6LwpPuFysvUjh3Oe3qvVwSsTuSpvIW/FGtA/xhUZZCnf3ATmLXy2JELFRt0y9/RaDnt+L90/JWc9A7yL1Ig==",
             "dev": true,
             "requires": {
                 "archy": "^1.0.0",
@@ -18192,7 +17748,7 @@
                 },
                 "cross-spawn": {
                     "version": "5.1.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
                     "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
                     "dev": true,
                     "requires": {
@@ -18203,7 +17759,7 @@
                 },
                 "execa": {
                     "version": "0.7.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/execa/-/execa-0.7.0.tgz",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
                     "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
                     "dev": true,
                     "requires": {
@@ -18255,7 +17811,7 @@
                 },
                 "strip-ansi": {
                     "version": "4.0.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
                     "dev": true,
                     "requires": {
@@ -18572,7 +18128,7 @@
         },
         "slice-ansi": {
             "version": "0.0.4",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/slice-ansi/-/slice-ansi-0.0.4.tgz",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
             "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
             "dev": true
         },
@@ -18727,6 +18283,7 @@
             "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
+            "optional": true,
             "requires": {
                 "hoek": "2.x.x"
             }
@@ -18915,9 +18472,9 @@
             }
         },
         "source-map-support": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.6.tgz",
-            "integrity": "sha512-N4KXEz7jcKqPf2b2vZF11lQIz9W5ZMuUcIOGj243lduidkf2fjkVKJS9vNxVWn3u/uxX38AcE8U9nnH9FPcq+g==",
+            "version": "0.5.8",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.8.tgz",
+            "integrity": "sha512-WqAEWPdb78u25RfKzOF0swBpY0dKrNdjc4GvLwm7ScX/o9bj8Eh/YL8mcMhBHYDGl87UkkSXDOFnW4G7GhWhGg==",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
@@ -19454,35 +19011,10 @@
                     "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
                     "dev": true
                 },
-                "autoprefixer": {
-                    "version": "9.1.0",
-                    "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.1.0.tgz",
-                    "integrity": "sha512-BbAIdxNdptG/x4DiGGfpkDVYyqu4nUyNdBB0Utr49Gn3+0RERV1MdHik2FSbbWwhMAuk1KrfVJHe7nEMheGdBA==",
-                    "dev": true,
-                    "requires": {
-                        "browserslist": "^4.0.1",
-                        "caniuse-lite": "^1.0.30000872",
-                        "normalize-range": "^0.1.2",
-                        "num2fraction": "^1.2.2",
-                        "postcss": "^7.0.2",
-                        "postcss-value-parser": "^3.2.3"
-                    }
-                },
-                "browserslist": {
-                    "version": "4.0.1",
-                    "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.0.1.tgz",
-                    "integrity": "sha512-QqiiIWchEIkney3wY53/huI7ZErouNAdvOkjorUALAwRcu3tEwOV3Sh6He0DnP38mz1JjBpCBb50jQBmaYuHPw==",
-                    "dev": true,
-                    "requires": {
-                        "caniuse-lite": "^1.0.30000865",
-                        "electron-to-chromium": "^1.3.52",
-                        "node-releases": "^1.0.0-alpha.10"
-                    }
-                },
                 "cosmiconfig": {
-                    "version": "5.0.5",
-                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.5.tgz",
-                    "integrity": "sha512-94j37OtvxS5w7qr7Ta6dt67tWdnOxigBVN4VnSxNXFez9o18PGQ0D33SchKP17r9LAcWVTYV72G6vDayAUBFIg==",
+                    "version": "5.0.6",
+                    "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.0.6.tgz",
+                    "integrity": "sha512-6DWfizHriCrFWURP1/qyhsiFvYdlJzbCzmtFWh744+KyWsJo5+kPzUZZaMRSSItoYc0pxFX7gEO7ZC1/gN/7AQ==",
                     "dev": true,
                     "requires": {
                         "is-directory": "^0.3.1",
@@ -19499,15 +19031,6 @@
                         "ms": "2.0.0"
                     }
                 },
-                "dot-prop": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-                    "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-                    "dev": true,
-                    "requires": {
-                        "is-obj": "^1.0.0"
-                    }
-                },
                 "get-stdin": {
                     "version": "6.0.0",
                     "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -19515,9 +19038,9 @@
                     "dev": true
                 },
                 "ignore": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.3.tgz",
-                    "integrity": "sha512-Z/vAH2GGIEATQnBVXMclE2IGV6i0GyVngKThcGZ5kHgHMxLo9Ow2+XHRq1aEKEej5vOF1TPJNbvX6J/anT0M7A==",
+                    "version": "4.0.6",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
                     "dev": true
                 },
                 "is-fullwidth-code-point": {
@@ -19525,28 +19048,6 @@
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
                     "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
                     "dev": true
-                },
-                "postcss": {
-                    "version": "7.0.2",
-                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.2.tgz",
-                    "integrity": "sha512-fmaUY5370keLUTx+CnwRxtGiuFTcNBLQBqr1oE3WZ/euIYmGAo0OAgOhVJ3ByDnVmOR3PK+0V9VebzfjRIUcqw==",
-                    "dev": true,
-                    "requires": {
-                        "chalk": "^2.4.1",
-                        "source-map": "^0.6.1",
-                        "supports-color": "^5.4.0"
-                    }
-                },
-                "postcss-selector-parser": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
-                    "dev": true,
-                    "requires": {
-                        "dot-prop": "^4.1.1",
-                        "indexes-of": "^1.0.1",
-                        "uniq": "^1.0.1"
-                    }
                 },
                 "string-width": {
                     "version": "2.1.1",
@@ -19597,12 +19098,6 @@
                 "postcss-value-parser": "^3.3.0"
             },
             "dependencies": {
-                "cssesc": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-1.0.1.tgz",
-                    "integrity": "sha512-S2hzrpWvE6G/rW7i7IxJfWBYn27QWfOIncUW++8Rbo1VB5zsJDSVPcnI+Q8z7rhxT6/yZeLOCja4cZnghJrNGA==",
-                    "dev": true
-                },
                 "postcss-selector-parser": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-4.0.0.tgz",
@@ -20179,7 +19674,7 @@
         },
         "tslint": {
             "version": "5.11.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/tslint/-/tslint-5.11.0.tgz",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
             "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
             "dev": true,
             "requires": {
@@ -20198,14 +19693,14 @@
             }
         },
         "tslint-eslint-rules": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.3.1.tgz",
-            "integrity": "sha512-qq2H/AU/FlFbQJKXuxhtIk+ni/nQu9jHHhsFKa6hnA0/n3zl1/RWRc3TVFlL8HfWFMzkST350VeTrFpy1u4OUg==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/tslint-eslint-rules/-/tslint-eslint-rules-5.4.0.tgz",
+            "integrity": "sha512-WlSXE+J2vY/VPgIcqQuijMQiel+UtmXS+4nvK4ZzlDiqBfXse8FAvkNnTcYhnQyOTW5KFM+uRRGXxYhFpuBc6w==",
             "dev": true,
             "requires": {
                 "doctrine": "0.7.2",
                 "tslib": "1.9.0",
-                "tsutils": "2.8.0"
+                "tsutils": "^3.0.0"
             },
             "dependencies": {
                 "tslib": {
@@ -20215,19 +19710,19 @@
                     "dev": true
                 },
                 "tsutils": {
-                    "version": "2.8.0",
-                    "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/tsutils/-/tsutils-2.8.0.tgz",
-                    "integrity": "sha1-AWAXNymzvxOGKN0UoVN+AIUdgUo=",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.0.0.tgz",
+                    "integrity": "sha512-LjHBWR0vWAUHWdIAoTjoqi56Kz+FDKBgVEuL+gVPG/Pv7QW5IdaDDeK9Txlr6U0Cmckp5EgCIq1T25qe3J6hyw==",
                     "dev": true,
                     "requires": {
-                        "tslib": "^1.7.1"
+                        "tslib": "^1.8.1"
                     }
                 }
             }
         },
         "tslint-language-service": {
             "version": "0.9.9",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/tslint-language-service/-/tslint-language-service-0.9.9.tgz",
+            "resolved": "https://registry.npmjs.org/tslint-language-service/-/tslint-language-service-0.9.9.tgz",
             "integrity": "sha1-9UbcOEg5eeb7PPpZWErYUls61No=",
             "dev": true,
             "requires": {
@@ -20368,9 +19863,9 @@
             "optional": true
         },
         "uglifyjs-webpack-plugin": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.2.7.tgz",
-            "integrity": "sha512-1VicfKhCYHLS8m1DCApqBhoulnASsEoJ/BvpUpP4zoNAPpKzdH+ghk0olGJMmwX2/jprK2j3hAHdUbczBSy2FA==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-1.3.0.tgz",
+            "integrity": "sha512-ovHIch0AMlxjD/97j9AYovZxG5wnHOPkL7T1GKochBADp/Zwc44pEWNqpKl1Loupp1WhFg7SlYmHZRUfdAacgw==",
             "dev": true,
             "requires": {
                 "cacache": "^10.0.4",
@@ -20415,7 +19910,7 @@
         },
         "underscore": {
             "version": "1.6.0",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/underscore/-/underscore-1.6.0.tgz",
+            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
             "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
             "dev": true
         },
@@ -20654,9 +20149,9 @@
             }
         },
         "uri-js": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-3.0.2.tgz",
+            "integrity": "sha1-+QuFhQf4HepNz7s8TD2/orVX+qo=",
             "dev": true,
             "requires": {
                 "punycode": "^2.1.0"
@@ -20693,14 +20188,14 @@
             "dev": true
         },
         "url-loader": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.0.1.tgz",
-            "integrity": "sha512-rAonpHy7231fmweBKUFe0bYnlGDty77E+fm53NZdij7j/YOpyGzc7ttqG1nAXl3aRs0k41o0PC3TvGXQiw2Zvw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/url-loader/-/url-loader-1.1.0.tgz",
+            "integrity": "sha512-p/+44Z+yHoQVV6VKsgZuHi7UfvaKhJqucXvKQtsVQYyzaSC8KVdoXjIM5TToZxarq9WB+qIhMVTZr1v7bENKdg==",
             "dev": true,
             "requires": {
                 "loader-utils": "^1.1.0",
                 "mime": "^2.0.3",
-                "schema-utils": "^0.4.3"
+                "schema-utils": "1.0.0"
             },
             "dependencies": {
                 "loader-utils": {
@@ -20719,6 +20214,17 @@
                     "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
                     "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
                     "dev": true
+                },
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
                 }
             }
         },
@@ -20861,9 +20367,9 @@
             }
         },
         "validate.js": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.9.0.tgz",
-            "integrity": "sha1-is8BRPFSChmDXGzGY/ReCDaqVsg=",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/validate.js/-/validate.js-0.12.0.tgz",
+            "integrity": "sha512-/x2RJSvbqEyxKj0RPN4xaRquK+EggjeVXiDDEyrJzsJogjtiZ9ov7lj/svVb4DM5Q5braQF4cooAryQbUwOxlA==",
             "dev": true
         },
         "vargs": {
@@ -21475,6 +20981,18 @@
                 "vargs": "0.1.0"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "5.5.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+                    "dev": true,
+                    "requires": {
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.3.0"
+                    }
+                },
                 "async": {
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/async/-/async-2.0.1.tgz",
@@ -21513,6 +21031,16 @@
                         }
                     }
                 },
+                "har-validator": {
+                    "version": "5.0.3",
+                    "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+                    "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+                    "dev": true,
+                    "requires": {
+                        "ajv": "^5.1.0",
+                        "har-schema": "^2.0.0"
+                    }
+                },
                 "hawk": {
                     "version": "6.0.2",
                     "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
@@ -21529,6 +21057,12 @@
                     "version": "4.2.1",
                     "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
                     "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+                    "dev": true
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+                    "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
                     "dev": true
                 },
                 "punycode": {
@@ -21983,17 +21517,6 @@
                         "xregexp": "4.0.0"
                     }
                 },
-                "enhanced-resolve": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.0.tgz",
-                    "integrity": "sha512-F/7vkyTtyc/llOIn8oWclcB25KdRaiPBpZYDgJHgh/UHtpgT2p2eldQgtQnLtUvfMKPKxbRaQM/hHkvLHt1Vng==",
-                    "dev": true,
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "memory-fs": "^0.4.0",
-                        "tapable": "^1.0.0"
-                    }
-                },
                 "execa": {
                     "version": "0.7.0",
                     "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
@@ -22122,12 +21645,6 @@
                         "ansi-regex": "^3.0.0"
                     }
                 },
-                "tapable": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.0.0.tgz",
-                    "integrity": "sha512-dQRhbNQkRnaqauC7WqSJ21EEksgT0fYZX2lqXzGkpo8JNig9zGZTYoMGvyI2nWmXlE2VSVXVDu7wLVGu/mQEsg==",
-                    "dev": true
-                },
                 "which-module": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
@@ -22159,6 +21676,29 @@
                         "y18n": "^3.2.1 || ^4.0.0",
                         "yargs-parser": "^10.1.0"
                     }
+                }
+            }
+        },
+        "webpack-dev-middleware": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.3.tgz",
+            "integrity": "sha512-I6Mmy/QjWU/kXwCSFGaiOoL5YEQIVmbb0o45xMoCyQAg/mClqZVTcsX327sPfekDyJWpCxb+04whNyLOIxpJdQ==",
+            "dev": true,
+            "requires": {
+                "loud-rejection": "^1.6.0",
+                "memory-fs": "~0.4.1",
+                "mime": "^2.1.0",
+                "path-is-absolute": "^1.0.0",
+                "range-parser": "^1.0.3",
+                "url-join": "^4.0.0",
+                "webpack-log": "^1.0.1"
+            },
+            "dependencies": {
+                "mime": {
+                    "version": "2.3.1",
+                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
+                    "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
+                    "dev": true
                 }
             }
         },
@@ -22662,12 +22202,6 @@
                         "to-regex": "^3.0.2"
                     }
                 },
-                "mime": {
-                    "version": "2.3.1",
-                    "resolved": "https://registry.npmjs.org/mime/-/mime-2.3.1.tgz",
-                    "integrity": "sha512-OEUllcVoydBHGN1z84yfQDimn58pZNNNXgZlHXSboxMlFvgI6MXSWpWKpFRra7H1HxpVhHTkrghfRW49k6yjeg==",
-                    "dev": true
-                },
                 "os-locale": {
                     "version": "2.1.0",
                     "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
@@ -22698,21 +22232,6 @@
                                 "ansi-regex": "^3.0.0"
                             }
                         }
-                    }
-                },
-                "webpack-dev-middleware": {
-                    "version": "3.1.3",
-                    "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-3.1.3.tgz",
-                    "integrity": "sha512-I6Mmy/QjWU/kXwCSFGaiOoL5YEQIVmbb0o45xMoCyQAg/mClqZVTcsX327sPfekDyJWpCxb+04whNyLOIxpJdQ==",
-                    "dev": true,
-                    "requires": {
-                        "loud-rejection": "^1.6.0",
-                        "memory-fs": "~0.4.1",
-                        "mime": "^2.1.0",
-                        "path-is-absolute": "^1.0.0",
-                        "range-parser": "^1.0.3",
-                        "url-join": "^4.0.0",
-                        "webpack-log": "^1.0.1"
                     }
                 },
                 "which-module": {
@@ -22791,20 +22310,12 @@
             "dev": true
         },
         "whatwg-encoding": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.3.tgz",
-            "integrity": "sha512-jLBwwKUhi8WtBfsMQlL4bUUcT8sMkAtQinscJAe/M4KHCkHuUJAF6vuB0tueNIw4c8ziO6AkRmgY+jL3a0iiPw==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.4.tgz",
+            "integrity": "sha512-vM9KWN6MP2mIHZ86ytcyIv7e8Cj3KTfO2nd2c8PFDqcI4bxFmQp83ibq4wadq7rL9l9sZV6o9B0LTt8ygGAAXg==",
             "dev": true,
             "requires": {
-                "iconv-lite": "0.4.19"
-            },
-            "dependencies": {
-                "iconv-lite": {
-                    "version": "0.4.19",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-                    "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-                    "dev": true
-                }
+                "iconv-lite": "0.4.23"
             }
         },
         "whatwg-url": {
@@ -22871,18 +22382,12 @@
                     "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
                     "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=",
                     "dev": true
-                },
-                "colors": {
-                    "version": "1.0.3",
-                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-                    "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-                    "dev": true
                 }
             }
         },
         "with-callback": {
             "version": "1.0.2",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/with-callback/-/with-callback-1.0.2.tgz",
+            "resolved": "https://registry.npmjs.org/with-callback/-/with-callback-1.0.2.tgz",
             "integrity": "sha1-oJYpuakgAo1yFAT7Q1vc/1yRvCE=",
             "dev": true,
             "optional": true
@@ -22958,7 +22463,7 @@
         },
         "xmlbuilder": {
             "version": "8.2.2",
-            "resolved": "https://repo.ptsecurity.ru/artifactory/api/npm/npmjs/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-8.2.2.tgz",
             "integrity": "sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=",
             "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
         "tsconfig-paths": "^3.5.0",
         "tsconfig-paths-webpack-plugin": "^3.2.0",
         "tslint": "^5.11.0",
+        "tslint-language-service": "^0.9.9",
         "typescript": "~2.7.2",
         "uglify-js": "^2.8.29",
         "url-loader": "^1.0.1",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
         "experimentalDecorators": true,
         "module": "es2015",
         "moduleResolution": "node",
+        "noUnusedLocals": true,
         "noUnusedParameters": true,
         "strictNullChecks": true,
         "skipLibCheck": true,
@@ -28,6 +29,11 @@
         "types": [
             "jasmine",
             "tslib"
+        ],
+        "plugins": [
+            {
+                "name": "tslint-language-service"
+            }
         ]
     },
     "include": [


### PR DESCRIPTION
Данный реквест порожден различиями работы штатного tslint'а в webstorm'е и его же, но через CLI(с указанием опции --project).
Различия обусловлены https://palantir.github.io/tslint/usage/type-checking/. 
На текущий момент из коробки webstorm это не поддерживает(https://youtrack.jetbrains.com/issue/WEB-22778#), вследствие чего при попытке использовать tslint в webstorm и CLI (с указанием опции --project) получаются разные результаты в части правил с "requires type check".
Для корректной работы данных правил в Webstorm'е подключен плагин `tslint-language-service`