### PR TITLE
chore(common): fixing tslint errors

### DIFF
--- a/packages/mosaic/core/option/optgroup.ts
+++ b/packages/mosaic/core/option/optgroup.ts
@@ -7,7 +7,8 @@ import { mixinDisabled, CanDisable, CanDisableCtor } from '../common-behaviors/i
 /** @docs-private */
 export class McOptgroupBase {}
 
-export const mcOptgroupMixinBase: CanDisableCtor & typeof McOptgroupBase = mixinDisabled(McOptgroupBase);
+// tslint:disable-next-line: naming-convention
+export const McOptgroupMixinBase: CanDisableCtor & typeof McOptgroupBase = mixinDisabled(McOptgroupBase);
 
 // Counter for unique group ids.
 let uniqueOptgroupIdCounter = 0;
@@ -31,7 +32,7 @@ let uniqueOptgroupIdCounter = 0;
         '[attr.aria-labelledby]': 'labelId'
     }
 })
-export class McOptgroup extends mcOptgroupMixinBase implements CanDisable {
+export class McOptgroup extends McOptgroupMixinBase implements CanDisable {
     /** Label for the option group. */
     @Input() label: string;
 

--- a/packages/mosaic/core/option/optgroup.ts
+++ b/packages/mosaic/core/option/optgroup.ts
@@ -7,7 +7,7 @@ import { mixinDisabled, CanDisable, CanDisableCtor } from '../common-behaviors/i
 /** @docs-private */
 export class McOptgroupBase {}
 
-export const McOptgroupMixinBase: CanDisableCtor & typeof McOptgroupBase = mixinDisabled(McOptgroupBase);
+export const mcOptgroupMixinBase: CanDisableCtor & typeof McOptgroupBase = mixinDisabled(McOptgroupBase);
 
 // Counter for unique group ids.
 let uniqueOptgroupIdCounter = 0;
@@ -31,7 +31,7 @@ let uniqueOptgroupIdCounter = 0;
         '[attr.aria-labelledby]': 'labelId'
     }
 })
-export class McOptgroup extends McOptgroupMixinBase implements CanDisable {
+export class McOptgroup extends mcOptgroupMixinBase implements CanDisable {
     /** Label for the option group. */
     @Input() label: string;
 

--- a/packages/mosaic/core/select/constants.ts
+++ b/packages/mosaic/core/select/constants.ts
@@ -1,5 +1,5 @@
-import { InjectionToken } from '@angular/core';
 import { ScrollStrategy, Overlay, RepositionScrollStrategy } from '@angular/cdk/overlay';
+import { InjectionToken } from '@angular/core';
 
 
 /** The max height of the select's overlay panel */

--- a/packages/mosaic/core/services/measure-scrollbar.service.ts
+++ b/packages/mosaic/core/services/measure-scrollbar.service.ts
@@ -8,15 +8,15 @@ import { Inject, Injectable } from '@angular/core';
 export class McMeasureScrollbarService {
 
     get scrollBarWidth(): number {
-        if (this._scrollbarWidth) {
-            return this._scrollbarWidth;
+        if (this._scrollBarWidth) {
+            return this._scrollBarWidth;
         }
         this.initScrollBarWidth();
 
-        return this._scrollbarWidth;
+        return this._scrollBarWidth;
     }
 
-    private _scrollbarWidth: number;
+    private _scrollBarWidth: number;
     private scrollbarMeasure = {
         position: 'absolute',
         top: '-9999px',
@@ -46,6 +46,6 @@ export class McMeasureScrollbarService {
         const width = scrollDiv.offsetWidth - scrollDiv.clientWidth;
 
         this.document.body.removeChild(scrollDiv);
-        this._scrollbarWidth = width;
+        this._scrollBarWidth = width;
     }
 }

--- a/packages/mosaic/datepicker/datepicker-input.ts
+++ b/packages/mosaic/datepicker/datepicker-input.ts
@@ -210,12 +210,22 @@ export class McDatepickerInput<D> implements ControlValueAccessor, OnDestroy, Va
     /** Whether the last value set on the input was valid. */
     private lastValueValid = false;
 
+    /** The combined form control validator for this input. */
+    private validator: ValidatorFn | null;
+
     constructor(
         public elementRef: ElementRef<HTMLInputElement>,
         @Optional() public dateAdapter: DateAdapter<D>,
         @Optional() @Inject(MC_DATE_FORMATS) private dateFormats: McDateFormats,
         @Optional() private formField: McFormField
     ) {
+        this.validator = Validators.compose([
+            this.parseValidator,
+            this.minValidator,
+            this.maxValidator,
+            this.filterValidator
+        ]);
+
         if (!this.dateAdapter) {
             throw createMissingDateImplError('DateAdapter');
         }
@@ -355,16 +365,6 @@ export class McDatepickerInput<D> implements ControlValueAccessor, OnDestroy, Va
         this.elementRef.nativeElement.value =
             value ? this.dateAdapter.format(value, this.dateFormats.display.dateInput) : '';
     }
-
-    /** The combined form control validator for this input. */
-        // tslint:disable:member-ordering
-    private validator: ValidatorFn | null =
-        Validators.compose([
-            this.parseValidator,
-            this.minValidator,
-            this.maxValidator,
-            this.filterValidator
-        ]);
 
     /**
      * @param obj The object to check.

--- a/packages/mosaic/icon/icon.component.ts
+++ b/packages/mosaic/icon/icon.component.ts
@@ -22,7 +22,8 @@ export class McIconBase {
     constructor(public _elementRef: ElementRef) {}
 }
 
-export const mcIconMixinBase: CanColorCtor & typeof McIconBase = mixinColor(McIconBase, ThemePalette.Empty);
+// tslint:disable-next-line: naming-convention
+export const McIconMixinBase: CanColorCtor & typeof McIconBase = mixinColor(McIconBase, ThemePalette.Empty);
 
 
 @Component({
@@ -33,7 +34,7 @@ export const mcIconMixinBase: CanColorCtor & typeof McIconBase = mixinColor(McIc
     encapsulation: ViewEncapsulation.None,
     inputs: ['color']
 })
-export class McIcon extends mcIconMixinBase implements CanColor {
+export class McIcon extends McIconMixinBase implements CanColor {
     constructor(elementRef: ElementRef, @Attribute('mc-icon') iconName: string) {
         super(elementRef);
 

--- a/packages/mosaic/icon/icon.component.ts
+++ b/packages/mosaic/icon/icon.component.ts
@@ -6,7 +6,6 @@ import {
     ElementRef,
     ViewEncapsulation
 } from '@angular/core';
-
 import { mixinColor, CanColor, CanColorCtor, ThemePalette } from '@ptsecurity/mosaic/core';
 
 
@@ -14,14 +13,16 @@ import { mixinColor, CanColor, CanColorCtor, ThemePalette } from '@ptsecurity/mo
     selector: '[mc-icon]',
     host: { class: 'mc mc-icon' }
 })
+// tslint:disable-next-line:naming-convention
 export class McIconCSSStyler {}
 
 
 export class McIconBase {
+    // tslint:disable-next-line:naming-convention
     constructor(public _elementRef: ElementRef) {}
 }
 
-export const _McIconMixinBase: CanColorCtor & typeof McIconBase = mixinColor(McIconBase, ThemePalette.Empty);
+export const mcIconMixinBase: CanColorCtor & typeof McIconBase = mixinColor(McIconBase, ThemePalette.Empty);
 
 
 @Component({
@@ -32,7 +33,7 @@ export const _McIconMixinBase: CanColorCtor & typeof McIconBase = mixinColor(McI
     encapsulation: ViewEncapsulation.None,
     inputs: ['color']
 })
-export class McIcon extends _McIconMixinBase implements CanColor {
+export class McIcon extends mcIconMixinBase implements CanColor {
     constructor(elementRef: ElementRef, @Attribute('mc-icon') iconName: string) {
         super(elementRef);
 

--- a/packages/mosaic/link/link.component.ts
+++ b/packages/mosaic/link/link.component.ts
@@ -20,7 +20,8 @@ export class McLinkBase {
     constructor(public elementRef: ElementRef) {}
 }
 
-export const mcLinkBase: HasTabIndexCtor & CanDisableCtor & typeof McLinkBase
+// tslint:disable-next-line: naming-convention
+export const McLinkBaseConst: HasTabIndexCtor & CanDisableCtor & typeof McLinkBase
     = mixinTabIndex(mixinDisabled(McLinkBase));
 
 @Directive({
@@ -33,7 +34,7 @@ export const mcLinkBase: HasTabIndexCtor & CanDisableCtor & typeof McLinkBase
     }
 })
 
-export class McLink extends mcLinkBase implements OnDestroy, HasTabIndex, CanDisable {
+export class McLink extends McLinkBaseConst implements OnDestroy, HasTabIndex, CanDisable {
 
     @Input()
     get disabled() {

--- a/packages/mosaic/link/link.component.ts
+++ b/packages/mosaic/link/link.component.ts
@@ -16,13 +16,13 @@ import {
 } from '@ptsecurity/mosaic/core';
 
 
-export class McLinkBase {
+export class McLinkMixinBase {
     constructor(public elementRef: ElementRef) {}
 }
 
 // tslint:disable-next-line: naming-convention
-export const McLinkBaseConst: HasTabIndexCtor & CanDisableCtor & typeof McLinkBase
-    = mixinTabIndex(mixinDisabled(McLinkBase));
+export const McLinkBase: HasTabIndexCtor & CanDisableCtor & typeof McLinkMixinBase
+    = mixinTabIndex(mixinDisabled(McLinkMixinBase));
 
 @Directive({
     selector: 'a.mc-link',
@@ -34,7 +34,7 @@ export const McLinkBaseConst: HasTabIndexCtor & CanDisableCtor & typeof McLinkBa
     }
 })
 
-export class McLink extends McLinkBaseConst implements OnDestroy, HasTabIndex, CanDisable {
+export class McLink extends McLinkBase implements OnDestroy, HasTabIndex, CanDisable {
 
     @Input()
     get disabled() {

--- a/packages/mosaic/link/link.component.ts
+++ b/packages/mosaic/link/link.component.ts
@@ -20,7 +20,7 @@ export class McLinkBase {
     constructor(public elementRef: ElementRef) {}
 }
 
-export const _McLinkBase: HasTabIndexCtor & CanDisableCtor & typeof McLinkBase
+export const mcLinkBase: HasTabIndexCtor & CanDisableCtor & typeof McLinkBase
     = mixinTabIndex(mixinDisabled(McLinkBase));
 
 @Directive({
@@ -33,7 +33,7 @@ export const _McLinkBase: HasTabIndexCtor & CanDisableCtor & typeof McLinkBase
     }
 })
 
-export class McLink extends _McLinkBase implements OnDestroy, HasTabIndex, CanDisable {
+export class McLink extends mcLinkBase implements OnDestroy, HasTabIndex, CanDisable {
 
     @Input()
     get disabled() {

--- a/packages/mosaic/link/link.component.ts
+++ b/packages/mosaic/link/link.component.ts
@@ -16,13 +16,13 @@ import {
 } from '@ptsecurity/mosaic/core';
 
 
-export class McLinkMixinBase {
+export class McLinkBase {
     constructor(public elementRef: ElementRef) {}
 }
 
 // tslint:disable-next-line: naming-convention
-export const McLinkBase: HasTabIndexCtor & CanDisableCtor & typeof McLinkMixinBase
-    = mixinTabIndex(mixinDisabled(McLinkMixinBase));
+export const McLinkMixinBase: HasTabIndexCtor & CanDisableCtor & typeof McLinkBase
+    = mixinTabIndex(mixinDisabled(McLinkBase));
 
 @Directive({
     selector: 'a.mc-link',
@@ -34,7 +34,7 @@ export const McLinkBase: HasTabIndexCtor & CanDisableCtor & typeof McLinkMixinBa
     }
 })
 
-export class McLink extends McLinkBase implements OnDestroy, HasTabIndex, CanDisable {
+export class McLink extends McLinkMixinBase implements OnDestroy, HasTabIndex, CanDisable {
 
     @Input()
     get disabled() {

--- a/packages/mosaic/link/link.module.ts
+++ b/packages/mosaic/link/link.module.ts
@@ -1,6 +1,5 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-
 import { A11yModule } from '@ptsecurity/cdk/a11y';
 
 import { McLink } from './link.component';

--- a/packages/mosaic/list/list-selection.component.spec.ts
+++ b/packages/mosaic/list/list-selection.component.spec.ts
@@ -1,6 +1,7 @@
 // tslint:disable:no-magic-numbers
 // tslint:disable:mocha-no-side-effect-code
 // tslint:disable:max-func-body-length
+// tslint:disable:no-empty
 
 import { Component, DebugElement, ChangeDetectionStrategy } from '@angular/core';
 import { async, ComponentFixture, fakeAsync, TestBed, tick, flush } from '@angular/core/testing';

--- a/packages/mosaic/list/list-selection.component.spec.ts
+++ b/packages/mosaic/list/list-selection.component.spec.ts
@@ -395,7 +395,7 @@ describe('McListSelection without forms', () => {
         }));
 
         it('should set its initial selected state in the selectionModel', () => {
-            const optionEl = listItemEl.injector.get(McListOption);
+            const optionEl = listItemEl.injector.get<McListOption>(McListOption);
             const selectedOptions = selectionList.componentInstance.selectionModel;
             expect(selectedOptions.isSelected(optionEl)).toBeTruthy();
         });

--- a/packages/mosaic/list/list.module.ts
+++ b/packages/mosaic/list/list.module.ts
@@ -1,8 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-
 import { A11yModule } from '@ptsecurity/cdk/a11y';
-
 import { McLineModule } from '@ptsecurity/mosaic/core';
 
 import { McListSelection, McListOption } from './list-selection.component';


### PR DESCRIPTION
Fixing naming-convention, ordered-imports, member-ordering, no-empty tslint errors.
Syntax injector.get() is deprecated and now changed to injector.get\<Type\>().