### PR TITLE
fix(dropdown): .mc-link outline set to none #86  

### DIFF
--- a/packages/mosaic/dropdown/_dropdown-theme.scss
+++ b/packages/mosaic/dropdown/_dropdown-theme.scss
@@ -30,11 +30,11 @@
         }
 
         &.cdk-keyboard-focused, &.cdk-program-focused {
-            border-color: mc-color($primary);
-            box-shadow: inset 0 0 0 1px mc-color($primary);
+            outline: mc-color($primary) solid 2px;
+            outline-offset: -2px;
 
             &.mc-link{
-                outline: none;
+                outline-offset: -2px;
             }
 
         }

--- a/packages/mosaic/dropdown/_dropdown-theme.scss
+++ b/packages/mosaic/dropdown/_dropdown-theme.scss
@@ -32,6 +32,11 @@
         &.cdk-keyboard-focused, &.cdk-program-focused {
             border-color: mc-color($primary);
             box-shadow: inset 0 0 0 1px mc-color($primary);
+
+            &.mc-link{
+                outline: none;
+            }
+
         }
 
         &[disabled] {


### PR DESCRIPTION
Сейчас у ссылки в компоненте dropdown при фокусе появляется и граница и outline. 
Для решения классу .mc-link добавлено свойство outline: none.