### PR TITLE
chore: updated vendor package gulp-markdown to 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
         "gulp-highlight-files": "^0.0.6",
         "gulp-htmlmin": "^4.0.0",
         "gulp-if": "^2.0.2",
-        "gulp-markdown": "^1.2.0",
+        "gulp-markdown": "^4.0.0",
         "gulp-rename": "^1.4.0",
         "gulp-sass": "^4.0.2",
         "gulp-transform": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5144,14 +5144,14 @@ gulp-if@^2.0.2:
     ternary-stream "^2.0.1"
     through2 "^2.0.1"
 
-gulp-markdown@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/gulp-markdown/-/gulp-markdown-1.2.0.tgz#37cdc61379fb039841fa6cab4984a8e79128a772"
-  integrity sha1-N83GE3n7A5hB+myrSYSo55Eop3I=
+gulp-markdown@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/gulp-markdown/-/gulp-markdown-4.0.0.tgz#1bf228052f52c98d53cc2fa6f50c750ceeceb920"
+  integrity sha512-aLpEc695NHBJMyS0XnQjKLPAx3By7VElALjBV0GVbicsNdiz9pYjcjgA1Eh+hErGJ7WlLiWhISfKf/sg08Q2BA==
   dependencies:
-    gulp-util "^3.0.0"
-    marked "^0.3.2"
-    through2 "^2.0.0"
+    marked "^0.6.2"
+    plugin-error "^1.0.1"
+    through2 "^3.0.1"
 
 gulp-match@^1.0.3:
   version "1.0.3"
@@ -5187,7 +5187,7 @@ gulp-transform@^2.0.0:
     gulp-util "^3.0.8"
     lodash "^4.17.4"
 
-gulp-util@^3.0.0, gulp-util@^3.0.7, gulp-util@^3.0.8:
+gulp-util@^3.0.7, gulp-util@^3.0.8:
   version "3.0.8"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.8.tgz#0054e1e744502e27c04c187c3ecc505dd54bbb4f"
   integrity sha1-AFTh50RQLifATBh8PsxQXdVLu08=
@@ -7211,6 +7211,11 @@ marked@^0.3.2:
   resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
   integrity sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==
 
+marked@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.6.2.tgz#c574be8b545a8b48641456ca1dbe0e37b6dccc1a"
+  integrity sha512-LqxwVH3P/rqKX4EKGz7+c2G9r98WeM/SW34ybhgNGhUQNKtf1GmmSkJ6cDGJ/t6tiyae49qRkpyTw2B9HOrgUA==
+
 matchdep@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/matchdep/-/matchdep-2.0.0.tgz#c6f34834a0d8dbc3b37c27ee8bbcb27c7775582e"
@@ -9148,6 +9153,15 @@ read-pkg@^4.0.1:
     string_decoder "~1.1.1"
     util-deprecate "~1.0.1"
 
+"readable-stream@2 || 3":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.3.0.tgz#cb8011aad002eb717bf040291feba8569c986fb9"
+  integrity sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
 readable-stream@^3.0.6, readable-stream@^3.1.1:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.2.0.tgz#de17f229864c120a9f56945756e4f32c4045245d"
@@ -10991,6 +11005,13 @@ through2@^2.0.0, through2@^2.0.1, through2@^2.0.2, through2@^2.0.3, through2@~2.
   dependencies:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
+
+through2@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-3.0.1.tgz#39276e713c3302edf9e388dd9c812dd3b825bd5a"
+  integrity sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==
+  dependencies:
+    readable-stream "2 || 3"
 
 through@2, "through@>=2.2.7 <3", through@^2.3.6:
   version "2.3.8"


### PR DESCRIPTION
## What is the current behavior?
The Gulp-markdown package has a vulnerability because its old version had a vulnerable package marked in dependencies:  
https://app.snyk.io/vuln/SNYK-JS-MARKED-174116

## What is the new behavior?
I updated the version of the gulp-markdown package. 

## Reviewers
@Fost 