### PR TITLE
fix(tooltip): Fix tooltip positioning, set input attribute for anchor…

### DIFF
--- a/src/lib-dev/tooltip/module.ts
+++ b/src/lib-dev/tooltip/module.ts
@@ -1,4 +1,4 @@
-import { Component, NgModule, ViewEncapsulation } from '@angular/core';
+import { Component, NgModule, ViewChild, ViewEncapsulation } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
@@ -7,7 +7,7 @@ import { McButtonModule } from '@ptsecurity/mosaic/button';
 import { McInputModule } from '@ptsecurity/mosaic/input';
 import { McListModule } from '@ptsecurity/mosaic/list';
 import { McRadioModule } from '@ptsecurity/mosaic/radio';
-import { McToolTipModule } from '@ptsecurity/mosaic/tooltip';
+import { McToolTipModule, McTooltip } from '@ptsecurity/mosaic/tooltip';
 
 
 /* tslint:disable:no-trailing-whitespace */
@@ -18,6 +18,17 @@ import { McToolTipModule } from '@ptsecurity/mosaic/tooltip';
     template: require('./template.html')
 })
 export class DemoComponent {
+
+    @ViewChild('manualTooltip') manualTooltip: McTooltip;
+
+    trigger(e) {
+        e.stopPropagation();
+        if (this.manualTooltip.isTooltipOpen) {
+            this.manualTooltip.hide();
+        } else {
+            this.manualTooltip.show();
+        }
+    }
 }
 
 @NgModule({

--- a/src/lib-dev/tooltip/template.html
+++ b/src/lib-dev/tooltip/template.html
@@ -1,34 +1,34 @@
 <section class="container flex-100 layout-row layout-align-center-center">
-    <div class="flex-60 layout-row layout-align-center-center">
+    <div class="flex-60 layout-column layout-align-center-center">
         <div class="flex layout-column layout-align-center-center container-item">
             <span class="mc-title">Focus</span>
             <button class="mc-primary"
                     mc-button
-                    mc-tooltip="One two three"
+                    mcTooltip="One two three"
                     mcTitle="Download file"
                     mcTrigger="hover"
                     >Simple</button>
             <button class="mc-primary"
                 mc-button
                 color="primary"
-                mc-tooltip
+                mcTooltip
                 mcTitle="Удалить файл"
                 mcTrigger="focus"
                 mcPlacement="top">top</button>
             <button class="mc-primary"
                 mc-button
-                mc-tooltip="Подсказка может занимать две и более строк"
+                mcTooltip="Подсказка может занимать две и более строк"
                 mcTrigger="focus"
                 mcPlacement="right"
                 mcTooltipDisabled>disabled</button>
             <button class="mc-primary"
                 mc-button
-                mc-tooltip="PDQL-запрос фильтра содержит ошибки"
+                mcTooltip="PDQL-запрос фильтра содержит ошибки"
                 mcTrigger="focus"
                 mcPlacement="left">left</button>
             <button class="mc-primary"
                 mc-button
-                mc-tooltip="PDQL-запрос фильтра содержит ошибки. Uncaught SyntaxError: Unexpected string"
+                mcTooltip="PDQL-запрос фильтра содержит ошибки. Uncaught SyntaxError: Unexpected string"
                 mcTrigger="focus"
                 mcPlacement="bottom">bottom</button>
         </div>
@@ -36,45 +36,47 @@
             <span class="mc-title">Hover</span>
             <button class="mc-primary"
                     mc-button
-                    mc-tooltip="Показать\Скрыть"
+                    mcTooltip="Показать\Скрыть"
                     mcPlacement="top">top</button>
             <button class="mc-primary"
                     mc-button
-                    mc-tooltip="Активировать записи"
+                    mcTooltip="Активировать записи"
                     mcPlacement="right">right</button>
             <button class="mc-primary"
                     mc-button
-                    mc-tooltip="PDQL-запрос фильтра содержит ошибки
+                    mcTooltip="PDQL-запрос фильтра содержит ошибки
                                 испральве запрос"
                     mcPlacement="left">left</button>
             <button class="mc-primary"
                     mc-button
-                    mc-tooltip="Обновить"
+                    mcTooltip="Обновить"
                     mcPlacement="bottom">bottom</button>
         </div>
     </div>
     <div class="flex layout-column layout-align-center-center container-item">
         <div class="flex layout-row layout-align-center-center">
-            <mc-radio-group class="flex layout-column layout-align-center-center">
-                <mc-radio-button
-                    class="example-radio-button"
-                    value="option_1"
-                    mc-tooltip
-                    mcTitle="Option 1"
-                    mcPlacement="left">Option 1</mc-radio-button>
-                <mc-radio-button
-                    class="example-radio-button"
-                    value="option_2"
-                    mc-tooltip
-                    mcTitle="Option 2 tooltip"
-                    mcPlacement="left">Option 2</mc-radio-button>
-                <mc-radio-button
-                    class="example-radio-button"
-                    value="option_3"
-                    mc-tooltip
-                    mcTitle="Last option tooltip placed left"
-                    mcPlacement="left">Option 3</mc-radio-button>
-            </mc-radio-group>
+            <div>
+                <span> Mouse over to </span>
+                <button mc-button
+                        (mouseenter)="tooltip.show()"
+                        aria-label="Button that progamatically shows a tooltip on another button"
+                        class="example-action-button">
+                    show
+                </button>
+                <button mc-button
+                        (mouseenter)="tooltip.hide()"
+                        aria-label="Button that progamatically hides a tooltip on another button"
+                        class="example-action-button">
+                    hide
+                </button>
+            </div>
+
+            <button mc-button #tooltip="mcTooltip"
+                    mcTooltip
+                    mcTitle="Info about the action"
+                    mcPlacement="right">
+                Action
+            </button>
         </div>
         <div class="flex layout-row layout-aling-center-center">
             <mc-list-selection
@@ -84,30 +86,30 @@
                 <mc-list-option
                     value="Disabled"
                     disabled
-                    mc-tooltip
+                    mcTooltip
                     mcTooltipDisabled
                 >Disabled</mc-list-option>
                 <mc-list-option
                     value="Normal"
-                    mc-tooltip="Item inside list can have a tooltip with a lot of text.
+                    mcTooltip="Item inside list can have a tooltip with a lot of text.
                                 Tooltip for nex element is disabled."
                     mcPlacement="left">Normal</mc-list-option>
                 <mc-list-option
                     value="Hovered"
                     class="mc-hovered"
-                    mc-tooltip="Not empty"
+                    mcTooltip="Not empty"
                     mcPlacement="right"
                     mcTooltipDisabled>Hovered</mc-list-option>
                 <mc-list-option
                     value="Focused"
                     class="mc-focused"
-                    mc-tooltip
+                    mcTooltip
                     mcTitle="Focused list item have a tooltip"
                     mcPlacement="bottom">Focused</mc-list-option>
                 <mc-list-option
                     value="Selected"
                     class="mc-selected"
-                    mc-tooltip="Выбранный элемент списка"
+                    mcTooltip="Выбранный элемент списка"
                     mcPlacement="right">Selected</mc-list-option>
             </mc-list-selection>
         </div>

--- a/src/lib/tooltip/tooltip.component.html
+++ b/src/lib/tooltip/tooltip.component.html
@@ -1,5 +1,4 @@
-<ng-container [ngTemplateOutlet]="mcTooltipDefaultTemplate"></ng-container>
-<ng-template #mcTooltipDefaultTemplate>
+
     <div class="mc-tooltip"
          [ngClass]="_classMap"
          [@fadeAnimation]="''+($visible | async)">
@@ -10,4 +9,4 @@
             </div>
         </div>
     </div>
-</ng-template>
+

--- a/src/lib/tooltip/tooltip.module.ts
+++ b/src/lib/tooltip/tooltip.module.ts
@@ -4,18 +4,18 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { OverlayModule } from '@ptsecurity/cdk/overlay';
 
 import {
-    McToolTipComponent,
-    McTooltipDirective,
+    McTooltipComponent,
+    McTooltip,
     MC_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER
 } from './tooltip.component';
 
 
 @NgModule({
-    declarations: [ McToolTipComponent, McTooltipDirective ],
-    exports: [ McToolTipComponent, McTooltipDirective ],
-    imports: [ BrowserAnimationsModule, CommonModule, OverlayModule ],
+    declarations: [McTooltipComponent, McTooltip],
+    exports: [McTooltipComponent, McTooltip],
+    imports: [BrowserAnimationsModule, CommonModule, OverlayModule],
     providers: [MC_TOOLTIP_SCROLL_STRATEGY_FACTORY_PROVIDER],
-    entryComponents: [ McToolTipComponent ]
+    entryComponents: [McTooltipComponent]
 })
 export class McToolTipModule {
 }

--- a/src/lib/tooltip/tooltip.spec.ts
+++ b/src/lib/tooltip/tooltip.spec.ts
@@ -4,7 +4,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { OverlayContainer } from '@ptsecurity/cdk/overlay';
 import { dispatchMouseEvent } from '@ptsecurity/cdk/testing';
 
-import { McTooltipDirective } from './tooltip.component';
+import { McTooltip } from './tooltip.component';
 import { McToolTipModule } from './tooltip.module';
 
 
@@ -136,11 +136,11 @@ describe('McTooltip', () => {
     selector: 'mc-tooltip-test-new',
     template: `
     <a #titleString
-       mc-tooltip
+       mcTooltip
        mcTitle="title-string"
        mcTrigger="hover"
        mcPlacement="top">Show</a>
-    <a #titleTemplate mc-tooltip mcTitle="template">Show</a>
+    <a #titleTemplate mcTooltip mcTitle="template">Show</a>
     <ng-template #template>
       title-template
     </ng-template>
@@ -148,33 +148,33 @@ describe('McTooltip', () => {
 })
 class McTooltipTestNewComponent {
     @ViewChild('titleString') titleString: ElementRef;
-    @ViewChild('titleString', { read: McTooltipDirective }) titleStringMcTooltipDirective: McTooltipDirective;
+    @ViewChild('titleString', { read: McTooltip }) titleStringMcTooltipDirective: McTooltip;
     @ViewChild('titleTemplate') titleTemplate: ElementRef;
-    @ViewChild('titleTemplate', { read: McTooltipDirective }) titleTemplateMcTooltipDirective: McTooltipDirective;
+    @ViewChild('titleTemplate', { read: McTooltip }) titleTemplateMcTooltipDirective: McTooltip;
 }
 @Component({
     selector: 'mc-tooltip-test-wrapper',
     template: `
-    <a #mostSimpleTrigger mc-tooltip="MOST-SIMPLE">Show</a>
+    <a #mostSimpleTrigger mcTooltip="MOST-SIMPLE">Show</a>
 
     <span #normalTrigger
-          mc-tooltip="normalized-text"
+          mcTooltip="normalized-text"
           mcTitle="NORMAL"
           mcTrigger="hover"
           mcPlacement="right">
         Show
     </span>
 
-    <span #focusTrigger mc-tooltip mcTitle="FOCUS" mcTrigger="focus">Show</span>
-    <span #visibleTrigger mc-tooltip mcTitle="VISIBLE" mcVisible="visible">Show</span>
+    <span #focusTrigger mcTooltip mcTitle="FOCUS" mcTrigger="focus">Show</span>
+    <span #visibleTrigger mcTooltip mcTitle="VISIBLE" mcVisible="visible">Show</span>
   `
 })
 class McTooltipTestWrapperComponent {
     @ViewChild('normalTrigger') normalTrigger: ElementRef;
-    @ViewChild('normalTrigger', { read: McTooltipDirective }) normalDirective: McTooltipDirective;
+    @ViewChild('normalTrigger', { read: McTooltip }) normalDirective: McTooltip;
     @ViewChild('focusTrigger') focusTrigger: ElementRef;
     visible: boolean;
     @ViewChild('visibleTrigger') visibleTrigger: ElementRef;
     @ViewChild('mostSimpleTrigger') mostSimpleTrigger: ElementRef;
-    @ViewChild('mostSimpleTrigger', { read: McTooltipDirective }) mostSimpleDirective: McTooltipDirective;
+    @ViewChild('mostSimpleTrigger', { read: McTooltip }) mostSimpleDirective: McTooltip;
 }


### PR DESCRIPTION
… element
1. Поправил позиционирование элемента.
Как проверить:
- запустить дев-пример
- развернуть браузер на всё окно
- вызвать тултип ( например по фокусу с позиционированием слева)
- уменьшить размер окна браузера ( например по ширине, так чтобы тултип не помещался слева )

Результат - тултипа позиционируется справа от элемента, к которому привязан

2. Добавил mcElementHost и пример использования.
В дев-примере добавил кнопку "Programmatically click", которая создаёт тултип через реф-переменную, на элементе span рядом с кнопкой создаётся ElementRef `#elementAnchor`, которая пробрасывается в тултип `[mcHostElement]="elementAnchor"`. В результате можно показывать\скрывать тултип через методы контроллера и привязывать к любому элементу.

PS: текстовые названия поправлю на что-нибудь более порядочное до вливания в основную ветку, если к остальной части кода не будет замечаний.
