### PR TITLE
fix(select): Отображение тегов в Match Container (#164347)

### DIFF
--- a/src/lib/select/select.scss
+++ b/src/lib/select/select.scss
@@ -35,7 +35,7 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
 }
 
 .mc-select__trigger {
-    display: inline-table;
+    display: flex;
     box-sizing: border-box;
     position: relative;
 
@@ -52,8 +52,8 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
 }
 
 .mc-select__matcher {
-    display: table-cell;
-    vertical-align: middle;
+    display: flex;
+    align-items: center;
 
     width: 100%;
 


### PR DESCRIPTION
Тут решается проблема с "вываливанием" текста из матчера.