### PR TITLE
fix(multiselect):  multyselect tag size #90

### DIFF
--- a/packages/mosaic/select/select.scss
+++ b/packages/mosaic/select/select.scss
@@ -55,7 +55,7 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
     cursor: pointer;
 
     // todo возможно нужно через JS
-    padding: 3px 7px 3px 15px;
+    padding: 3px 7px 2px 15px;
 
     &.mc-select__trigger_multiple {
         padding-left: 7px;
@@ -87,7 +87,7 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
 
     overflow: hidden;
 
-    max-height: 26px;
+    max-height: 28px;
 
     margin: 0;
     padding-left: 0;

--- a/packages/mosaic/select/select.scss
+++ b/packages/mosaic/select/select.scss
@@ -55,7 +55,7 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
     cursor: pointer;
 
     // todo возможно нужно через JS
-    padding: 3px 7px 2px 15px;
+    padding: 1px 7px 1px 15px;
 
     &.mc-select__trigger_multiple {
         padding-left: 7px;
@@ -70,9 +70,6 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
 
     overflow: hidden;
     text-overflow: ellipsis;
-
-    // compensate borders
-    margin-top: -2px;
 
     white-space: nowrap;
 

--- a/packages/mosaic/select/select.scss
+++ b/packages/mosaic/select/select.scss
@@ -55,7 +55,10 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
     cursor: pointer;
 
     // todo возможно нужно через JS
-    padding: 0 7px 0 15px;
+    padding: {
+        right: 7px;
+        left: 15px;
+    };
 
     &.mc-select__trigger_multiple {
         padding-left: 7px;
@@ -124,9 +127,7 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
 }
 
 .mc-select__arrow-wrapper {
-    display: table-cell;
-    vertical-align: middle;
-    line-height: 30px;
+    align-self: center;
 
     // When used in a box or standard appearance form-field the arrow should be shifted up 50%.
     .mc-form-field-appearance-fill &,

--- a/packages/mosaic/select/select.scss
+++ b/packages/mosaic/select/select.scss
@@ -55,7 +55,7 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
     cursor: pointer;
 
     // todo возможно нужно через JS
-    padding: 1px 7px 1px 15px;
+    padding: 0 7px 0 15px;
 
     &.mc-select__trigger_multiple {
         padding-left: 7px;
@@ -126,6 +126,7 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
 .mc-select__arrow-wrapper {
     display: table-cell;
     vertical-align: middle;
+    line-height: 30px;
 
     // When used in a box or standard appearance form-field the arrow should be shifted up 50%.
     .mc-form-field-appearance-fill &,


### PR DESCRIPTION
@mikeozornin, проблема была в том, что тегу требуется 28 пикселей, а в select он обрезался родителем в 26px, а потому box-shadow, на который приходится 1px границы обрезался. Я увеличила высоту до 28px и изменила padding .mc-select__trigger - чтобы он укладывался в 30px элемента. А потом убрала  margin-top - он ломал симметрию.