### PR TITLE
fix(issue#110): Datepicker's calendar icon button should be focusable

### DIFF
--- a/src/lib/datepicker/datepicker-module.ts
+++ b/src/lib/datepicker/datepicker-module.ts
@@ -28,7 +28,6 @@ import { McYearView } from './year-view';
         OverlayModule,
         A11yModule,
         PortalModule,
-        McButtonModule,
         McIconModule
     ],
     exports: [
@@ -42,7 +41,8 @@ import { McYearView } from './year-view';
         McMonthView,
         McYearView,
         McMultiYearView,
-        McCalendarHeader
+        McCalendarHeader,
+        McButtonModule
     ],
     declarations: [
         McCalendar,


### PR DESCRIPTION
@Fost 
@lskramarov 
@mikeozornin 

RC was about incorrect export\import of McButtonModule