### PR TITLE
feat(docs): code editor styling

### DIFF
--- a/packages/docs/src/app/components/footer/footer.component.scss
+++ b/packages/docs/src/app/components/footer/footer.component.scss
@@ -1,7 +1,7 @@
 .docs-footer {
     position: fixed;
     bottom: 0;
-
+    z-index: 1;
     width: 100%;
     will-change: transform;
     padding: {

--- a/packages/docs/src/app/shared/doc-viewer/doc-viewer-module.ts
+++ b/packages/docs/src/app/shared/doc-viewer/doc-viewer-module.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { McButtonModule } from '@ptsecurity/mosaic/button';
 import { McTabsModule } from '@ptsecurity/mosaic/tabs';
+import { McToolTipModule } from '@ptsecurity/mosaic/tooltip';
 
 import { CopierService } from '../copier/copier.service';
 import { ExampleViewer } from '../example-viewer/example-viewer';
@@ -18,7 +19,8 @@ import { DocViewer } from './doc-viewer';
         McTabsModule,
         CommonModule,
         StackblitzButtonModule,
-        PortalModule
+        PortalModule,
+        McToolTipModule
     ],
     providers: [CopierService],
     declarations: [DocViewer, ExampleViewer],

--- a/packages/docs/src/app/shared/example-viewer/example-viewer.html
+++ b/packages/docs/src/app/shared/example-viewer/example-viewer.html
@@ -12,8 +12,16 @@
             <mc-tab *ngFor="let tabName of getExampleTabNames()" [label]="tabName">
                 <div class="docs-example-source-wrapper">
                     <pre class="docs-example-numbers">{{numbers}}</pre>
+                    <span class="docs-example-source_copy">
+                            <i class="mc mc-copy_16"
+                               (click)="copyCode($event)"
+                               #tooltip="mcTooltip"
+                               mcTooltip
+                               mcTitle="Содержимое скопировано в буфер обмена"
+                               mcTrigger="manual"
+                               mcPlacement="bottom"></i>
+                    </span>
                     <pre class="docs-example-source">
-                        <span class="docs-example-source_copy"><i class="mc mc-copy_16" (click)="copyCode($event)"></i></span>
                         <doc-viewer #viewer [documentUrl]="exampleTabs[tabName]"></doc-viewer>
                         <div class="docs-example-source-shadow"></div>
                     </pre>

--- a/packages/docs/src/app/shared/example-viewer/example-viewer.scss
+++ b/packages/docs/src/app/shared/example-viewer/example-viewer.scss
@@ -36,10 +36,12 @@
 }
 
 .docs-example-source_copy {
+    display: flex;
     position: absolute;
     top: 0;
     right: 0;
-    padding: 2px 6px;
+    z-index: 1;
+    padding: 6px 6px;
 }
 
 .docs-example-viewer-title {

--- a/packages/docs/src/app/shared/example-viewer/example-viewer.ts
+++ b/packages/docs/src/app/shared/example-viewer/example-viewer.ts
@@ -1,6 +1,7 @@
 import { ComponentPortal } from '@angular/cdk/portal';
-import { Component, Input } from '@angular/core';
+import { Component, Input, ViewChild } from '@angular/core';
 import { EXAMPLE_COMPONENTS, LiveExample } from '@ptsecurity/mosaic-examples';
+import { McTooltip } from '@ptsecurity/mosaic/tooltip';
 
 import { CopierService } from '../copier/copier.service';
 
@@ -26,6 +27,7 @@ export class ExampleViewer {
     /** Whether the source for the example is being displayed. */
     showSource = false;
     numbers = '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n';
+    mcTooltipDelay = 3000;
     /** String key of the currently displayed example. */
     @Input()
     get example() {
@@ -46,6 +48,7 @@ export class ExampleViewer {
 
     private _example: string;
 
+    @ViewChild('tooltip', { static: false }) tooltip: McTooltip;
     constructor(private copier: CopierService) {
     }
 
@@ -75,6 +78,11 @@ export class ExampleViewer {
         sel.addRange(range);
         document.execCommand('copy');
         sel.removeAllRanges();
+
+        this.tooltip.show();
+        setTimeout(() => {
+            this.tooltip.hide();
+        }, this.mcTooltipDelay);
     }
 
     private resolveHighlightedExampleFile(fileName: string) {

--- a/packages/docs/src/app/shared/stackblitz/stackblitz-button.scss
+++ b/packages/docs/src/app/shared/stackblitz/stackblitz-button.scss
@@ -3,7 +3,7 @@
     &__wrapper {
         position: absolute;
         right: 0;
-        z-index: 1000;
+        z-index: 100;
     }
 
     &__icon{
@@ -22,5 +22,6 @@
         border-top: 0;
         border-left: 0;
         border-right: 0;
+        cursor: pointer;
     }
 }


### PR DESCRIPTION
Добавлен tooltip при копировании кода из редактора, исправлено заезжание ссылки stackblitz на шапку и области редактора на футер.