### PR TITLE
chore(tabs): fixing tslint errors

### DIFF
--- a/packages/mosaic/tabs/tab-body.spec.ts
+++ b/packages/mosaic/tabs/tab-body.spec.ts
@@ -11,7 +11,11 @@ import { McTabBody, McTabBodyPortal } from './tab-body';
 
 describe('McTabBody', () => {
     let dir: Direction = 'ltr';
-    const dirChange: Subject<Direction> = new Subject<Direction>();
+    let dirChange: Subject<Direction>;
+
+    beforeAll(() => {
+        dirChange = new Subject<Direction>();
+    });
 
     beforeEach(async(() => {
         dir = 'ltr';

--- a/packages/mosaic/tabs/tab-body.ts
+++ b/packages/mosaic/tabs/tab-body.ts
@@ -1,6 +1,6 @@
 import { AnimationEvent } from '@angular/animations';
 import { Directionality, Direction } from '@angular/cdk/bidi';
-import { TemplatePortal, CdkPortalOutlet, PortalHostDirective } from '@angular/cdk/portal';
+import { TemplatePortal, CdkPortalOutlet } from '@angular/cdk/portal';
 import {
     Component,
     ChangeDetectorRef,
@@ -87,7 +87,7 @@ export class McTabBody implements OnInit, OnDestroy {
     @Output() readonly onCentered: EventEmitter<void> = new EventEmitter<void>(true);
 
     /** The portal host inside of this container into which the tab body content will be loaded. */
-    @ViewChild(PortalHostDirective, {static: false}) portalHost: PortalHostDirective;
+    @ViewChild(CdkPortalOutlet, {static: false}) portalHost: CdkPortalOutlet;
 
     /** The tab body content to display. */
     @Input('content') content: TemplatePortal;

--- a/packages/mosaic/tabs/tab-group.ts
+++ b/packages/mosaic/tabs/tab-group.ts
@@ -76,7 +76,7 @@ export interface IMcTabsConfig {
 }
 
 /** Injection token that can be used to provide the default options the tabs module. */
-export const MC_TABS_CONFIG = new InjectionToken('MC_TABS_CONFIG');
+export const MC_TABS_CONFIG = new InjectionToken<string>('MC_TABS_CONFIG');
 
 // Boilerplate for applying mixins to McTabGroup.
 /** @docs-private */

--- a/packages/mosaic/tabs/tab-header.ts
+++ b/packages/mosaic/tabs/tab-header.ts
@@ -87,7 +87,7 @@ export class McTabHeader extends McTabHeaderBase
 
     /** Tracks which element has focus; used for keyboard navigation */
     get focusIndex(): number {
-        return this.keyManager ? this.keyManager.activeItemIndex! : 0;
+        return this.keyManager ? this.keyManager.activeItemIndex : 0;
     }
 
     /** When the focus index is set, we must manually send focus to the correct label */
@@ -206,6 +206,7 @@ export class McTabHeader extends McTabHeaderBase
     }
 
     handleKeydown(event: KeyboardEvent) {
+        // tslint:disable-next-line: deprecation
         switch (event.keyCode) {
             case HOME:
                 this.keyManager.setFirstItemActive();
@@ -410,7 +411,7 @@ export class McTabHeader extends McTabHeaderBase
         }
 
         // The view length is the visible width of the tab labels.
-        const viewLength = this.tabListContainer.nativeElement.offsetWidth;
+        const viewLength: number = this.tabListContainer.nativeElement.offsetWidth;
 
         let labelBeforePos: number;
         let labelAfterPos: number;

--- a/tslint.json
+++ b/tslint.json
@@ -16,6 +16,7 @@
 
         // need only for this project
         "no-non-null-assertion": false,
-        "strict-type-predicates": false
+        "strict-type-predicates": false,
+        "no-unbound-method": [true, { "whitelist": ["expect"], "allow-typeof": true }]
     }
 }


### PR DESCRIPTION
fixing no-side-effect-code, deprecated, no-inferred-empty-object-type, no-unnecessary-type-assertion, restrict-plus-operands tslint errors.

expect is added to the whitelist for no-unbound-method, because expect doesn't call function, see https://github.com/palantir/tslint/pull/4472 for more details.

