### PR TITLE
fix(cdk): add cdk-*-focused classes to radio and disable focus on alert #94 

### DIFF
--- a/packages/mosaic/core/styles/_alerts.scss
+++ b/packages/mosaic/core/styles/_alerts.scss
@@ -98,11 +98,7 @@
 
     $is-dark: map-get($theme, is-dark);
 
-    .mc-alert__close:focus {
-        border: 1px solid mc-color($primary);
-        box-shadow: 0 0 0 1px mc-color($primary);
-        z-index: 1;
-    }
+    
 
     .mc-alert {
         color: mc-color($foreground, text);

--- a/packages/mosaic/radio/_radio-theme.scss
+++ b/packages/mosaic/radio/_radio-theme.scss
@@ -43,7 +43,7 @@
             }
         }
 
-        & .mc-radio-input:focus {
+        &.cdk-keyboard-focused .mc-radio-input {
             + .mc-radio-label-content .mc-radio-button__outer-circle {
                 border-color: $focus-color;
 

--- a/packages/mosaic/radio/radio.component.ts
+++ b/packages/mosaic/radio/radio.component.ts
@@ -1,3 +1,4 @@
+import { FocusMonitor } from '@angular/cdk/a11y';
 import { UniqueSelectionDispatcher } from '@angular/cdk/collections';
 import {
     AfterContentInit, AfterViewInit,
@@ -18,7 +19,7 @@ import {
     mixinTabIndex,
     toBoolean
 } from '@ptsecurity/mosaic/core';
-import {FocusMonitor} from '@angular/cdk/a11y';
+
 
 // Increasing integer for generating unique ids for radio components.
 let nextUniqueId = 0;
@@ -302,8 +303,7 @@ export const _McRadioButtonMixinBase:
         class: 'mc-radio-button',
         '[attr.id]': 'id',
         '[class.mc-checked]': 'checked',
-        '[class.mc-disabled]': 'disabled',
-        '(focus)': '_inputElement.nativeElement.focus()'
+        '[class.mc-disabled]': 'disabled'
     }
 })
 export class McRadioButton extends _McRadioButtonMixinBase
@@ -439,7 +439,7 @@ export class McRadioButton extends _McRadioButtonMixinBase
         @Optional() radioGroup: McRadioGroup,
         elementRef: ElementRef,
         private readonly _changeDetector: ChangeDetectorRef,
-        private _focusMonitor: FocusMonitor,
+        private focusMonitor: FocusMonitor,
         private readonly _radioDispatcher: UniqueSelectionDispatcher
     ) {
 
@@ -465,7 +465,7 @@ export class McRadioButton extends _McRadioButtonMixinBase
     }
 
     ngAfterViewInit() {
-        this._focusMonitor
+        this.focusMonitor
             .monitor(this._elementRef, true)
             .subscribe((focusOrigin) => {
                 if (!focusOrigin && this.radioGroup) {
@@ -475,14 +475,13 @@ export class McRadioButton extends _McRadioButtonMixinBase
     }
 
     ngOnDestroy() {
-        this._focusMonitor.stopMonitoring(this._elementRef);
+        this.focusMonitor.stopMonitoring(this._elementRef);
         this.removeUniqueSelectionListener();
     }
 
     /** Focuses the radio button. */
-    // tslint:disable-next-line
     focus(): void {
-        this._focusMonitor.focusVia(this._inputElement, 'keyboard');
+        this._inputElement.nativeElement.focus();
     }
 
     /**


### PR DESCRIPTION
В компонент radio был добавлен FocusMonitor и отключен фокус при клике мыши. В alert не думаю, что есть смысл добавлять FocusMonitor для кнопки - попробовала установить фокус клавиатурой на реальном alert с `position: absolute;` - не сработало. Пока просто отключила фокус на кнопке закрыть. @mikeozornin, посмотришь?