### PR TITLE
Fix/fix modal footer line

### DIFF
--- a/packages/mosaic-dev/modal/module.ts
+++ b/packages/mosaic-dev/modal/module.ts
@@ -38,10 +38,10 @@ export class ModalDemoComponent {
                 ' or an alert. It will be <b>deleted</b> there too. </br></br>' +
                 'Delete the selected action anyway?',
             mcOkType    : 'error',
-            mcOkText    : 'Yes',
-            mcCancelText: 'No',
+            mcOkText    : 'Delete',
+            mcCancelText: 'Cancel',
             mcWidth     : '480px',
-            mcOnOk      : () => console.log('OK'),
+            mcOnOk      : () => console.log('Delete'),
             mcOnCancel  : () => console.log('Cancel')
         });
     }
@@ -100,7 +100,8 @@ export class ModalDemoComponent {
         let pos = 0;
 
         [ 'create', 'delete', 'success' ].forEach((method) => this.modalService[method]({
-            mcOkText    : 'Yes',
+            mcOkText    : 'Confirm',
+            mcCancelText: 'Cancel',
             mcMask: false,
             mcContent: `Test content: <b>${method}</b>`,
             mcStyle: { position: 'absolute', top: `${pos * 70}px`, left: `${(pos++) * 300}px` }

--- a/packages/mosaic/modal/_modal-theme.scss
+++ b/packages/mosaic/modal/_modal-theme.scss
@@ -45,8 +45,8 @@
     .mc-confirm {
         // todo почему футер внезапно перестал быть футером ?
         .mc-confirm-btns {
+            border-top: 1px solid $inner-border;
             background-color: if($is-dark, transparent, mc-color($second, 60));
-            border-top: 1px solid mc-color($second, 60);
         }
     }
 }


### PR DESCRIPTION
В темной теме линия футера очень яркая.

Сейчас:
<img width="509" alt="image" src="https://user-images.githubusercontent.com/1744928/57581791-29318000-74c5-11e9-9c64-aa8cf3494029.png">

Правильно (в сайдпанели):
<img width="420" alt="image" src="https://user-images.githubusercontent.com/1744928/57581793-351d4200-74c5-11e9-8257-35d642e0eb05.png">

Заодно поправил некоторые тексты (Yes / No лучше не писать, чтобы никто не думал, что так можно), и на примере с кучей модалок на кнопке отмены вообще не было текста.