### PR TITLE
fix(link): add style for correct display of a focused link (#51)

### DIFF
--- a/packages/mosaic/link/_link-theme.scss
+++ b/packages/mosaic/link/_link-theme.scss
@@ -16,6 +16,10 @@
     .mc-link {
         color: $color;
 
+        &:focus {
+            outline: none;
+        }
+
         &:visited {
             color: $color;
         }
@@ -25,7 +29,8 @@
         }
 
         &.cdk-keyboard-focused {
-            outline-color: $color;
+            outline: $color solid 2px;
+            outline-offset: 2px;
         }
 
         &.mc-link_underlined .mc-link__text {

--- a/packages/mosaic/link/link.scss
+++ b/packages/mosaic/link/link.scss
@@ -22,9 +22,7 @@
     }
 
     &.cdk-mouse-focused {
-        outline-width: 2px;
-        outline-style: solid;
-        outline-offset: 2px;
+        outline: none;
     }
 
     &[disabled] {

--- a/packages/mosaic/link/link.scss
+++ b/packages/mosaic/link/link.scss
@@ -15,16 +15,6 @@
         margin-right: 4px;
     }
 
-    &.cdk-focused {
-        outline-width: 2px;
-        outline-style: solid;
-        outline-offset: 2px;
-    }
-
-    &.cdk-mouse-focused {
-        outline: none;
-    }
-
     &[disabled] {
         pointer-events: none;
         cursor: default;

--- a/packages/mosaic/link/link.scss
+++ b/packages/mosaic/link/link.scss
@@ -15,7 +15,7 @@
         margin-right: 4px;
     }
 
-    &.cdk-keyboard-focused {
+    &.cdk-focused {
         outline-width: 2px;
         outline-style: solid;
         outline-offset: 2px;

--- a/packages/mosaic/link/link.scss
+++ b/packages/mosaic/link/link.scss
@@ -21,6 +21,12 @@
         outline-offset: 2px;
     }
 
+    &.cdk-mouse-focused {
+        outline-width: 2px;
+        outline-style: solid;
+        outline-offset: 2px;
+    }
+
     &[disabled] {
         pointer-events: none;
         cursor: default;


### PR DESCRIPTION
fix(link): add &.cdk-mouse-focused style for correct display of a focused link (#51)

correct display of a focused link on mouth click

Breaking Changes: none