### PR TITLE
feat(docs): correcting animation's start and adaptivity

### DIFF
--- a/packages/docs/src/app/components/anchors/anchors.scss
+++ b/packages/docs/src/app/components/anchors/anchors.scss
@@ -1,7 +1,7 @@
 .anchors-menu {
     position: fixed;
     top: 64px;
-    width: 350px;
+    width: 300px;
     right: 0;
     bottom: 0;
 

--- a/packages/docs/src/app/components/component-viewer/component-viewer.component.ts
+++ b/packages/docs/src/app/components/component-viewer/component-viewer.component.ts
@@ -64,6 +64,8 @@ export class ComponentViewerComponent implements OnDestroy {
     encapsulation: ViewEncapsulation.None
 })
 export class ComponentOverviewComponent implements OnDestroy {
+    currentUrl: string;
+    routeSeparator: string = '/overview';
     documentName: string = '';
     documentLost: boolean = false;
     isLoad: boolean = true;
@@ -74,12 +76,22 @@ export class ComponentOverviewComponent implements OnDestroy {
     constructor(public componentViewer: ComponentViewerComponent,
                 private router: Router,
                 private ref: ChangeDetectorRef) {
+        this.currentUrl = this.getRoute(router.url);
 
         this.router.events.pipe(takeUntil(this.destroyed)).subscribe((event) => {
             if (event instanceof NavigationStart) {
-                this.isLoad = false;
+                const rootUrl = this.getRoute(event.url);
+
+                if (rootUrl !== this.currentUrl) {
+                    this.currentUrl = rootUrl;
+                    this.isLoad = false;
+                }
             }
         });
+    }
+
+    getRoute(route: string): string {
+        return route.split(this.routeSeparator)[0];
     }
 
     scrollToSelectedContentSection() {

--- a/packages/docs/src/app/components/footer/footer.component.scss
+++ b/packages/docs/src/app/components/footer/footer.component.scss
@@ -5,8 +5,8 @@
     width: 100%;
     will-change: transform;
     padding: {
-        left: 360px;
-        right: 360px;
+        left: 300px;
+        right: 300px;
     };
 
     &__wrapper {

--- a/packages/docs/src/app/components/main-layout/main-layout.component.scss
+++ b/packages/docs/src/app/components/main-layout/main-layout.component.scss
@@ -5,11 +5,11 @@
 }
 
 .content {
-    max-width: calc(100% - 720px);
+    max-width: calc(100% - 600px); // for Edge
     margin: {
         top: 64px;
-        left: 360px;
-        right: 360px;
+        left: 300px;
+        right: 300px;
         bottom: 62px;
     }
 

--- a/packages/docs/src/app/components/sidenav/sidenav.scss
+++ b/packages/docs/src/app/components/sidenav/sidenav.scss
@@ -9,12 +9,12 @@
     position: fixed;
     top: 64px;
     bottom: 0;
-    z-index: 2;
+    z-index: 101;
 
     overflow: hidden;
     overflow-y: auto;
     max-height: 100%;
-    width: 360px;
+    width: 300px;
 
     padding: {
         top: 10px;


### PR DESCRIPTION
Уточнено условие начала анимации для предотвращения  ее триггера по изменению якоря.
Уменьшины размеры сайдбара и якорей с 360px до 300px для улучшения адаптивности.
Исправлено перекрытие футером сайдбара, которое нарушало кликабельность нижних пунктов аккордиона.