### PR TITLE
feat(tags): updating default _addOnBlur value

### DIFF
--- a/packages/mosaic/tags/tag-input.ts
+++ b/packages/mosaic/tags/tag-input.ts
@@ -85,7 +85,7 @@ export class McTagInput implements McTagTextControl, OnChanges {
         this._addOnBlur = coerceBooleanProperty(value);
     }
 
-    private _addOnBlur: boolean = false;
+    private _addOnBlur: boolean = true;
 
     /** Whether the input is disabled. */
     @Input()


### PR DESCRIPTION
Сейчас нет токенизации по потере фокуса, из-за этого, если не нажать Enter, поле McTagInput остается с текстом, срабатывает валидация и неясно что происходит: https://youtrack.ptsecurity.com/issue/UIM-165.

Теперь токенизация по потере фокуса стоит по умолчанию, чтобы ее отключить необходимо передать [mcTagInputAddOnBlur]=false в input после mc-tag-list, пример можно найти в tag-list.component.spec.ts

