### PR TITLE
fix(button): moving button's typography in specific button's classes

### DIFF
--- a/packages/mosaic/button/_button-theme.scss
+++ b/packages/mosaic/button/_button-theme.scss
@@ -162,14 +162,13 @@
 }
 
 @mixin mc-button-typography($config) {
-    .mc-primary {
-        @include mc-typography-level-to-styles($config, body-strong);
-    }
-
-    .mc-second,
-    .mc-error,
+    .mc-button,
     .mc-icon-button {
         @include mc-typography-level-to-styles($config, body);
+
+        &.mc-primary {
+            @include mc-typography-level-to-styles($config, body-strong);
+        }
     }
 
     .mc-icon-button.mc-button-wrapper {


### PR DESCRIPTION
Типографика кнопок перенесена из глобальных классов в классы mc-button и mc-icon-button, чтобы она не переопределяла типографику других элементов. 