### PR TITLE
fix(dropdown): hide scrollbar in safary

### DIFF
--- a/packages/mosaic/dropdown/dropdown.scss
+++ b/packages/mosaic/dropdown/dropdown.scss
@@ -50,8 +50,6 @@ $mc-dropdown-panel-border-radius: 3px !default;
 }
 
 .mc-dropdown__content {
-    height: 100%;
-
     h1, h2, h3, h4, h5 {
         padding: 8px 16px 4px 16px;
         margin: 0;


### PR DESCRIPTION
В сафари в выпадающем меню любой длины появляется вертикальный скроллбар:
![dropdown with vertical scroll](https://user-images.githubusercontent.com/22144369/65701761-8865ea80-e08a-11e9-909c-68936baed1ec.png)

Теперь выпадающее меню в сафари будет выглядеть так:
![dropdown without vertical scroll](https://user-images.githubusercontent.com/22144369/65703014-af252080-e08c-11e9-8eeb-53c8cdc940ce.png)

По каким-то причинам height: 100%; в сафари приводил к появлению вертикального скроллбара. На сколько я понимаю, в классе mc-dropdown__content в этом стиле нет необходимости. Я проверила результат во всех поддерживаемых браузерах: все работает.

Если такая необходимость все же имеется, height: 100% можно заменить на max-height: 100% - с ним тоже все работает. 