### PR TITLE
fix: Dependency for es6 compilation result

### DIFF
--- a/src/cdk/tree/tree.ts
+++ b/src/cdk/tree/tree.ts
@@ -305,6 +305,7 @@ export class CdkTreeNode<T> implements IFocusableOption, OnDestroy {
     @Input() role: 'treeitem' | 'group' = 'treeitem';
 
     protected destroyed = new Subject<void>();
+    protected tree: CdkTree<T>;
 
     get data(): T {
         return this._data;
@@ -328,8 +329,9 @@ export class CdkTreeNode<T> implements IFocusableOption, OnDestroy {
 
     constructor(
         protected elementRef: ElementRef,
-        @Inject(forwardRef(() => CdkTree)) protected tree: CdkTree<T>
+        @Inject(forwardRef(() => CdkTree)) tree: any
     ) {
+        this.tree = tree;
         CdkTreeNode.mostRecentTreeNode = this as CdkTreeNode<T>;
     }
 

--- a/src/lib/datepicker/calendar.ts
+++ b/src/lib/datepicker/calendar.ts
@@ -43,11 +43,14 @@ export type McCalendarView = 'month' | 'year' | 'multi-year';
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class McCalendarHeader<D> {
+    calendar: McCalendar<D>;
+
     constructor(private intl: McDatepickerIntl,
-                @Inject(forwardRef(() => McCalendar)) public calendar: McCalendar<D>,
+                @Inject(forwardRef(() => McCalendar)) calendar: any,
                 @Optional() private dateAdapter: DateAdapter<D>,
                 @Optional() @Inject(MC_DATE_FORMATS) private dateFormats: McDateFormats,
                 changeDetectorRef: ChangeDetectorRef) {
+        this.calendar = calendar;
 
         this.calendar.stateChanges.subscribe(() => changeDetectorRef.markForCheck());
     }

--- a/src/lib/list/list-selection.component.ts
+++ b/src/lib/list/list-selection.component.ts
@@ -59,6 +59,7 @@ import {
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class McListOption implements AfterContentInit, OnDestroy, OnInit, IFocusableOption {
+    listSelection: McListSelection;
     _hasFocus: boolean = false;
 
     @ContentChildren(McLine) _lines: QueryList<McLine>;
@@ -107,8 +108,10 @@ export class McListOption implements AfterContentInit, OnDestroy, OnInit, IFocus
         private _element: ElementRef,
         private _changeDetector: ChangeDetectorRef,
         @Inject(forwardRef(() => McListSelection))
-        public listSelection: McListSelection
-    ) {}
+        listSelection: any
+    ) {
+        this.listSelection = listSelection;
+    }
 
     ngOnInit() {
         if (this._selected) {


### PR DESCRIPTION
В es6 сборке есть проблема. 
Конструкции вида `@Inject(forwardRef(() => McCalendar)) calendar: McCalendar<D>` создают проблемы.
Объявление типа `: McCalendar<D>` попадает в метаданные конструктора. Если McCalendar декларируется ниже по коду, то в es6 версии кода получается обращение к несуществующей переменной, и все весело падает в реалтайме.
Мои исправления решают проблему никак не влияя на функциональность