### PR TITLE
chore: updated vendor package karma-junit-reporter to 1.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
         "karma-chrome-launcher": "^2.2.0",
         "karma-coverage": "^1.1.2",
         "karma-jasmine": "^2.0.1",
-        "karma-junit-reporter": "^2.0.0",
+        "karma-junit-reporter": "^1.2.0",
         "karma-remap-coverage": "^0.1.5",
         "karma-sauce-launcher": "1.2.0",
         "karma-sourcemap-loader": "^0.3.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6436,13 +6436,13 @@ karma-jasmine@^2.0.1:
   dependencies:
     jasmine-core "^3.3"
 
-karma-junit-reporter@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/karma-junit-reporter/-/karma-junit-reporter-2.0.0.tgz#f84629e0e1ef28dd2977c96f346c33d5bf93e159"
-  integrity sha1-+EYp4OHvKN0pd8lvNGwz1b+T4Vk=
+karma-junit-reporter@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/karma-junit-reporter/-/karma-junit-reporter-1.2.0.tgz#4f9c40cedfb1a395f8aef876abf96189917c6396"
+  integrity sha1-T5xAzt+xo5X4rvh2q/lhiZF8Y5Y=
   dependencies:
     path-is-absolute "^1.0.0"
-    xmlbuilder "3.1.0"
+    xmlbuilder "8.2.2"
 
 karma-remap-coverage@^0.1.5:
   version "0.1.5"
@@ -7002,11 +7002,6 @@ lodash@4.17.11, lodash@^4.0.0, lodash@^4.13.1, lodash@^4.16.6, lodash@^4.17.0, l
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
   integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
-
-lodash@^3.5.0:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-  integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
 log-symbols@^1.0.2:
   version "1.0.2"
@@ -12195,12 +12190,10 @@ xhr2@^0.1.4:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-2.0.1.tgz#4d8b8f1eccd3419aa362061becef515e1e559635"
   integrity sha1-TYuPHszTQZqjYgYb7O9RXh5VljU=
 
-xmlbuilder@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-3.1.0.tgz#2c86888f2d4eade850fa38ca7f7223f7209516e1"
-  integrity sha1-LIaIjy1OrehQ+jjKf3Ij9yCVFuE=
-  dependencies:
-    lodash "^3.5.0"
+xmlbuilder@8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-8.2.2.tgz#69248673410b4ba42e1a6136551d2922335aa773"
+  integrity sha1-aSSGc0ELS6QuGmE2VR0pIjNap3M=
 
 xmlhttprequest-ssl@~1.5.4:
   version "1.5.5"


### PR DESCRIPTION
## What is the current behavior?
There is a vulnerability in karma-junit-reporter package, because its version is old and have lodash package vendor  
https://app.snyk.io/vuln/SNYK-JS-LODASH-73639  
https://app.snyk.io/vuln/npm:lodash:20180130  
https://app.snyk.io/vuln/SNYK-JS-LODASH-73638  

## What is the new behavior?
I updated the version of the karma-junit-reporter package. Vulnerability should not be, because karma-junit-reporter package now does not have lodash dependencies.  
Package had version confusion https://github.com/karma-runner/karma-junit-reporter/issues/168  


## Reviewers
@Fost  @imrekb 