### PR TITLE
Fix(tabs): stretching while applying mc-stretch-tab within mc-light-tab

### DIFF
--- a/packages/mosaic-dev/tabs/template.html
+++ b/packages/mosaic-dev/tabs/template.html
@@ -1,4 +1,14 @@
 <div>
+    <h4>Default tabs</h4>
+    <mc-tab-group>
+        <mc-tab label="First">Content 1</mc-tab>
+        <mc-tab label="Second">Content 2</mc-tab>
+        <mc-tab disabled label="Third">Content 3</mc-tab>
+        <mc-tab label="4">Content 4</mc-tab>
+        <mc-tab label="5">Content 5</mc-tab>
+    </mc-tab-group>
+
+    <h4>Light tabs</h4>
     <mc-tab-group mc-light-tabs>
         <mc-tab label="First">Content 1</mc-tab>
         <mc-tab label="Second">Content 2</mc-tab>
@@ -7,15 +17,15 @@
         <mc-tab label="5">Content 5</mc-tab>
     </mc-tab-group>
 
-    <br><br><br>
-
-    <mc-tab-group>
+    <h4>Light tabs + stretch tabs</h4>
+    <mc-tab-group mc-light-tabs mc-stretch-tabs>
         <mc-tab label="First">Content 1</mc-tab>
         <mc-tab label="Second">Content 2</mc-tab>
         <mc-tab disabled label="Third">Content 3</mc-tab>
         <mc-tab label="4">Content 4</mc-tab>
         <mc-tab label="5">Content 5</mc-tab>
     </mc-tab-group>
+
 
     <h3>Navigation</h3>
 

--- a/packages/mosaic/tabs/tab-header.scss
+++ b/packages/mosaic/tabs/tab-header.scss
@@ -76,7 +76,7 @@
     }
 }
 
-.mc-tab-label {
+.mc-tab-label, .mc-tab-light-label {
     .mc-tab-group_stretch-labels & {
         flex-basis: 0;
         flex-grow: 1;


### PR DESCRIPTION
Style for stretch & light tab label has been fixed.