### PR TITLE
feat(docs): styling generated from markdown content

### DIFF
--- a/packages/docs/src/app/components/anchors/anchors.component.ts
+++ b/packages/docs/src/app/components/anchors/anchors.component.ts
@@ -29,11 +29,14 @@ export class AnchorsComponent {
     // коэффициент для вычисления расстояния якоря над заголовком при скроле (== headerHeight * anchorHeaderCoef)
     anchorHeaderCoef = 3;
     debounceTime: number = 5;
+    readonly isSmoothScrollSupported;
     private destroyed = new Subject();
     private urlFragment = '';
     private scrollContainer: any;
     private currentUrl: any;
     private scrollTimeout: number = 1000;
+    private scrolling = false;
+    private scrollOptions: ScrollIntoViewOptions = { behavior: 'smooth' };
 
     constructor(private router: Router,
                 private route: ActivatedRoute,
@@ -41,7 +44,7 @@ export class AnchorsComponent {
                 private ref: ChangeDetectorRef,
                 @Inject(DOCUMENT) private document: Document) {
         this.container = '.anchors-menu';
-
+        this.isSmoothScrollSupported  = 'scrollBehavior' in this.document.documentElement.style;
         this.router.events.pipe(takeUntil(this.destroyed)).subscribe((event) => {
             if (event instanceof NavigationEnd) {
                 const rootUrl = router.url.split('#')[0];
@@ -56,20 +59,34 @@ export class AnchorsComponent {
         // Срабатывает при изменении якоря в адресной строке руками или кликом по якорю
         this.route.fragment.pipe(takeUntil(this.destroyed)).subscribe((fragment) => {
             this.urlFragment = fragment;
-            const target = document.getElementById(this.urlFragment);
+            const anchorActive = this.document.querySelector('.anchors-menu__list-element_active');
+
+            const target = this.document.getElementById(this.urlFragment);
             const index = this.getAnchorIndex(this.urlFragment);
 
             if (index) { this.setActiveAnchor(index); }
 
             if (target) {
                 this.click = true;
-                target.scrollIntoView();
+
+                if (anchorActive && this.urlFragment === anchorActive.textContent.trim().toLowerCase()) {
+                    return;
+                }
+                this.scrollTo(target);
             }
         });
     }
 
     ngOnDestroy() {
         this.destroyed.next();
+    }
+
+    scrollTo(target) {
+        if (this.isSmoothScrollSupported) {
+            target.scrollIntoView(this.scrollOptions);
+        } else {
+            target.scrollIntoView();
+        }
     }
 
     getAnchorIndex(urlFragment): number {
@@ -83,14 +100,14 @@ export class AnchorsComponent {
 
     setScrollPosition() {
         this.anchors = this.createAnchors();
-        const target = document.getElementById(this.urlFragment);
+        const target = this.document.getElementById(this.urlFragment);
 
         if (target) {
             const index = this.getAnchorIndex(this.urlFragment);
 
             if (index) { this.setActiveAnchor(index); }
             target.scrollTop += this.headerHeight;
-            target.scrollIntoView();
+            this.scrollTo(target);
         }
 
         const scrollPromise = new Promise((resolve, reject) => {
@@ -154,7 +171,7 @@ export class AnchorsComponent {
     private onScroll() {
         // Если переход на якорь был инициирован не скролом выходим из функции
         if (this.click) {
-            this.click = false;
+            this.disableClickState();
 
             return;
         }
@@ -180,5 +197,13 @@ export class AnchorsComponent {
         }
         this.anchors[index].active = true;
         this.ref.detectChanges();
+    }
+
+    private disableClickState() {
+        // При клике по якорю браузер вызывает scroll несколько раз - setTimeout нужен, чтобы код отработал единожды
+        // Возможная альтернатива: debounceTime: number = 50; - но это ухудшает отзывчивость якорей при скролле
+        setTimeout(() => {
+            this.click = false;
+        }, 500);
     }
 }

--- a/packages/docs/src/app/components/anchors/anchors.component.ts
+++ b/packages/docs/src/app/components/anchors/anchors.component.ts
@@ -21,13 +21,12 @@ interface IAnchor {
 })
 export class AnchorsComponent {
     @Input() anchors: IAnchor[] = [];
-    // TODO edit selector to the right one after content correction - there wil be no h3 after that
-    @Input() headerSelectors = 'h3.docs-header-link';
+    @Input() headerSelectors = '.docs-header-link_3';
 
     click: boolean = false;
     container: string;
     headerHeight: number = 64;
-    // коэффициент для вычисления расстояния якоря над заголовком при скроле ( = headerHeight*anchorHeaderCoef)
+    // коэффициент для вычисления расстояния якоря над заголовком при скроле (== headerHeight * anchorHeaderCoef)
     anchorHeaderCoef = 3;
     debounceTime: number = 5;
     private destroyed = new Subject();

--- a/packages/docs/src/app/components/component-viewer/component-overview-theme.scss
+++ b/packages/docs/src/app/components/component-viewer/component-overview-theme.scss
@@ -1,0 +1,7 @@
+@mixin mc-component-viewer-theme($theme) {
+    $second: map-get($theme, second);
+
+    .title{
+        color: map-get($second, 700);
+    }
+}

--- a/packages/docs/src/app/components/component-viewer/component-overview.scss
+++ b/packages/docs/src/app/components/component-viewer/component-overview.scss
@@ -1,3 +1,14 @@
-.capitalize {
+.title{
     text-transform: capitalize;
+}
+
+.docs-header-link {
+    padding-top: 20px;
+}
+
+.docs-markdown {
+    &__p {
+        margin: 0;
+        padding-top: 8px;
+    }
 }

--- a/packages/docs/src/app/components/component-viewer/component-overview.template.html
+++ b/packages/docs/src/app/components/component-viewer/component-overview.template.html
@@ -1,4 +1,4 @@
-<span class="mc-display-3 capitalize">
+<span class="mc-display-3 title">
     {{componentViewer.componentDocItem.id}}
 </span>
 <doc-viewer

--- a/packages/docs/src/app/components/main-layout/main-layout.component.scss
+++ b/packages/docs/src/app/components/main-layout/main-layout.component.scss
@@ -4,16 +4,9 @@
     margin: {
         top: 64px;
         left: 360px;
+        right: 360px;
         bottom: 62px;
     }
 
-    padding: {
-        top: 20px;
-        right: 360px;
-        left: 48px;
-    }
-
-    &__wrapper {
-        padding: 10px 0;
-    }
+    padding: 20px 69px;
 }

--- a/packages/docs/src/app/docs.scss
+++ b/packages/docs/src/app/docs.scss
@@ -1,3 +1,7 @@
+html {
+    scroll-behavior: smooth;
+}
+
 docs-app {
     display: flex;
     flex-direction: column;

--- a/packages/docs/src/app/shared/example-viewer/_example-viewer-theme.scss
+++ b/packages/docs/src/app/shared/example-viewer/_example-viewer-theme.scss
@@ -8,7 +8,7 @@
     example-viewer {
         .docs-example-viewer-wrapper {
             border: 1px solid rgba(mc-color($foreground, secondary-text), 0.03);
-            box-shadow: 0 2px 2px rgba(0, 0, 0, 0.24), 0 0 2px rgba(0, 0, 0, 0.12);
+            box-shadow: 0 2px 2px rgba(0,0,0,0.24), 0 0 2px rgba(0,0,0,0.12);
             margin: 4px;
         }
 
@@ -30,6 +30,10 @@
         .docs-example-source {
             border-bottom: 1px solid mc-color($foreground, divider);
             overflow: auto;
+        }
+
+        .docs-example-viewer-body {
+            border: 1px solid mc-color($foreground, divider);
         }
     }
 }

--- a/packages/docs/src/app/shared/example-viewer/example-viewer.html
+++ b/packages/docs/src/app/shared/example-viewer/example-viewer.html
@@ -1,16 +1,12 @@
-<div class="docs-example-viewer-wrapper">
-    <div class="docs-example-viewer-title">
-        <div class="docs-example-viewer-title-spacer">{{exampleData?.title}}</div>
-
-        <button type="button" (click)="toggleSourceView()">
-            SourceView button
-        </button>
-
-
-        <stackblitz-button [example]="example"></stackblitz-button>
+<div class="docs-example-viewer__wrapper">
+    <div class="docs-example-viewer__example">
+        <div class="docs-example-viewer-body">
+            <ng-template [cdkPortalOutlet]="selectedPortal"></ng-template>
+        </div>
     </div>
 
-    <div class="docs-example-viewer-source" *ngIf="showSource">
+    <div class="docs-example-viewer__source" >
+        <stackblitz-button [example]="example"></stackblitz-button>
         <mc-tab-group mc-light-tabs>
             <mc-tab *ngFor="let tabName of getExampleTabNames()" [label]="tabName">
                 <div class="docs-example-source-wrapper">
@@ -20,9 +16,5 @@
                 </div>
             </mc-tab>
         </mc-tab-group>
-    </div>
-
-    <div class="docs-example-viewer-body">
-        <ng-template [cdkPortalOutlet]="selectedPortal"></ng-template>
     </div>
 </div>

--- a/packages/docs/src/app/shared/example-viewer/example-viewer.scss
+++ b/packages/docs/src/app/shared/example-viewer/example-viewer.scss
@@ -43,5 +43,5 @@
 }
 
 .docs-example-viewer-body {
-    padding: 30px;
+    padding: 16px;
 }

--- a/packages/docs/src/app/shared/stackblitz/stackblitz-button-theme.scss
+++ b/packages/docs/src/app/shared/stackblitz/stackblitz-button-theme.scss
@@ -1,0 +1,44 @@
+@mixin docs-stackblitz-theme($theme) {
+    $primary: map-get($theme, primary);
+    $second: map-get($theme, second);
+    $foreground: map-get($theme, foreground);
+
+    $is-dark: map-get($theme, is-dark);
+
+    $color: mc-color($primary);
+    $color_hover: mc-color($primary, if($is-dark, lighter, darker));
+    $color_disabled: mc-color($foreground, disabled-text);
+
+    .stackblitz__link {
+        color: $color;
+        border-bottom: 1px solid rgba($color, 0.5);
+
+        &:focus {
+            outline: none;
+        }
+
+        &:visited {
+            color: $color;
+        }
+
+        &:hover {
+            color: $color_hover;
+            border-bottom-color: rgba($color_hover, 0.5);
+        }
+
+        &.cdk-keyboard-focused {
+            outline: $color solid 2px;
+            outline-offset: 2px;
+        }
+
+        &[disabled] {
+            color: $color_disabled;
+        }
+    }
+}
+
+@mixin docs-stackblitz-typography($config) {
+    .stackblitz__link {
+        @include mc-typography-level-to-styles($config, body);
+    }
+}

--- a/packages/docs/src/app/shared/stackblitz/stackblitz-button.html
+++ b/packages/docs/src/app/shared/stackblitz/stackblitz-button.html
@@ -1,7 +1,11 @@
-<div>
-  <button mc-button type="button"
+<div class="stackblitz__wrapper">
+
+    <svg class="stackblitz__icon" width='9.5px' height='14px' viewBox='0 0 23 34' version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink'> <title>Path</title> <desc>Created with Sketch.</desc> <g id='Symbols' stroke='none' stroke-width='1' fill='none' fill-rule='evenodd'> <g class='icon' fill='#1389FD' fill-rule='nonzero'> <polygon id='Path' points='0 19.9187087 9.87007874 19.9187087 4.12007874 34 23 13.9612393 13.0846457 13.9612393 18.7893701 0'></polygon> </g> </g> </svg>
+
+    <button
+        class = "stackblitz__link"
         (click)="openStackblitz()"
         [disabled]="isDisabled">
-    Stackblitz
+        Stackblitz
   </button>
 </div>

--- a/packages/docs/src/app/shared/stackblitz/stackblitz-button.scss
+++ b/packages/docs/src/app/shared/stackblitz/stackblitz-button.scss
@@ -1,0 +1,25 @@
+.stackblitz {
+
+    &__wrapper {
+        position: absolute;
+        right: 0;
+    }
+
+    &__icon{
+        width: 9.5px;
+        height: 14px;
+        margin-bottom: -2px;
+    }
+
+    &__link {
+        margin: {
+            top: 11px;
+            bottom: 11px;
+        }
+
+        background: none;
+        border-top: 0;
+        border-left: 0;
+        border-right: 0;
+    }
+}

--- a/packages/docs/src/app/shared/stackblitz/stackblitz-button.ts
+++ b/packages/docs/src/app/shared/stackblitz/stackblitz-button.ts
@@ -9,6 +9,7 @@ import { StackblitzWriter } from './stackblitz-writer';
 @Component({
     selector: 'stackblitz-button',
     templateUrl: './stackblitz-button.html',
+    styleUrls: ['./stackblitz-button.scss'],
     providers: [StackblitzWriter],
     host: {
         '(mouseover)': 'isDisabled = !stackblitzForm'

--- a/packages/docs/src/main.scss
+++ b/packages/docs/src/main.scss
@@ -9,6 +9,9 @@
 @import "~@ptsecurity/mosaic-icons/dist/styles/mc-icons.css";
 @import 'app/components/navbar/navbar-theme';
 @import 'app/components/footer/footer-theme';
+@import 'app/components/component-viewer/component-overview-theme';
+@import 'app/shared/stackblitz/stackblitz-button-theme';
+@import 'app/shared/example-viewer/example-viewer-theme';
 
 $primary: mc-palette($mc-blue, 400, 500, 600);
 $second: mc-palette($mc-grey, 100, 300, 400);
@@ -37,3 +40,15 @@ $config: mc-typography-config();
 @include mc-footer-theme($theme);
 
 @include mc-footer-typography($config);
+
+@include mc-component-viewer-theme($theme);
+
+@include docs-markdown-theme($theme);
+
+@include docs-markdown-typography($config);
+
+@include docs-stackblitz-theme($theme);
+
+@include docs-stackblitz-typography($config);
+
+@include example-viewer-theme($theme);

--- a/packages/docs/src/styles/_common.scss
+++ b/packages/docs/src/styles/_common.scss
@@ -19,6 +19,7 @@ html {
     -webkit-font-smoothing: antialiased;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0); // 4
     -webkit-touch-callout: none;
+    scroll-behavior: smooth;
 }
 
 // Body

--- a/packages/docs/src/styles/_markdown.scss
+++ b/packages/docs/src/styles/_markdown.scss
@@ -1,77 +1,113 @@
 // Styles for overview and guide docs generated via `marked` from the material2 repo.
-
 .docs-markdown {
     max-width: 100%;
 
-    h1 {
-        display: inline-block;
-        font-size: 34px;
-        font-weight: 400;
-        padding: 5px;
+    &__p {
+        margin: 0;
+        padding-top: 8px;
     }
 
-    h2 {
-        font-size: 24px;
-    }
-
-    h3 {
-        font-size: 20px;
-    }
-
-    h2, h4 {
-        margin-top: 40px;
-    }
-
-    h5 {
-        font-size: 18px;
-    }
-
-    p, ul, ol {
-        font-size: 16px;
-        line-height: 28px;
-    }
-
-    a {
+    &__a {
+        display: initial;
         text-decoration: none;
-    }
-
-    td code {
-        font-size: 14px;
-    }
-
-    pre {
-        border-radius: 5px;
-        display: flex;
-        margin: 0 auto;
-        overflow-x: auto;
-        padding: 20px;
-        white-space: pre-wrap;
-
-        code {
-            padding: 0;
-            font-size: 100%;
-        }
-    }
-
-    code {
-        padding: 3px;
+        cursor: pointer;
     }
 }
 
-.docs-header-link {
-    header-link a {
-        text-decoration: none;
-        // deduct -30px so the anchor icon will be positioned outside the content
-        margin-left: -30px;
-        display: inline-block;
-        vertical-align: middle;
+@mixin docs-markdown-theme($theme) {
+    $primary: map-get($theme, primary);
+    $second: map-get($theme, second);
+    $foreground: map-get($theme, foreground);
+
+    $is-dark: map-get($theme, is-dark);
+
+    $color: mc-color($primary);
+    $color_hover: mc-color($primary, if($is-dark, lighter, darker));
+    $color_disabled: mc-color($foreground, disabled-text);
+
+    .docs-header-link {
+        color: map-get($second, 700);
     }
 
-    .material-icons {
-        visibility: hidden;
+    .docs-markdown {
+        color: map-get($second, 700);
+
+        &__a {
+            color: $color;
+            border-bottom: 1px solid rgba($color, 0.5);
+
+            &:focus {
+                outline: none;
+            }
+
+            &:visited {
+                color: $color;
+            }
+
+            &:hover {
+                color: $color_hover;
+                border-bottom-color: rgba($color_hover, 0.5);
+            }
+
+            &.cdk-keyboard-focused {
+                outline: $color solid 2px;
+                outline-offset: 2px;
+            }
+
+            &[disabled] {
+                color: $color_disabled;
+            }
+        }
     }
 
-    &:hover .material-icons {
-        visibility: visible;
+    .docs-example-viewer__source {
+        position: relative;
+    }
+}
+
+@mixin docs-markdown-typography($config) {
+
+    .docs-header-link {
+        &_3 {
+            @include mc-typography-level-to-styles($config, headline);
+        }
+
+        &_4 {
+            @include mc-typography-level-to-styles($config, body-strong);
+        }
+    }
+
+    .docs-markdown {
+        &__p, &__a {
+            @include mc-typography-level-to-styles($config, body);
+        }
+    }
+}
+
+
+@mixin docs-linc($color, $color_hover, $color_disabled) {
+    color: $color;
+    border-bottom: 1px solid rgba($color, 0.5);
+
+    &:focus {
+        outline: none;
+    }
+
+    &:visited {
+        color: $color;
+    }
+
+    &:hover {
+        color: $color_hover;
+        border-bottom-color: rgba($color_hover, 0.5);
+    }
+
+    &.cdk-keyboard-focused {
+        outline: $color solid 2px;
+        outline-offset: 2px;
+    }
+
+    &[disabled] {
+        color: $color_disabled;
     }
 }

--- a/packages/mosaic/button/button.md
+++ b/packages/mosaic/button/button.md
@@ -3,6 +3,7 @@ Mosaic buttons are available using native `<button>` or `<a>` elements.
 ### Variants
 There are two button variants, each applied as an attribute:
 + basic buttons
++ icon buttons
 
 #### Basic buttons
 


### PR DESCRIPTION
Стилизованы заголовки, текст и ссылки. Не стилизованы: списки и примеры кода.
Добавлен плавный скролл (работает только при поддержке браузера).