### PR TITLE
feat(dropdown): fixing tslint errors

### DIFF
--- a/packages/mosaic/dropdown/dropdown-content.ts
+++ b/packages/mosaic/dropdown/dropdown-content.ts
@@ -22,9 +22,9 @@ import { Subject } from 'rxjs';
 export class McDropdownContent implements OnDestroy {
 
     /** Emits when the dropdown content has been attached. */
-    _attached = new Subject<void>();
-    private _portal: TemplatePortal<any>;
-    private _outlet: DomPortalOutlet;
+    attached = new Subject<void>();
+    private portal: TemplatePortal;
+    private outlet: DomPortalOutlet;
 
     constructor(
         private _template: TemplateRef<any>,
@@ -39,14 +39,14 @@ export class McDropdownContent implements OnDestroy {
      * @docs-private
      */
     attach(context: any = {}) {
-        if (!this._portal) {
-            this._portal = new TemplatePortal(this._template, this._viewContainerRef);
+        if (!this.portal) {
+            this.portal = new TemplatePortal(this._template, this._viewContainerRef);
         }
 
         this.detach();
 
-        if (!this._outlet) {
-            this._outlet = new DomPortalOutlet(this._document.createElement('div'),
+        if (!this.outlet) {
+            this.outlet = new DomPortalOutlet(this._document.createElement('div'),
                 this._componentFactoryResolver, this._appRef, this._injector);
         }
 
@@ -55,9 +55,9 @@ export class McDropdownContent implements OnDestroy {
         // Because we support opening the same dropdown from different triggers (which in turn have their
         // own `OverlayRef` panel), we have to re-insert the host element every time, otherwise we
         // risk it staying attached to a pane that's no longer in the DOM.
-        element.parentNode!.insertBefore(this._outlet.outletElement, element);
-        this._portal.attach(this._outlet, context);
-        this._attached.next();
+        element.parentNode!.insertBefore(this.outlet.outletElement, element);
+        this.portal.attach(this.outlet, context);
+        this.attached.next();
     }
 
     /**
@@ -65,14 +65,14 @@ export class McDropdownContent implements OnDestroy {
      * @docs-private
      */
     detach() {
-        if (this._portal.isAttached) {
-            this._portal.detach();
+        if (this.portal.isAttached) {
+            this.portal.detach();
         }
     }
 
     ngOnDestroy() {
-        if (this._outlet) {
-            this._outlet.dispose();
+        if (this.outlet) {
+            this.outlet.dispose();
         }
     }
 }

--- a/packages/mosaic/dropdown/dropdown-item.ts
+++ b/packages/mosaic/dropdown/dropdown-item.ts
@@ -20,7 +20,7 @@ import { MC_DROPDOWN_PANEL, McDropdownPanel } from './dropdown-panel';
 // Boilerplate for applying mixins to McDropdownItem.
 /** @docs-private */
 export class McDropdownItemBase {}
-export const _McDropdownItemMixinBase: CanDisableCtor & typeof McDropdownItemBase =
+export const mcDropdownItemMixinBase: CanDisableCtor & typeof McDropdownItemBase =
     mixinDisabled(McDropdownItemBase);
 
 /**
@@ -34,12 +34,12 @@ export const _McDropdownItemMixinBase: CanDisableCtor & typeof McDropdownItemBas
     host: {
         '[attr.role]': 'role',
         class: 'mc-dropdown__item',
-        '[class.mc-dropdown__item_highlighted]': '_highlighted',
-        '[attr.tabindex]': '_getTabIndex()',
+        '[class.mc-dropdown__item_highlighted]': 'highlighted',
+        '[attr.tabindex]': 'getTabIndex()',
         '[attr.aria-disabled]': 'disabled.toString()',
         '[attr.disabled]': 'disabled || null',
-        '(click)': '_checkDisabled($event)',
-        '(mouseenter)': '_handleMouseEnter()'
+        '(click)': 'checkDisabled($event)',
+        '(mouseenter)': 'handleMouseEnter()'
     },
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
@@ -47,10 +47,10 @@ export const _McDropdownItemMixinBase: CanDisableCtor & typeof McDropdownItemBas
         <div #content>
             <ng-content></ng-content>
         </div>
-        <i *ngIf="_triggersNestedDropdown" mc-icon="mc-angle-right-M_16" class="mc-dropdown__trigger"></i>
+        <i *ngIf="triggersNestedDropdown" mc-icon="mc-angle-right-M_16" class="mc-dropdown__trigger"></i>
     `
 })
-export class McDropdownItem extends _McDropdownItemMixinBase
+export class McDropdownItem extends mcDropdownItemMixinBase
     implements IFocusableOption, CanDisable, OnDestroy {
 
     /** ARIA role for the dropdown item. */
@@ -58,16 +58,16 @@ export class McDropdownItem extends _McDropdownItemMixinBase
 
     @ViewChild('content', {static: false}) content;
 
-    private _document: Document;
-
     /** Stream that emits when the dropdown item is hovered. */
-    readonly _hovered: Subject<McDropdownItem> = new Subject<McDropdownItem>();
+    readonly hovered: Subject<McDropdownItem> = new Subject<McDropdownItem>();
 
     /** Whether the dropdown item is highlighted. */
-    _highlighted: boolean = false;
+    highlighted: boolean = false;
 
     /** Whether the dropdown item acts as a trigger for a nested dropdown. */
-    _triggersNestedDropdown: boolean = false;
+    triggersNestedDropdown: boolean = false;
+
+    private document: Document;
 
     constructor(
         private _elementRef: ElementRef<HTMLElement>,
@@ -87,15 +87,15 @@ export class McDropdownItem extends _McDropdownItemMixinBase
             _parentDropdownPanel.addItem(this);
         }
 
-        this._document = document;
+        this.document = document;
     }
 
     /** Focuses the dropdown item. */
     focus(origin: FocusOrigin = 'program'): void {
         if (this._focusMonitor) {
-            this._focusMonitor.focusVia(this._getHostElement(), origin);
+            this._focusMonitor.focusVia(this.getHostElement(), origin);
         } else {
-            this._getHostElement().focus();
+            this.getHostElement().focus();
         }
     }
 
@@ -108,21 +108,21 @@ export class McDropdownItem extends _McDropdownItemMixinBase
             this._parentDropdownPanel.removeItem(this);
         }
 
-        this._hovered.complete();
+        this.hovered.complete();
     }
 
     /** Used to set the `tabindex`. */
-    _getTabIndex(): string {
+    getTabIndex(): string {
         return this.disabled ? '-1' : '0';
     }
 
     /** Returns the host DOM element. */
-    _getHostElement(): HTMLElement {
+    getHostElement(): HTMLElement {
         return this._elementRef.nativeElement;
     }
 
     /** Prevents the default element actions if it is disabled. */
-    _checkDisabled(event: Event): void {
+    checkDisabled(event: Event): void {
         if (this.disabled) {
             event.preventDefault();
             event.stopPropagation();
@@ -130,15 +130,15 @@ export class McDropdownItem extends _McDropdownItemMixinBase
     }
 
     /** Emits to the hover stream. */
-    _handleMouseEnter() {
-        this._hovered.next(this);
+    handleMouseEnter() {
+        this.hovered.next(this);
     }
 
     /** Gets the label to be used when determining whether the option should be focused. */
     getLabel(): string {
         const element: HTMLElement = this.content.nativeElement;
         // tslint:disable-next-line:no-magic-numbers
-        const textNodeType = this._document ? this._document.TEXT_NODE : 3;
+        const textNodeType = this.document ? this.document.TEXT_NODE : 3;
         let output = '';
 
         if (element.childNodes) {

--- a/packages/mosaic/dropdown/dropdown-panel.ts
+++ b/packages/mosaic/dropdown/dropdown-panel.ts
@@ -16,7 +16,7 @@ export const MC_DROPDOWN_PANEL = new InjectionToken<McDropdownPanel>('MC_DROPDOW
  * Interface for a custom dropdown panel that can be used with `mcDropdownTriggerFor`.
  * @docs-private
  */
-// tslint:disable-next-line:interface-name
+// tslint:disable-next-line:naming-convention
 export interface McDropdownPanel<T = any> {
     xPosition: DropdownPositionX;
     yPosition: DropdownPositionY;

--- a/packages/mosaic/dropdown/dropdown-trigger.ts
+++ b/packages/mosaic/dropdown/dropdown-trigger.ts
@@ -41,6 +41,7 @@ export const MC_DROPDOWN_SCROLL_STRATEGY =
     new InjectionToken<() => ScrollStrategy>('mc-dropdown-scroll-strategy');
 
 /** @docs-private */
+// tslint:disable-next-line:naming-convention
 export function MC_DROPDOWN_SCROLL_STRATEGY_FACTORY(overlay: Overlay): () => ScrollStrategy {
     return () => overlay.scrollStrategies.reposition();
 }
@@ -93,11 +94,11 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
         }
 
         this._dropdown = dropdown;
-        this._closeSubscription.unsubscribe();
+        this.closeSubscription.unsubscribe();
 
         if (dropdown) {
-            this._closeSubscription = dropdown.closed.asObservable().subscribe((reason) => {
-                this._destroy();
+            this.closeSubscription = dropdown.closed.asObservable().subscribe((reason) => {
+                this.destroy();
 
                 // If a click closed the dropdown, we should close the entire chain of nested dropdowns.
                 if ((reason === 'click' || reason === 'tab') && this._parent) {
@@ -107,17 +108,9 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
         }
     }
 
-    private _dropdown: McDropdownPanel;
-
-    private _opened: boolean = false;
-    /** Whether the dropdown is open. */
-    get opened(): boolean {
-        return this._opened;
-    }
-
     // Tracking input type is necessary so it's possible to only auto-focus
     // the first item of the list when the dropdown is opened via the keyboard
-    _openedBy: 'mouse' | 'touch' | null = null;
+    openedBy: 'mouse' | 'touch' | null = null;
 
     /** Data to be passed along to any lazily-rendered content. */
     @Input('mcDropdownTriggerData') data: any;
@@ -128,13 +121,22 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
     /** Event emitted when the associated dropdown is closed. */
     @Output() readonly dropdownClosed: EventEmitter<void> = new EventEmitter<void>();
 
-    private _portal: TemplatePortal;
+    private _dropdown: McDropdownPanel;
 
-    private _overlayRef: OverlayRef | null = null;
+    /** Whether the dropdown is open. */
+    get opened(): boolean {
+        return this._opened;
+    }
 
-    private _closeSubscription = Subscription.EMPTY;
+    private _opened: boolean = false;
 
-    private _hoverSubscription = Subscription.EMPTY;
+    private portal: TemplatePortal;
+
+    private overlayRef: OverlayRef | null = null;
+
+    private closeSubscription = Subscription.EMPTY;
+
+    private hoverSubscription = Subscription.EMPTY;
 
     constructor(private _overlay: Overlay,
                 private _element: ElementRef<HTMLElement>,
@@ -145,30 +147,30 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
                 @Optional() private _dir: Directionality,
                 private _focusMonitor?: FocusMonitor) {
 
-        _element.nativeElement.addEventListener('touchstart', this._handleTouchStart,
+        _element.nativeElement.addEventListener('touchstart', this.handleTouchStart,
             passiveEventListenerOptions);
 
         if (_dropdownItemInstance) {
-            _dropdownItemInstance._triggersNestedDropdown = this.triggersNestedDropdown();
+            _dropdownItemInstance.triggersNestedDropdown = this.triggersNestedDropdown();
         }
     }
 
     ngAfterContentInit() {
-        this._check();
-        this._handleHover();
+        this.check();
+        this.handleHover();
     }
 
     ngOnDestroy() {
-        if (this._overlayRef) {
-            this._overlayRef.dispose();
-            this._overlayRef = null;
+        if (this.overlayRef) {
+            this.overlayRef.dispose();
+            this.overlayRef = null;
         }
 
-        this._element.nativeElement.removeEventListener('touchstart', this._handleTouchStart,
+        this._element.nativeElement.removeEventListener('touchstart', this.handleTouchStart,
             passiveEventListenerOptions);
 
-        this._cleanUpSubscriptions();
-        this._closeSubscription.unsubscribe();
+        this.cleanUpSubscriptions();
+        this.closeSubscription.unsubscribe();
     }
 
     /** Whether the dropdown triggers a nested dropdown or a top-level one. */
@@ -188,25 +190,25 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
             return;
         }
 
-        this._check();
+        this.check();
 
-        const overlayRef = this._createOverlay();
+        const overlayRef = this.createOverlay();
         const overlayConfig = overlayRef.getConfig();
 
-        this._setPosition(overlayConfig.positionStrategy as FlexibleConnectedPositionStrategy);
+        this.setPosition(overlayConfig.positionStrategy as FlexibleConnectedPositionStrategy);
         overlayConfig.hasBackdrop = this.dropdown.hasBackdrop == null ? !this.triggersNestedDropdown() :
             this.dropdown.hasBackdrop;
-        overlayRef.attach(this._getPortal());
+        overlayRef.attach(this.getPortal());
 
         if (this.dropdown.lazyContent) {
             this.dropdown.lazyContent.attach(this.data);
         }
 
-        this._closeSubscription = this._closingActions().subscribe(() => this.close());
-        this._init();
+        this.closeSubscription = this.closingActions().subscribe(() => this.close());
+        this.init();
 
         if (this.dropdown instanceof McDropdown) {
-            this.dropdown._startAnimation();
+            this.dropdown.startAnimation();
         }
     }
 
@@ -231,7 +233,7 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
     handleMousedown(event: MouseEvent): void {
         // Since right or middle button clicks won't trigger the `click` event,
         // we shouldn't consider the dropdown as opened by mouse in those cases.
-        this._openedBy = event.button === 0 ? 'mouse' : null;
+        this.openedBy = event.button === 0 ? 'mouse' : null;
 
         // Since clicking on the trigger won't close the dropdown if it opens a nested dropdown,
         // we should prevent focus from moving onto it via click to avoid the
@@ -243,7 +245,8 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
 
     /** Handles key presses on the trigger. */
     handleKeydown(event: KeyboardEvent): void {
-        const keyCode = event.keyCode;
+        // tslint:disable-next-line:deprecation
+        const keyCode = event.key || event.keyCode;
 
         if (keyCode === SPACE || keyCode === ENTER) {
             this.open();
@@ -271,40 +274,40 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
      * Handles touch start events on the trigger.
      * Needs to be an arrow function so we can easily use addEventListener and removeEventListener.
      */
-    private _handleTouchStart = () => this._openedBy = 'touch';
+    private handleTouchStart = () => this.openedBy = 'touch';
 
     /** Closes the dropdown and does the necessary cleanup. */
-    private _destroy() {
-        if (!this._overlayRef || !this.opened) {
+    private destroy() {
+        if (!this.overlayRef || !this.opened) {
             return;
         }
 
         const dropdown = this.dropdown;
 
-        this._closeSubscription.unsubscribe();
-        this._overlayRef.detach();
+        this.closeSubscription.unsubscribe();
+        this.overlayRef.detach();
 
         if (dropdown instanceof McDropdown) {
-            dropdown._resetAnimation();
+            dropdown.resetAnimation();
 
             if (dropdown.lazyContent) {
                 // Wait for the exit animation to finish before detaching the content.
-                dropdown._animationDone
+                dropdown.animationDone
                     .pipe(
                         filter((event) => event.toState === 'void'),
                         take(1),
                         // Interrupt if the content got re-attached.
-                        takeUntil(dropdown.lazyContent._attached)
+                        takeUntil(dropdown.lazyContent.attached)
                     )
-                    .subscribe(() => dropdown.lazyContent!.detach(), undefined, () => {
+                    .subscribe({next: () => dropdown.lazyContent.detach(), error: undefined, complete: () => {
                         // No matter whether the content got re-attached, reset the dropdown.
-                        this._reset();
-                    });
+                        this.reset();
+                    }});
             } else {
-                this._reset();
+                this.reset();
             }
         } else {
-            this._reset();
+            this.reset();
 
             if (dropdown.lazyContent) {
                 dropdown.lazyContent.detach();
@@ -316,42 +319,42 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
      * This method sets the dropdown state to open and focuses the first item if
      * the dropdown was opened via the keyboard.
      */
-    private _init(): void {
+    private init(): void {
         this.dropdown.parent = this.triggersNestedDropdown() ? this._parent : undefined;
         this.dropdown.direction = this.dir;
-        this._setIsOpened(true);
-        this.dropdown.focusFirstItem(this._openedBy || 'program');
+        this.setIsOpened(true);
+        this.dropdown.focusFirstItem(this.openedBy || 'program');
     }
 
     /**
      * This method resets the dropdown when it's closed, most importantly restoring
      * focus to the dropdown trigger if the dropdown was opened via the keyboard.
      */
-    private _reset(): void {
-        this._setIsOpened(false);
+    private reset(): void {
+        this.setIsOpened(false);
 
         // We should reset focus if the user is navigating using a keyboard or
         // if we have a top-level trigger which might cause focus to be lost
         // when clicking on the backdrop.
-        if (!this._openedBy) {
+        if (!this.openedBy) {
             // Note that the focus style will show up both for `program` and
             // `keyboard` so we don't have to specify which one it is.
             this.focus();
         } else if (!this.triggersNestedDropdown()) {
-            this.focus(this._openedBy);
+            this.focus(this.openedBy);
         }
 
-        this._openedBy = null;
+        this.openedBy = null;
     }
 
     // set state rather than toggle to support triggers sharing a dropdown
-    private _setIsOpened(isOpen: boolean): void {
+    private setIsOpened(isOpen: boolean): void {
         this._opened = isOpen;
         // tslint:disable-next-line:no-void-expression
         this._opened ? this.dropdownOpened.emit() : this.dropdownClosed.emit();
 
         if (this.triggersNestedDropdown()) {
-            this._dropdownItemInstance._highlighted = isOpen;
+            this._dropdownItemInstance.highlighted = isOpen;
         }
     }
 
@@ -359,7 +362,7 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
      * This method checks that a valid instance of McDropdown has been passed into
      * mcDropdownTriggerFor. If not, an exception is thrown.
      */
-    private _check() {
+    private check() {
         if (!this.dropdown) {
             throwMcDropdownMissingError();
         }
@@ -369,26 +372,26 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
      * This method creates the overlay from the provided dropdown's template and saves its
      * OverlayRef so that it can be attached to the DOM when open is called.
      */
-    private _createOverlay(): OverlayRef {
-        if (!this._overlayRef) {
-            const config = this._getOverlayConfig();
-            this._subscribeToPositions(config.positionStrategy as FlexibleConnectedPositionStrategy);
-            this._overlayRef = this._overlay.create(config);
+    private createOverlay(): OverlayRef {
+        if (!this.overlayRef) {
+            const config = this.getOverlayConfig();
+            this.subscribeToPositions(config.positionStrategy as FlexibleConnectedPositionStrategy);
+            this.overlayRef = this._overlay.create(config);
 
             // Consume the `keydownEvents` in order to prevent them from going to another overlay.
             // Ideally we'd also have our keyboard event logic in here, however doing so will
             // break anybody that may have implemented the `McDropdownPanel` themselves.
-            this._overlayRef.keydownEvents().subscribe();
+            this.overlayRef.keydownEvents().subscribe();
         }
 
-        return this._overlayRef;
+        return this.overlayRef;
     }
 
     /**
      * This method builds the configuration object needed to create the overlay, the OverlayState.
      * @returns OverlayConfig
      */
-    private _getOverlayConfig(): OverlayConfig {
+    private getOverlayConfig(): OverlayConfig {
         return new OverlayConfig({
             positionStrategy: this._overlay.position()
                 .flexibleConnectedTo(this._element)
@@ -405,7 +408,7 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
      * on the dropdown based on the new position. This ensures the animation origin is always
      * correct, even if a fallback position is used for the overlay.
      */
-    private _subscribeToPositions(position: FlexibleConnectedPositionStrategy): void {
+    private subscribeToPositions(position: FlexibleConnectedPositionStrategy): void {
         if (this.dropdown.setPositionClasses) {
             position.positionChanges.subscribe((change) => {
                 const posX: DropdownPositionX = change.connectionPair.overlayX === 'start' ? 'after' : 'before';
@@ -421,13 +424,14 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
      * so the overlay connects with the trigger correctly.
      * @param positionStrategy Strategy whose position to update.
      */
-    private _setPosition(positionStrategy: FlexibleConnectedPositionStrategy) {
+    private setPosition(positionStrategy: FlexibleConnectedPositionStrategy) {
 
         let [originX, originFallbackX, overlayX, overlayFallbackX]: HorizontalConnectionPos[] =
             this.dropdown.xPosition === 'before' ?
                 ['end', 'start', 'end', 'start'] :
                 ['start', 'end', 'start', 'end'];
 
+        // tslint:disable-next-line:prefer-const
         let [overlayY, overlayFallbackY, originY, originFallbackY]: VerticalConnectionPos[] =
             this.dropdown.yPosition === 'above' ?
                 ['bottom', 'top', 'bottom', 'top'] :
@@ -474,17 +478,17 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
     }
 
     /** Cleans up the active subscriptions. */
-    private _cleanUpSubscriptions(): void {
-        this._closeSubscription.unsubscribe();
-        this._hoverSubscription.unsubscribe();
+    private cleanUpSubscriptions(): void {
+        this.closeSubscription.unsubscribe();
+        this.hoverSubscription.unsubscribe();
     }
 
     /** Returns a stream that emits whenever an action that should close the dropdown occurs. */
-    private _closingActions() {
-        const backdrop = this._overlayRef!.backdropClick();
-        const detachments = this._overlayRef!.detachments();
+    private closingActions() {
+        const backdrop = this.overlayRef!.backdropClick();
+        const detachments = this.overlayRef!.detachments();
         const parentClose = this._parent ? this._parent.closed : observableOf();
-        const hover = this._parent ? this._parent._hovered().pipe(
+        const hover = this._parent ? this._parent.hovered().pipe(
             filter((active) => active !== this._dropdownItemInstance),
             filter(() => this._opened)
         ) : observableOf();
@@ -493,13 +497,13 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
     }
 
     /** Handles the cases where the user hovers over the trigger. */
-    private _handleHover() {
+    private handleHover() {
         // Subscribe to changes in the hovered item in order to toggle the panel.
         if (!this.triggersNestedDropdown()) {
             return;
         }
 
-        this._hoverSubscription = this._parent._hovered()
+        this.hoverSubscription = this._parent.hovered()
         // Since we might have multiple competing triggers for the same dropdown (e.g. a nested dropdown
         // with different data and triggers), we have to delay it by a tick to ensure that
         // it won't be closed immediately after it is opened.
@@ -508,16 +512,16 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
                 delay(0, asapScheduler)
             )
             .subscribe(() => {
-                this._openedBy = 'mouse';
+                this.openedBy = 'mouse';
 
                 // If the same dropdown is used between multiple triggers, it might still be animating
                 // while the new trigger tries to re-open it. Wait for the animation to finish
                 // before doing so. Also interrupt if the user moves to another item.
-                if (this.dropdown instanceof McDropdown && this.dropdown._isAnimating) {
+                if (this.dropdown instanceof McDropdown && this.dropdown.isAnimating) {
                     // We need the `delay(0)` here in order to avoid
                     // 'changed after checked' errors in some cases. See #12194.
-                    this.dropdown._animationDone
-                        .pipe(take(1), delay(0, asapScheduler), takeUntil(this._parent._hovered()))
+                    this.dropdown.animationDone
+                        .pipe(take(1), delay(0, asapScheduler), takeUntil(this._parent.hovered()))
                         .subscribe(() => this.open());
                 } else {
                     this.open();
@@ -526,15 +530,15 @@ export class McDropdownTrigger implements AfterContentInit, OnDestroy {
     }
 
     /** Gets the portal that should be attached to the overlay. */
-    private _getPortal(): TemplatePortal {
+    private getPortal(): TemplatePortal {
         // Note that we can avoid this check by keeping the portal on the dropdown panel.
         // While it would be cleaner, we'd have to introduce another required method on
         // `McDropdownPanel`, making it harder to consume.
-        if (!this._portal || this._portal.templateRef !== this.dropdown.templateRef) {
-            this._portal = new TemplatePortal(this.dropdown.templateRef, this._viewContainerRef);
+        if (!this.portal || this.portal.templateRef !== this.dropdown.templateRef) {
+            this.portal = new TemplatePortal(this.dropdown.templateRef, this._viewContainerRef);
         }
 
-        return this._portal;
+        return this.portal;
     }
 
 }

--- a/packages/mosaic/dropdown/dropdown.component.ts
+++ b/packages/mosaic/dropdown/dropdown.component.ts
@@ -35,7 +35,7 @@ import { DropdownPositionX, DropdownPositionY } from './dropdown-positions';
 
 
 /** Default `mc-dropdown` options that can be overridden. */
-// tslint:disable-next-line:interface-name
+// tslint:disable-next-line:naming-convention
 export interface McDropdownDefaultOptions {
     /** The x-axis position of the dropdown. */
     xPosition: DropdownPositionX;
@@ -64,6 +64,7 @@ export const MC_DROPDOWN_DEFAULT_OPTIONS =
     });
 
 /** @docs-private */
+// tslint:disable-next-line:naming-convention
 export function MC_DROPDOWN_DEFAULT_OPTIONS_FACTORY(): McDropdownDefaultOptions {
     return {
         overlapTriggerX: true,
@@ -157,19 +158,19 @@ export class McDropdown implements AfterContentInit, McDropdownPanel<McDropdownI
      */
     @Input('class')
     set panelClass(classes: string) {
-        const previousPanelClass = this._previousPanelClass;
+        const previousPanelClass = this.previousPanelClass;
 
         if (previousPanelClass && previousPanelClass.length) {
             previousPanelClass.split(' ').forEach((className: string) => {
-                this._classList[className] = false;
+                this.classList[className] = false;
             });
         }
 
-        this._previousPanelClass = classes;
+        this.previousPanelClass = classes;
 
         if (classes && classes.length) {
             classes.split(' ').forEach((className: string) => {
-                this._classList[className] = true;
+                this.classList[className] = true;
             });
 
             this._elementRef.nativeElement.className = '';
@@ -182,16 +183,16 @@ export class McDropdown implements AfterContentInit, McDropdownPanel<McDropdownI
     private _hasBackdrop: boolean | undefined = this._defaultOptions.hasBackdrop;
 
     /** Config object to be passed into the dropdown's ngClass */
-    _classList: { [key: string]: boolean } = {};
+    classList: { [key: string]: boolean } = {};
 
     /** Current state of the panel animation. */
-    _panelAnimationState: 'void' | 'enter' = 'void';
+    panelAnimationState: 'void' | 'enter' = 'void';
 
     /** Emits whenever an animation on the dropdown completes. */
-    _animationDone = new Subject<AnimationEvent>();
+    animationDone = new Subject<AnimationEvent>();
 
     /** Whether the dropdown is animating. */
-    _isAnimating: boolean;
+    isAnimating: boolean;
 
     /** Parent dropdown of the current dropdown panel. */
     parent: McDropdownPanel | undefined;
@@ -220,18 +221,18 @@ export class McDropdown implements AfterContentInit, McDropdownPanel<McDropdownI
     @Output() readonly closed: EventEmitter<void | 'click' | 'keydown' | 'tab'> =
         new EventEmitter<void | 'click' | 'keydown' | 'tab'>();
 
-    private _previousPanelClass: string;
+    private previousPanelClass: string;
 
-    private _keyManager: FocusKeyManager<McDropdownItem>;
+    private keyManager: FocusKeyManager<McDropdownItem>;
 
     /** Dropdown items inside the current dropdown. */
-    private _items: McDropdownItem[] = [];
+    private itemsArray: McDropdownItem[] = [];
 
     /** Emits whenever the amount of dropdown items changes. */
-    private _itemChanges = new Subject<McDropdownItem[]>();
+    private itemChanges = new Subject<McDropdownItem[]>();
 
     /** Subscription to tab events on the dropdown panel */
-    private _tabSubscription = Subscription.EMPTY;
+    private tabSubscription = Subscription.EMPTY;
 
     constructor(
         private _elementRef: ElementRef<HTMLElement>,
@@ -243,26 +244,27 @@ export class McDropdown implements AfterContentInit, McDropdownPanel<McDropdownI
     }
 
     ngAfterContentInit() {
-        this._keyManager = new FocusKeyManager<McDropdownItem>(this.items).withWrap().withTypeAhead();
-        this._tabSubscription = this._keyManager.tabOut.subscribe(() => this.closed.emit('tab'));
+        this.keyManager = new FocusKeyManager<McDropdownItem>(this.items).withWrap().withTypeAhead();
+        this.tabSubscription = this.keyManager.tabOut.subscribe(() => this.closed.emit('tab'));
     }
 
     ngOnDestroy() {
-        this._tabSubscription.unsubscribe();
+        this.tabSubscription.unsubscribe();
         this.closed.complete();
     }
 
     /** Stream that emits whenever the hovered dropdown item changes. */
-    _hovered(): Observable<McDropdownItem> {
-        return this._itemChanges.pipe(
-            startWith(this._items),
-            switchMap((items) => merge(...items.map((item) => item._hovered)))
+    hovered(): Observable<McDropdownItem> {
+        return this.itemChanges.pipe(
+            startWith(this.itemsArray),
+            switchMap((items) => merge(...items.map((item) => item.hovered)))
         );
     }
 
     /** Handle a keyboard event from the dropdown, delegating to the appropriate action. */
-    _handleKeydown(event: KeyboardEvent) {
-        const keyCode = event.keyCode;
+    handleKeydown(event: KeyboardEvent) {
+        // tslint:disable-next-line:deprecation
+        const keyCode = event.key || event.keyCode;
 
         switch (keyCode) {
             case ESCAPE:
@@ -280,10 +282,10 @@ export class McDropdown implements AfterContentInit, McDropdownPanel<McDropdownI
                 break;
             default:
                 if (keyCode === UP_ARROW || keyCode === DOWN_ARROW) {
-                    this._keyManager.setFocusOrigin('keyboard');
+                    this.keyManager.setFocusOrigin('keyboard');
                 }
 
-                this._keyManager.onKeydown(event);
+                this.keyManager.onKeydown(event);
         }
     }
 
@@ -296,9 +298,9 @@ export class McDropdown implements AfterContentInit, McDropdownPanel<McDropdownI
         if (this.lazyContent) {
             this._ngZone.onStable.asObservable()
                 .pipe(take(1))
-                .subscribe(() => this._keyManager.setFocusOrigin(origin).setFirstItemActive());
+                .subscribe(() => this.keyManager.setFocusOrigin(origin).setFirstItemActive());
         } else {
-            this._keyManager.setFocusOrigin(origin).setFirstItemActive();
+            this.keyManager.setFocusOrigin(origin).setFirstItemActive();
         }
     }
 
@@ -307,7 +309,7 @@ export class McDropdown implements AfterContentInit, McDropdownPanel<McDropdownI
      * the user to start from the first option when pressing the down arrow.
      */
     resetActiveItem() {
-        this._keyManager.setActiveItem(-1);
+        this.keyManager.setActiveItem(-1);
     }
 
     /**
@@ -320,9 +322,9 @@ export class McDropdown implements AfterContentInit, McDropdownPanel<McDropdownI
         // `mc-dropdown` ancestor. If we used `@ContentChildren(McDropdownItem, {descendants: true})`,
         // all descendant items will bleed into the top-level dropdown in the case where the consumer
         // has `mc-dropdown` instances nested inside each other.
-        if (this._items.indexOf(item) === -1) {
-            this._items.push(item);
-            this._itemChanges.next(this._items);
+        if (this.itemsArray.indexOf(item) === -1) {
+            this.itemsArray.push(item);
+            this.itemChanges.next(this.itemsArray);
         }
     }
 
@@ -331,11 +333,11 @@ export class McDropdown implements AfterContentInit, McDropdownPanel<McDropdownI
      * @docs-private
      */
     removeItem(item: McDropdownItem) {
-        const index = this._items.indexOf(item);
+        const index = this.itemsArray.indexOf(item);
 
-        if (this._items.indexOf(item) > -1) {
-            this._items.splice(index, 1);
-            this._itemChanges.next(this._items);
+        if (this.itemsArray.indexOf(item) > -1) {
+            this.itemsArray.splice(index, 1);
+            this.itemChanges.next(this.itemsArray);
         }
     }
 
@@ -347,7 +349,7 @@ export class McDropdown implements AfterContentInit, McDropdownPanel<McDropdownI
      * @docs-private
      */
     setPositionClasses(posX: DropdownPositionX = this.xPosition, posY: DropdownPositionY = this.yPosition) {
-        const classes = this._classList;
+        const classes = this.classList;
         classes['mc-dropdown-before'] = posX === 'before';
         classes['mc-dropdown-after'] = posX === 'after';
         classes['mc-dropdown-above'] = posY === 'above';
@@ -355,23 +357,23 @@ export class McDropdown implements AfterContentInit, McDropdownPanel<McDropdownI
     }
 
     /** Starts the enter animation. */
-    _startAnimation() {
-        this._panelAnimationState = 'enter';
+    startAnimation() {
+        this.panelAnimationState = 'enter';
     }
 
     /** Resets the panel animation to its initial state. */
-    _resetAnimation() {
-        this._panelAnimationState = 'void';
+    resetAnimation() {
+        this.panelAnimationState = 'void';
     }
 
     /** Callback that is invoked when the panel animation completes. */
-    _onAnimationDone(event: AnimationEvent) {
-        this._animationDone.next(event);
-        this._isAnimating = false;
+    onAnimationDone(event: AnimationEvent) {
+        this.animationDone.next(event);
+        this.isAnimating = false;
     }
 
-    _onAnimationStart(event: AnimationEvent) {
-        this._isAnimating = true;
+    onAnimationStart(event: AnimationEvent) {
+        this.isAnimating = true;
 
         // Scroll the content element to the top as soon as the animation starts. This is necessary,
         // because we move focus to the first item while it's still being animated, which can throw
@@ -379,7 +381,7 @@ export class McDropdown implements AfterContentInit, McDropdownPanel<McDropdownI
         // when the animation is done, however moving focus asynchronously will interrupt screen
         // readers which are in the process of reading out the dropdown already. We take the `element`
         // from the `event` since we can't use a `ViewChild` to access the pane.
-        if (event.toState === 'enter' && this._keyManager.activeItemIndex === 0) {
+        if (event.toState === 'enter' && this.keyManager.activeItemIndex === 0) {
             event.element.scrollTop = 0;
         }
     }

--- a/packages/mosaic/dropdown/dropdown.html
+++ b/packages/mosaic/dropdown/dropdown.html
@@ -1,12 +1,12 @@
 <ng-template>
     <div
         class="mc-dropdown__panel"
-        [ngClass]="_classList"
-        (keydown)="_handleKeydown($event)"
+        [ngClass]="classList"
+        (keydown)="handleKeydown($event)"
         (click)="closed.emit('click')"
-        [@transformDropdown]="_panelAnimationState"
-        (@transformDropdown.start)="_onAnimationStart($event)"
-        (@transformDropdown.done)="_onAnimationDone($event)"
+        [@transformDropdown]="panelAnimationState"
+        (@transformDropdown.start)="onAnimationStart($event)"
+        (@transformDropdown.done)="onAnimationDone($event)"
         tabindex="-1"
         role="dropdown">
         <div class="mc-dropdown__content">

--- a/packages/mosaic/dropdown/dropdown.spec.ts
+++ b/packages/mosaic/dropdown/dropdown.spec.ts
@@ -1201,7 +1201,7 @@ describe('McDropdown', () => {
             fixture.detectChanges();
 
             // Invoke the handler directly since the fake events are flaky on disabled elements.
-            items[1].componentInstance._handleMouseEnter();
+            items[1].componentInstance.handleMouseEnter();
             fixture.detectChanges();
             tick(500);
 
@@ -1224,7 +1224,7 @@ describe('McDropdown', () => {
             fixture.detectChanges();
 
             // Invoke the handler directly since the fake events are flaky on disabled elements.
-            item.componentInstance._handleMouseEnter();
+            item.componentInstance.handleMouseEnter();
             fixture.detectChanges();
             tick(500);
 
@@ -1542,7 +1542,8 @@ describe('McDropdown', () => {
             event.preventDefault = jasmine.createSpy('preventDefault spy');
 
             dispatchMouseEvent(overlay.querySelector('[mc-dropdown-item]')!, 'mousedown', 0, 0, event);
-            expect(event.preventDefault.bind(event)).toHaveBeenCalled();
+            // tslint:disable-next-line: no-unbound-method
+            expect(event.preventDefault).toHaveBeenCalled();
         });
 
         it('should handle the items being rendered in a repeater', fakeAsync(() => {

--- a/packages/mosaic/dropdown/dropdown.spec.ts
+++ b/packages/mosaic/dropdown/dropdown.spec.ts
@@ -1111,7 +1111,7 @@ describe('McDropdown', () => {
             fixture.detectChanges();
 
             const spy = jasmine.createSpy('hover spy');
-            const subscription = instance.rootDropdown._hovered().subscribe(spy);
+            const subscription = instance.rootDropdown.hovered().subscribe(spy);
             const dropdownItems = overlay.querySelectorAll('[mc-dropdown-item]');
 
             dispatchMouseEvent(dropdownItems[0], 'mouseenter');
@@ -1542,7 +1542,7 @@ describe('McDropdown', () => {
             event.preventDefault = jasmine.createSpy('preventDefault spy');
 
             dispatchMouseEvent(overlay.querySelector('[mc-dropdown-item]')!, 'mousedown', 0, 0, event);
-            expect(event.preventDefault).toHaveBeenCalled();
+            expect(event.preventDefault.bind(event)).toHaveBeenCalled();
         });
 
         it('should handle the items being rendered in a repeater', fakeAsync(() => {
@@ -1749,6 +1749,7 @@ class PositionedDropdown {
     yPosition: DropdownPositionY = 'above';
 }
 
+// tslint:disable-next-line: naming-convention
 interface TestableDropdown {
     trigger: McDropdownTrigger;
     triggerEl: ElementRef<HTMLElement>;


### PR DESCRIPTION
naming-convention errors are fixed everywhere except interfaces and exported functions.

Private fields are moved after public.

Deprecated event.keyCode is replaced by event.key || event.keyCode because not all browsers support event.key.

Deprecated subscribe(next, error, complete)  is replaced by subscribe(observer).

no-unbounding-method error fixed by binding event.preventDefault with event context.

yarn run server-dev:dropdown workes perfectly.