### PR TITLE
feat(docs): setting animation for component-overview

### DIFF
--- a/packages/docs/src/app/components/component-viewer/component-overview.template.html
+++ b/packages/docs/src/app/components/component-viewer/component-overview.template.html
@@ -1,17 +1,19 @@
-<span class="mc-display-3 title">
-    {{componentViewer.componentDocItem.id}}
-</span>
-<div *ngIf="documentLost" class="mc-alert mc-alert_error mc-alert_dismissible">
-            <span>Oops, {{componentViewer.componentDocItem.id}} component seems to be lost... But you can help us find it!
-                Just send a Pull Request to this repository:
-                <a class="docs-markdown__a" href="//github.com/positive-js/mosaic/pulls"> Mosaic</a>
-            </span>
+<div [@fadeInOut]="isLoad ? 'fadeIn' : 'fadeOut'" >
+    <span class="mc-display-3 title">
+        {{documentName}}
+    </span>
+    <div *ngIf="documentLost" class="mc-alert mc-alert_error mc-alert_dismissible">
+                <span>Oops, {{documentName}} component seems to be lost... But you can help us find it!
+                    Just send a Pull Request to this repository:
+                    <a class="docs-markdown__a" href="//github.com/positive-js/mosaic/pulls"> Mosaic</a>
+                </span>
+    </div>
+    <doc-viewer
+        documentUrl="docs-content/overviews/{{componentViewer.componentDocItem.packageName}}/{{componentViewer.componentDocItem.id}}.html"
+        class="docs-component-view-text-content docs-component-overview"
+        [class.docs-component-overview_hidden]="documentLost"
+        (contentRendered)="scrollToSelectedContentSection()"
+        (contentRenderFailed)="showDocumentLostAlert()">
+    </doc-viewer>
+    <anchors #toc ></anchors>
 </div>
-<doc-viewer
-    documentUrl="docs-content/overviews/{{componentViewer.componentDocItem.packageName}}/{{componentViewer.componentDocItem.id}}.html"
-    class="docs-component-view-text-content docs-component-overview"
-    [class.docs-component-overview_hidden]="documentLost"
-    (contentRendered)="scrollToSelectedContentSection()"
-    (contentRenderFailed)="showDocumentLostAlert()">
-</doc-viewer>
-<anchors #toc ></anchors>

--- a/packages/docs/src/app/shared/doc-viewer/doc-viewer.ts
+++ b/packages/docs/src/app/shared/doc-viewer/doc-viewer.ts
@@ -103,11 +103,14 @@ export class DocViewer implements OnDestroy {
 
     /** Show an error that occurred when fetching a document. */
     private showError(url: string, error: HttpErrorResponse) {
-        this.contentRenderFailed.next();
         // tslint:disable-next-line:no-console
         console.error(error);
         this._elementRef.nativeElement.innerText =
             `Failed to load document: ${url}. Error: ${error.statusText}`;
+
+        this._ngZone.onStable
+            .pipe(take(1))
+            .subscribe(() => this.contentRenderFailed.next());
     }
 
     /** Instantiate a ExampleViewer for each example. */


### PR DESCRIPTION
Setting fadeOut => fadeIn animation for document name, markdown, and anchors while routing is in process and content isn't rendered yet.