### PR TITLE
chore(modal): fixing tslint errors

### DIFF
--- a/packages/mosaic/modal/modal-control.service.ts
+++ b/packages/mosaic/modal/modal-control.service.ts
@@ -15,12 +15,12 @@ export class McModalControlService {
 
     // Track singleton afterAllClose through over the injection tree
     get afterAllClose(): Subject<void> {
-        return this.parentService ? this.parentService.afterAllClose : this.rootAfterAllClose!;
+        return this.parentService ? this.parentService.afterAllClose : this.rootAfterAllClose;
     }
 
     // Track singleton openModals array through over the injection tree
     get openModals(): McModalRef[] {
-        return this.parentService ? this.parentService.openModals : this.rootOpenModals!;
+        return this.parentService ? this.parentService.openModals : this.rootOpenModals;
     }
 
     // @ts-ignore

--- a/packages/mosaic/modal/modal-ref.class.ts
+++ b/packages/mosaic/modal/modal-ref.class.ts
@@ -7,6 +7,7 @@ import { McModalComponent } from './modal.component';
  * API class that public to users to handle the modal instance.
  * McModalRef is aim to avoid accessing to the modal instance directly by users.
  */
+// tslint:disable-next-line:naming-convention
 export abstract class McModalRef<T = any, R = any> {
     abstract afterOpen: Observable<void>;
     abstract afterClose: Observable<R>;

--- a/packages/mosaic/modal/modal-util.ts
+++ b/packages/mosaic/modal/modal-util.ts
@@ -22,4 +22,4 @@ export class ModalUtil {
     }
 }
 
-export default new ModalUtil(document);
+export const modalUtilObject = new ModalUtil(document);

--- a/packages/mosaic/modal/modal.service.ts
+++ b/packages/mosaic/modal/modal.service.ts
@@ -32,6 +32,7 @@ export class ModalBuilderForService {
         this.overlayRef.keydownEvents()
             // @ts-ignore
             .pipe(filter((event: KeyboardEvent) => {
+                // tslint:disable-next-line:deprecation replacement .key isn't supported in Edge
                 return event.keyCode === ESCAPE && options.mcCloseByESC;
             }))
             .subscribe(() => this.modalRef!.instance.close());
@@ -134,6 +135,7 @@ export class McModalService {
         return this.simpleConfirm(options, 'success');
     }
 
+    // tslint:disable-next-line: no-reserved-keywords
     delete<T>(options: IModalOptionsForService<T> = {}): McModalRef<T> {
         return this.simpleConfirm(options, 'warn');
     }


### PR DESCRIPTION
fixing naming-convention, orthodox-getter-and-setter, no-unnecessary-type-assertion, no-default-export, no-reserved-keywords, deprecation, no-inferred-empty-object-type tslint errors

