### PR TITLE
fix(modal): Фокус полей выходит за границы модального окна #UIM-11

### DIFF
--- a/packages/dev-app/system-config.ts
+++ b/packages/dev-app/system-config.ts
@@ -16,6 +16,7 @@ System.config({
         'rxjs/operators': 'system-rxjs-operators.js',
 
         // Angular CDK specific mappings.
+        '@angular/cdk/a11y': 'node:@angular/cdk/bundles/cdk-a11y.umd.js',
         '@angular/cdk/bidi': 'node:@angular/cdk/bundles/cdk-bidi.umd.js',
         '@angular/cdk/coercion': 'node:@angular/cdk/bundles/cdk-coercion.umd.js',
         '@angular/cdk/collections': 'node:@angular/cdk/bundles/cdk-collections.umd.js',
@@ -23,6 +24,7 @@ System.config({
         '@angular/cdk/platform': 'node:@angular/cdk/bundles/cdk-platform.umd.js',
         '@angular/cdk/portal': 'node:@angular/cdk/bundles/cdk-portal.umd.js',
         '@angular/cdk/overlay': 'node:@angular/cdk/bundles/cdk-overlay.umd.js',
+        '@angular/cdk/observers': 'node:@angular/cdk/bundles/cdk-observers.umd.js',
         '@angular/cdk/scrolling': 'node:@angular/cdk/bundles/cdk-scrolling.umd.js',
 
         // Angular specific mappings.

--- a/packages/mosaic/modal/modal.component.html
+++ b/packages/mosaic/modal/modal.component.html
@@ -27,7 +27,7 @@
              [style.transform-origin]="transformOrigin"
              role="document"
         >
-            <div class="mc-modal-content">
+            <div class="mc-modal-content" cdkTrapFocus>
                 <button *ngIf="mcClosable" (click)="onClickCloseBtn()" class="mc-modal-close" aria-label="Close">
                   <span class="mc-modal-close-x">
                       <i mc-icon="mc-close-L_16" class="mc-icon mc-icon_light" color="second"></i>
@@ -86,7 +86,7 @@
                 <button *ngIf="mcOkText!==null" mc-button color="primary" (click)="onClickOkCancel('ok')">
                     {{ okText }}
                 </button>
-                <button *ngIf="mcCancelText!==null" mc-button (click)="onClickOkCancel('cancel')">
+                <button *ngIf="mcCancelText!==null" mc-button (click)="onClickOkCancel('cancel')" autofocus>
                     {{ cancelText }}
                 </button>
             </ng-container>
@@ -119,7 +119,7 @@
         <button mc-button [color]="mcOkType" #autoFocusButtonOk *ngIf="mcOkText !== ''" (click)="onClickOkCancel('ok')">
             {{ okText }}
         </button>
-        <button mc-button color="second" *ngIf="mcCancelText!==''" (click)="onClickOkCancel('cancel')">
+        <button mc-button color="second" *ngIf="mcCancelText!==''" (click)="onClickOkCancel('cancel')" autofocus>
             {{ cancelText }}
         </button>
     </div>

--- a/packages/mosaic/modal/modal.module.ts
+++ b/packages/mosaic/modal/modal.module.ts
@@ -1,3 +1,4 @@
+import { A11yModule } from '@angular/cdk/a11y';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
@@ -11,10 +12,10 @@ import { McModalService } from './modal.service';
 
 
 @NgModule({
-    imports: [ CommonModule, OverlayModule, McButtonModule, McIconModule ],
-    exports: [ McModalComponent ],
-    declarations: [ McModalComponent, CssUnitPipe ],
-    entryComponents: [ McModalComponent ],
-    providers: [ McModalControlService, McModalService ]
+    imports: [CommonModule, OverlayModule, A11yModule, McButtonModule, McIconModule],
+    exports: [McModalComponent],
+    declarations: [McModalComponent, CssUnitPipe],
+    entryComponents: [McModalComponent],
+    providers: [McModalControlService, McModalService]
 })
-export class McModalModule { }
+export class McModalModule {}

--- a/tests/karma-system-config.js
+++ b/tests/karma-system-config.js
@@ -10,12 +10,14 @@ System.config({
         'moment': 'node:moment/min/moment-with-locales.min.js',
         'messageformat': 'node:messageformat/messageformat.js',
 
+        '@angular/cdk/a11y': 'node:@angular/cdk/bundles/cdk-a11y.umd.js',
         '@angular/cdk/bidi': 'node:@angular/cdk/bundles/cdk-bidi.umd.js',
         '@angular/cdk/coercion': 'node:@angular/cdk/bundles/cdk-coercion.umd.js',
         '@angular/cdk/collections': 'node:@angular/cdk/bundles/cdk-collections.umd.js',
         '@angular/cdk/keycodes': 'node:@angular/cdk/bundles/cdk-keycodes.umd.js',
         '@angular/cdk/platform': 'node:@angular/cdk/bundles/cdk-platform.umd.js',
         '@angular/cdk/portal': 'node:@angular/cdk/bundles/cdk-portal.umd.js',
+        '@angular/cdk/observers': 'node:@angular/cdk/bundles/cdk-observers.umd.js',
         '@angular/cdk/overlay': 'node:@angular/cdk/bundles/cdk-overlay.umd.js',
         '@angular/cdk/scrolling': 'node:@angular/cdk/bundles/cdk-scrolling.umd.js',
 

--- a/tools/packages/rollup-globals.ts
+++ b/tools/packages/rollup-globals.ts
@@ -40,11 +40,13 @@ export const rollupGlobals = {
     'messageformat': 'messageformat',
 
     '@angular/cdk': 'ng.cdk',
+    '@angular/cdk/a11y': 'ng.cdk.a11y',
     '@angular/cdk/bidi': 'ng.cdk.bidi',
     '@angular/cdk/coercion': 'ng.cdk.coercion',
     '@angular/cdk/collections': 'ng.cdk.collections',
     '@angular/cdk/platform': 'ng.cdk.platform',
     '@angular/cdk/portal': 'ng.cdk.portal',
+    '@angular/cdk/observers': 'ng.cdk.observers',
     '@angular/cdk/overlay': 'ng.cdk.overlay',
     '@angular/cdk/scrolling': 'ng.cdk.scrolling',
 


### PR DESCRIPTION
Добавил CdkTrapFocus, теперь фокус из модалки не уходит, но вот изначально его придется инициализировать с помощью autofocus.
В два дефолтных шаблона добавил autofocus.