### PR TITLE
fix(select): fix select overlay autowidth (#172942)

### DIFF
--- a/src/lib/select/select.html
+++ b/src/lib/select/select.html
@@ -38,7 +38,6 @@
     [cdkConnectedOverlayOpen]="panelOpen"
     [cdkConnectedOverlayPositions]="_positions"
     [cdkConnectedOverlayMinWidth]="_triggerRect?.width"
-    [cdkConnectedOverlayWidth]="_triggerRect?.width"
     [cdkConnectedOverlayOffsetY]="_offsetY"
     (backdropClick)="close()"
     (attach)="_onAttached()"


### PR DESCRIPTION
@Fost 

Проблема: ширина выпадающего списка селекта всегда была равна ширине самого селекта, что не позволяло задавать разную ширину для выпадающего списка и селекта. И в случае, если ширина селекта была auto, то ширина дропдауна была равна ширине селекта, которая могла быть очень мало.

Решение: удалить из шаблона назначение ширины `cdkOverlay` 