### PR TITLE
fix(splitter): sets wrong size for areas (#UIM-110)

### DIFF
--- a/packages/mosaic/splitter/splitter.component.ts
+++ b/packages/mosaic/splitter/splitter.component.ts
@@ -317,10 +317,7 @@ export class McSplitterComponent implements OnInit {
         const minRightAreaSize = rightArea.area.getMinSize();
 
         if (newLeftAreaSize <= minLeftAreaSize || newRightAreaSize <= minRightAreaSize) {
-            const rightAreaOffset = leftArea.initialSize - minLeftAreaSize;
-
-            leftArea.area.setSize(minLeftAreaSize);
-            rightArea.area.setSize(rightArea.initialSize + rightAreaOffset);
+            return;
         } else if (newLeftAreaSize <= 0) {
             leftArea.area.setSize(0);
             rightArea.area.setSize(rightArea.initialSize + leftArea.initialSize);


### PR DESCRIPTION
Непонятно зачем эта логика вообще была добавлена...