### PR TITLE
feat(docs): adding transparent buttons to navbar

### DIFF
--- a/packages/docs/src/app/components/navbar/_navbar-theme.scss
+++ b/packages/docs/src/app/components/navbar/_navbar-theme.scss
@@ -22,9 +22,12 @@
     }
 
     .docs-navbar-version {
-        color: if($is-dark, $text, $hint-text);
-
         &__date { color: $less-contrast-text; }
+
+        &__trigger.mc-icon-button,
+        &__trigger .docs-navbar-version__icon.mc-icon {
+            color: if($is-dark, $text, $hint-text);
+        }
     }
 
     .color-picker__dropdown-content {

--- a/packages/docs/src/app/components/navbar/navbar.scss
+++ b/packages/docs/src/app/components/navbar/navbar.scss
@@ -60,9 +60,7 @@ $doc-navbar-padding: 10px;
 .docs-navbar-version {
     display: flex;
     align-items: baseline;
-    height: $doc-navbar-font-size;
     font-size: $doc-navbar-font-size;
-    line-height: $doc-navbar-font-size;
     margin-bottom: -5px;
 
     &_bold { font-weight: 500; }
@@ -89,4 +87,11 @@ $doc-navbar-padding: 10px;
     top: 0;
     right: 0;
     z-index: 1000;
+}
+
+.color-picker .mc.mc-icon {
+    margin: {
+        left: 0;
+        right: 0;
+    }
 }

--- a/packages/docs/src/app/components/navbar/navbar.scss
+++ b/packages/docs/src/app/components/navbar/navbar.scss
@@ -60,7 +60,6 @@ $doc-navbar-padding: 10px;
 .docs-navbar-version {
     display: flex;
     align-items: baseline;
-    font-size: $doc-navbar-font-size;
     margin-bottom: -5px;
 
     &_bold { font-weight: 500; }
@@ -78,6 +77,10 @@ $doc-navbar-padding: 10px;
         display: flex;
         flex-grow: 1;
         white-space: nowrap;
+    }
+
+    &__trigger {
+        font-size: $doc-navbar-font-size;
     }
 }
 

--- a/packages/docs/src/app/components/navbar/navbar.template.html
+++ b/packages/docs/src/app/components/navbar/navbar.template.html
@@ -13,11 +13,12 @@
     </div>
 
     <div class="docs-navbar-version">
-        <div [mcDropdownTriggerFor]="versionDropdown" class="docs-navbar-version__trigger">
+        <button mc-button color="second" class="mc-button mc-button_transparent docs-navbar-version__trigger"
+                [mcDropdownTriggerFor]="versionDropdown">
             <span>Версия</span>
             <span class="docs-navbar-version__number" id="versionNumber">{{curVerIndex}}</span>
             <i mc-icon="mc-angle-down-L_16" class="docs-navbar-version__icon"></i>
-        </div>
+        </button>
         <mc-dropdown #versionDropdown="mcDropdown" xPosition="after" class="docs-navbar-version__dropdown">
             <button mc-dropdown-item *ngFor="let version of versions; let i = index" (click)="setVersion(version.number)" [class.docs-navbar-version_bold]="version.bold">
                 <span class="docs-navbar-version__item" >
@@ -31,10 +32,11 @@
     <div class="flex-spacer"></div>
 
     <div class="docs-navbar-dropdown">
-        <a class="docs-navbar-dropdown__trigger" [mcDropdownTriggerFor]="languageDropdown">
+        <button mc-button color="second" class="mc-button mc-button_transparent docs-navbar-dropdown__trigger"
+                [mcDropdownTriggerFor]="languageDropdown">
             <span >{{curLanguage}}</span>
             <i mc-icon="mc-angle-down-M_16" class="docs-navbar-dropdown__icon"></i>
-        </a>
+        </button>
 
         <mc-dropdown #languageDropdown="mcDropdown">
             <button mc-dropdown-item *ngFor="let language of languages; let i = index" (click)="setLanguage(language)">
@@ -44,10 +46,11 @@
     </div>
 
     <div class="docs-navbar-dropdown">
-        <a class="docs-navbar-dropdown__trigger" [mcDropdownTriggerFor]="themeDropdown">
-            <span>{{curTheme.name}}</span>
+        <button mc-button color="second" class="mc-button mc-button_transparent docs-navbar-dropdown__trigger"
+                [mcDropdownTriggerFor]="themeDropdown">
+            <span >{{curTheme.name}}</span>
             <i mc-icon="mc-angle-down-M_16" class="docs-navbar-dropdown__icon"></i>
-        </a>
+        </button>
 
         <mc-dropdown #themeDropdown="mcDropdown">
             <button mc-dropdown-item *ngFor="let theme of themes; let i = index" (click)="setTheme(i)">
@@ -57,7 +60,11 @@
     </div>
 
     <div class="color-picker">
-    <i mc-icon="mc-circle-8_16" [style.color]='activeColor.code' class="color-picker__icon" [mcDropdownTriggerFor]="colorDropdown"></i>
+        <button mc-button color="second" class="mc-button mc-button_transparent docs-navbar-dropdown__trigger"
+                [mcDropdownTriggerFor]="themeDropdown">
+            <i mc-icon="mc-circle-8_16" [style.color]='activeColor.code' class="color-picker__icon" [mcDropdownTriggerFor]="colorDropdown"></i>
+            <i mc-icon="mc-angle-down-M_16" class="docs-navbar-dropdown__icon"></i>
+        </button>
         <mc-dropdown #colorDropdown="mcDropdown" class="color-picker__dropdown" [style.margin-top]="0">
             <span *ngFor="let color of colors; let i = index" [class.color-picker__dropdown-content]="true" [class.mc-selected]="color.selected"  (click)="setColor(i)">
                 <i mc-icon="mc-circle-8_16" [style.color]='color.code' class="color-picker__icon"></i>


### PR DESCRIPTION
В компоненте навбар ссылки заменены на прозрачные кнопки. В данный момент модификатор _transparent не отрабатывает. PR исправляющий этот баг уже отправлен: https://github.com/positive-js/mosaic/pull/256