### PR TITLE
feat(date-formatter): update range dates formatter to show current year in some cases

### DIFF
--- a/packages/mosaic-dev/dateformatter/module.ts
+++ b/packages/mosaic-dev/dateformatter/module.ts
@@ -195,8 +195,8 @@ export class DemoComponent {
             moment().date(10).month(2)
         );
         this.enRangeShortDateEndsNotCurrentYear = this.dateAdapter.rangeShortDate(
-            moment().date(1).month(1).subtract(1, 'years'),
-            moment().date(10).month(2).subtract(1, 'years')
+            moment().date(1).month(1),
+            moment().date(10).month(2).add(1, 'years')
         );
         this.enRangeShortDateTimeSameDateCurrentYear = this.dateAdapter.rangeShortDateTime(
             moment().date(10).hour(10).minutes(14),
@@ -325,8 +325,8 @@ export class DemoComponent {
             moment().date(10).month(2)
         );
         this.enRangeLongDateEndsNotCurrentYear = this.dateAdapter.rangeLongDate(
-            moment().date(1).month(1).subtract(1, 'years'),
-            moment().date(10).month(2).subtract(1, 'years')
+            moment().date(1).month(1),
+            moment().date(10).month(2).add(1, 'years')
         );
         this.enRangeLongDateTimeSameDateCurrentYear = this.dateAdapter.rangeLongDateTime(
             moment().date(10).hour(10).minutes(14),

--- a/packages/mosaic-moment-adapter/adapter/moment-date-adapter.spec.ts
+++ b/packages/mosaic-moment-adapter/adapter/moment-date-adapter.spec.ts
@@ -669,7 +669,7 @@ describe('MomentDateAdapter formatter', () => {
                     const endDate = moment();
 
                     const startString: string = startDate.format(`${startDateFormat} ${YEAR}`);
-                    const endString: string = endDate.format(endDateFormat);
+                    const endString: string = endDate.format(`${endDateFormat} ${YEAR}`);
 
                     expect(adapter.rangeShortDate(startDate, endDate)).toBe(
                         `${startString}${LONG_DASH}${endString}`
@@ -680,7 +680,7 @@ describe('MomentDateAdapter formatter', () => {
                     const startDate = moment();
                     const endDate = moment(startDate).add(1, 'years');
 
-                    const startString: string = startDate.format(startDateFormat);
+                    const startString: string = startDate.format(`${startDateFormat} ${YEAR}`);
                     const endString: string = endDate.format(`${endDateFormat} ${YEAR}`);
 
                     expect(adapter.rangeShortDate(startDate, endDate)).toBe(
@@ -748,7 +748,7 @@ describe('MomentDateAdapter formatter', () => {
                     const endDate = moment();
 
                     const startString: string = startDate.format(`${DAY_SHORT_MONTH} ${YEAR}, ${TIME}`);
-                    const endString: string = endDate.format(endDateFormat);
+                    const endString: string = endDate.format(`${DAY_SHORT_MONTH} ${YEAR}, ${TIME}`);
 
                     expect(adapter.rangeShortDateTime(startDate, endDate)).toBe(
                         `${startString}${LONG_DASH}${endString}`
@@ -759,7 +759,7 @@ describe('MomentDateAdapter formatter', () => {
                     const startDate = moment();
                     const endDate = moment(startDate).add(1, 'years');
 
-                    const startString: string = startDate.format(startDateFormat);
+                    const startString: string = startDate.format(`${DAY_SHORT_MONTH} ${YEAR}, ${TIME}`);
                     const endString: string = endDate.format(`${DAY_SHORT_MONTH} ${YEAR}, ${TIME}`);
 
                     expect(adapter.rangeShortDateTime(startDate, endDate)).toBe(
@@ -803,7 +803,7 @@ describe('MomentDateAdapter formatter', () => {
                     const endDate: Moment = moment();
 
                     const startString: string = startDate.format(`${startDateFormat} ${YEAR}`);
-                    const endString: string = endDate.format(`${endDateFormat}`);
+                    const endString: string = endDate.format(`${endDateFormat} ${YEAR}`);
 
                     expect(adapter.rangeLongDate(startDate, endDate)).toBe(
                         `${startString}${LONG_DASH}${endString}`
@@ -814,7 +814,7 @@ describe('MomentDateAdapter formatter', () => {
                     const startDate: Moment = moment().dayOfYear(1);
                     const endDate: Moment = moment(startDate).add(1, 'years');
 
-                    const startString: string = startDate.format(`${startDateFormat}`);
+                    const startString: string = startDate.format(`${startDateFormat} ${YEAR}`);
                     const endString: string = endDate.format(`${endDateFormat} ${YEAR}`);
 
                     expect(adapter.rangeLongDate(startDate, endDate)).toBe(
@@ -882,7 +882,7 @@ describe('MomentDateAdapter formatter', () => {
                     const endDate: Moment = moment();
 
                     const startString: string = startDate.format(`${DAY_MONTH} ${YEAR}, ${TIME}`);
-                    const endString: string = endDate.format(endDateFormat);
+                    const endString: string = endDate.format(`${DAY_MONTH} ${YEAR}, ${TIME}`);
 
                     expect(adapter.rangeLongDateTime(startDate, endDate)).toBe(
                         `С${NBSP}${startString} по${NBSP}${endString}`
@@ -893,7 +893,7 @@ describe('MomentDateAdapter formatter', () => {
                     const startDate: Moment = moment().dayOfYear(1);
                     const endDate: Moment = moment(startDate).add(1, 'years');
 
-                    const startString: string = startDate.format(startDateFormat);
+                    const startString: string = startDate.format(`${DAY_MONTH} ${YEAR}, ${TIME}`);
                     const endString: string = endDate.format(`${DAY_MONTH} ${YEAR}, ${TIME}`);
 
                     expect(adapter.rangeLongDateTime(startDate, endDate)).toBe(
@@ -961,7 +961,7 @@ describe('MomentDateAdapter formatter', () => {
                     const endDate: Moment = moment();
 
                     const startString: string = startDate.format(`${DAY_MONTH} ${YEAR}, ${TIME}`);
-                    const endString: string = endDate.format(endDateFormat);
+                    const endString: string = endDate.format(`${DAY_MONTH} ${YEAR}, ${TIME}`);
 
                     expect(adapter.rangeMiddleDateTime(startDate, endDate)).toBe(
                         `${startString}${LONG_DASH}${endString}`
@@ -972,7 +972,7 @@ describe('MomentDateAdapter formatter', () => {
                     const startDate: Moment = moment().dayOfYear(1);
                     const endDate: Moment = moment(startDate).add(1, 'years');
 
-                    const startString: string = startDate.format(startDateFormat);
+                    const startString: string = startDate.format(`${DAY_MONTH} ${YEAR}, ${TIME}`);
                     const endString: string = endDate.format(`${DAY_MONTH} ${YEAR}, ${TIME}`);
 
                     expect(adapter.rangeMiddleDateTime(startDate, endDate)).toBe(
@@ -1201,7 +1201,7 @@ describe('MomentDateAdapter formatter', () => {
                     const endDate: Moment = moment();
 
                     const startString: string = startDate.format(`${startDateFormat}, ${YEAR}`);
-                    const endString: string = endDate.format(endDateFormat);
+                    const endString: string = endDate.format(`${endDateFormat}, ${YEAR}`);
 
                     expect(adapter.rangeShortDate(startDate, endDate)).toBe(
                         `${startString}${LONG_DASH}${endString}`
@@ -1212,7 +1212,7 @@ describe('MomentDateAdapter formatter', () => {
                     const startDate: Moment = moment();
                     const endDate: Moment = moment(startDate).add(1, 'years');
 
-                    const startString: string = startDate.format(startDateFormat);
+                    const startString: string = startDate.format(`${startDateFormat}, ${YEAR}`);
                     const endString: string = endDate.format(`${endDateFormat}, ${YEAR}`);
 
                     expect(adapter.rangeShortDate(startDate, endDate)).toBe(
@@ -1280,7 +1280,7 @@ describe('MomentDateAdapter formatter', () => {
                     const endDate: Moment = moment();
 
                     const startString: string = startDate.format(`${DAY_SHORT_MONTH}, ${YEAR}, ${TIME}`);
-                    const endString: string = endDate.format(endDateFormat);
+                    const endString: string = endDate.format(`${DAY_SHORT_MONTH}, ${YEAR}, ${TIME}`);
 
                     expect(adapter.rangeShortDateTime(startDate, endDate)).toBe(
                         `${startString}${LONG_DASH}${endString}`
@@ -1291,7 +1291,7 @@ describe('MomentDateAdapter formatter', () => {
                     const startDate: Moment = moment();
                     const endDate: Moment = moment(startDate).add(1, 'years');
 
-                    const startString: string = startDate.format(startDateFormat);
+                    const startString: string = startDate.format(`${DAY_SHORT_MONTH}, ${YEAR}, ${TIME}`);
                     const endString: string = endDate.format(`${DAY_SHORT_MONTH}, ${YEAR}, ${TIME}`);
 
                     expect(adapter.rangeShortDateTime(startDate, endDate)).toBe(
@@ -1335,7 +1335,7 @@ describe('MomentDateAdapter formatter', () => {
                     const endDate: Moment = moment();
 
                     const startString: string = startDate.format(`${startDateFormat}, ${YEAR}`);
-                    const endString: string = endDate.format(`${endDateFormat}`);
+                    const endString: string = endDate.format(`${endDateFormat}, ${YEAR}`);
 
                     expect(adapter.rangeLongDate(startDate, endDate)).toBe(
                         `${startString}${LONG_DASH}${endString}`
@@ -1346,7 +1346,7 @@ describe('MomentDateAdapter formatter', () => {
                     const startDate: Moment = moment().dayOfYear(1);
                     const endDate: Moment = moment(startDate).add(1, 'years');
 
-                    const startString: string = startDate.format(`${startDateFormat}`);
+                    const startString: string = startDate.format(`${startDateFormat}, ${YEAR}`);
                     const endString: string = endDate.format(`${endDateFormat}, ${YEAR}`);
 
                     expect(adapter.rangeLongDate(startDate, endDate)).toBe(
@@ -1414,7 +1414,7 @@ describe('MomentDateAdapter formatter', () => {
                     const endDate: Moment = moment();
 
                     const startString: string = startDate.format(`${DAY_MONTH}, ${YEAR}, ${TIME}`);
-                    const endString: string = endDate.format(endDateFormat);
+                    const endString: string = endDate.format(`${DAY_MONTH}, ${YEAR}, ${TIME}`);
 
                     expect(adapter.rangeLongDateTime(startDate, endDate)).toBe(
                         `From ${startString} to${NBSP}${endString}`
@@ -1425,7 +1425,7 @@ describe('MomentDateAdapter formatter', () => {
                     const startDate: Moment = moment().dayOfYear(1);
                     const endDate: Moment = moment(startDate).add(1, 'years');
 
-                    const startString: string = startDate.format(startDateFormat);
+                    const startString: string = startDate.format(`${DAY_MONTH}, ${YEAR}, ${TIME}`);
                     const endString: string = endDate.format(`${DAY_MONTH}, ${YEAR}, ${TIME}`);
 
                     expect(adapter.rangeLongDateTime(startDate, endDate)).toBe(
@@ -1493,7 +1493,7 @@ describe('MomentDateAdapter formatter', () => {
                     const endDate = moment();
 
                     const startString = startDate.format(`${DAY_MONTH}, ${YEAR}, ${TIME}`);
-                    const endString = endDate.format(endDateFormat);
+                    const endString = endDate.format(`${DAY_MONTH}, ${YEAR}, ${TIME}`);
 
                     expect(adapter.rangeMiddleDateTime(startDate, endDate)).toBe(
                         `${startString}${LONG_DASH}${endString}`
@@ -1504,7 +1504,7 @@ describe('MomentDateAdapter formatter', () => {
                     const startDate = moment().dayOfYear(1);
                     const endDate = moment(startDate).add(1, 'years');
 
-                    const startString = startDate.format(startDateFormat);
+                    const startString = startDate.format(`${DAY_MONTH}, ${YEAR}, ${TIME}`);
                     const endString = endDate.format(`${DAY_MONTH}, ${YEAR}, ${TIME}`);
 
                     expect(adapter.rangeMiddleDateTime(startDate, endDate)).toBe(

--- a/packages/mosaic-moment-adapter/adapter/moment-date-adapter.ts
+++ b/packages/mosaic-moment-adapter/adapter/moment-date-adapter.ts
@@ -357,6 +357,12 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
         const endDateVariables = this.compileVariables(endDate, variables);
         endDateVariables.SAME_MONTH = sameMonth;
 
+        const bothCurrentYear =
+            startDateVariables.CURRENT_YEAR === 'yes' &&
+            endDateVariables.CURRENT_YEAR === 'yes';
+        startDateVariables.CURRENT_YEAR = bothCurrentYear ? 'yes' : 'no';
+        endDateVariables.CURRENT_YEAR = bothCurrentYear ? 'yes' : 'no';
+
         const params = {...variables,
             START_DATE: this.messageformat.compile(template.START_DATE)(startDateVariables),
             END_DATE: this.messageformat.compile(template.END_DATE)(endDateVariables),
@@ -381,6 +387,12 @@ export class MomentDateAdapter extends DateAdapter<Moment> {
         const endDateVariables = this.compileVariables(endDate, variables);
         endDateVariables.SAME_MONTH = sameMonth;
         endDateVariables.SAME_DAY = sameDay;
+
+        const bothCurrentYear =
+            startDateVariables.CURRENT_YEAR === 'yes' &&
+            endDateVariables.CURRENT_YEAR === 'yes';
+        startDateVariables.CURRENT_YEAR = bothCurrentYear ? 'yes' : 'no';
+        endDateVariables.CURRENT_YEAR = bothCurrentYear ? 'yes' : 'no';
 
         const params = {...variables,
             START_DATETIME: this.messageformat.compile(template.START_DATETIME)(startDateVariables),


### PR DESCRIPTION
@Fost 
@lskramarov 
@mikeozornin 

TFS - 185214

Паста от Мишы

По нашему формату мы не пишем год, когда он текущий. Это приводит к таким картинкам:
http://screenshots.ptsecurity.com/mozornin-2019-06-04_14-11-36.png
Догадаться, что это 2019 невозможно, это небольшая катастрофа. Хочется переработать диапазоны.

Сейчас: Если год текущий на одном из концов, то его не пишем
Надо бы: Если год текущий на обоих концах совпадает, то их оба не пишем.

Примеры здесь: wiki - 20332985 исправлены