### PR TITLE
fix(dropdown): dropdown's scroll fix

### DIFF
--- a/packages/mosaic/dropdown/dropdown.scss
+++ b/packages/mosaic/dropdown/dropdown.scss
@@ -15,6 +15,7 @@ $mc-dropdown-panel-border-radius: 3px !default;
     padding: 5px 15px;
 
     text-align: left;
+    white-space: nowrap;
 
     &:not([disabled]) {
         cursor: pointer;


### PR DESCRIPTION
fix(dropdown): dropdown's scroll fix

dropdown's scroll fix

Breaking Changes: none

Проблема была в том, что Edge при первом показе dropdown переносил слова на следующую строку, хотя необходимости в этом не было. На сколько я понимаю, у dropdown потребности в переносе нет, так что пока я поправила баг с помощью `white-space: nowrap;`