### PR TITLE
feat(docs): adding embed icon font in Stackblitz examples

### DIFF
--- a/packages/docs/src/app/shared/stackblitz/stackblitz-writer.ts
+++ b/packages/docs/src/app/shared/stackblitz/stackblitz-writer.ts
@@ -35,7 +35,7 @@ const angularVersion = '>=8.0.0';
 const dependencies = {
     '@ptsecurity/cdk': mosaicVersion,
     '@ptsecurity/mosaic': mosaicVersion,
-    '@ptsecurity/mosaic-icons': '~3.0.0',
+    '@ptsecurity/mosaic-icons': '~3.1.0',
     '@ptsecurity/mosaic-moment-adapter': mosaicVersion,
     '@angular/cdk': angularVersion,
     '@angular/animations': angularVersion,

--- a/packages/docs/src/assets/stackblitz/styles.css
+++ b/packages/docs/src/assets/stackblitz/styles.css
@@ -1,5 +1,5 @@
 @import '~@ptsecurity/mosaic/prebuilt-themes/default-theme.css';
-@import "~@ptsecurity/mosaic-icons/dist/styles/mc-icons.css";
+@import "~@ptsecurity/mosaic-icons/dist/styles/mc-icons-embed.css";
 
 
 body {


### PR DESCRIPTION
@ptsecurity/mosaic-icons version is updated in Stackblitz writer.
mc-icons.css is switched to mc-icons-embed.css with embed icon font included.

