### PR TITLE
fix(form-field): ie fixes: apply vertical alignment on select, tree-select

### DIFF
--- a/packages/mosaic/select/select.component.ts
+++ b/packages/mosaic/select/select.component.ts
@@ -891,7 +891,7 @@ export class McSelect extends McSelectMixinBase implements
 
     private getTotalItemsWidthInMatcher(): number {
         const triggerClone = this.trigger.nativeElement.cloneNode(true);
-        triggerClone.querySelector('.mc-select__match-hidden-text').remove();
+        this._renderer.removeChild(triggerClone, triggerClone.querySelector('.mc-select__match-hidden-text'));
 
         this._renderer.setStyle(triggerClone, 'position', 'absolute');
         this._renderer.setStyle(triggerClone, 'visibility', 'hidden');
@@ -902,11 +902,15 @@ export class McSelect extends McSelectMixinBase implements
 
         let totalItemsWidth: number = 0;
         const itemMargin: number = 4;
-        triggerClone.querySelectorAll('mc-tag').forEach((item) => {
-            totalItemsWidth += item.getBoundingClientRect().width as number + itemMargin;
-        });
 
-        triggerClone.remove();
+        const mcTags = triggerClone.querySelectorAll('mc-tag');
+        const mcTagsLength = mcTags.length;
+
+        for (let i = 0; i < mcTagsLength; i++) {
+            totalItemsWidth += mcTags[i].getBoundingClientRect().width as number + itemMargin;
+        }
+
+        this._renderer.removeChild(this.trigger.nativeElement, triggerClone);
 
         return totalItemsWidth;
     }

--- a/packages/mosaic/select/select.component.ts
+++ b/packages/mosaic/select/select.component.ts
@@ -891,7 +891,7 @@ export class McSelect extends McSelectMixinBase implements
 
     private getTotalItemsWidthInMatcher(): number {
         const triggerClone = this.trigger.nativeElement.cloneNode(true);
-        this._renderer.removeChild(triggerClone, triggerClone.querySelector('.mc-select__match-hidden-text'));
+        triggerClone.querySelector('.mc-select__match-hidden-text').remove();
 
         this._renderer.setStyle(triggerClone, 'position', 'absolute');
         this._renderer.setStyle(triggerClone, 'visibility', 'hidden');
@@ -902,15 +902,11 @@ export class McSelect extends McSelectMixinBase implements
 
         let totalItemsWidth: number = 0;
         const itemMargin: number = 4;
+        triggerClone.querySelectorAll('mc-tag').forEach((item) => {
+            totalItemsWidth += item.getBoundingClientRect().width as number + itemMargin;
+        });
 
-        const mcTags = triggerClone.querySelectorAll('mc-tag');
-        const mcTagsLength = mcTags.length;
-
-        for (let i = 0; i < mcTagsLength; i++) {
-            totalItemsWidth += mcTags[i].getBoundingClientRect().width as number + itemMargin;
-        }
-
-        this._renderer.removeChild(this.trigger.nativeElement, triggerClone);
+        triggerClone.remove();
 
         return totalItemsWidth;
     }

--- a/packages/mosaic/select/select.scss
+++ b/packages/mosaic/select/select.scss
@@ -19,6 +19,9 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
 
     display: inline-block;
 
+    // Fix IE aligning - default align in IE is baseline, not the middle of element
+    vertical-align: top;
+
     width: 100%;
 
     outline: none;

--- a/packages/mosaic/select/select.scss
+++ b/packages/mosaic/select/select.scss
@@ -19,6 +19,8 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
 
     display: inline-block;
 
+    // Fix IE aligning - default align in IE is baseline, not the middle of element
+    vertical-align: top;
     width: 100%;
 
     outline: none;

--- a/packages/mosaic/select/select.scss
+++ b/packages/mosaic/select/select.scss
@@ -19,8 +19,6 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
 
     display: inline-block;
 
-    // Fix IE aligning - default align in IE is baseline, not the middle of element
-    vertical-align: top;
     width: 100%;
 
     outline: none;

--- a/packages/mosaic/tree-select/tree-select.scss
+++ b/packages/mosaic/tree-select/tree-select.scss
@@ -21,6 +21,9 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
 
     display: inline-block;
 
+    // Fix IE aligning - default align in IE is baseline, not the middle of element
+    vertical-align: top;
+
     width: 100%;
 
     outline: none;

--- a/packages/mosaic/tree-select/tree-select.scss
+++ b/packages/mosaic/tree-select/tree-select.scss
@@ -21,9 +21,6 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
 
     display: inline-block;
 
-    // Fix IE aligning - default align in IE is baseline, not the middle of element
-    vertical-align: top;
-
     width: 100%;
 
     outline: none;


### PR DESCRIPTION
**What's done**
- IE11: fix vertical alignment for select and tree-select components (should be set for inline-block elements with content);

**Was**
![image](https://user-images.githubusercontent.com/1513274/63841258-26cb3700-c98b-11e9-85c7-0b0f63929e3d.png)

**Now**
![image](https://user-images.githubusercontent.com/1513274/63841217-131fd080-c98b-11e9-9a9e-b292612cb296.png)



**Reviewers**
@Fost @mikeozornin @lskramarov 