### PR TITLE
fix(form-field): change prefix icon color according the theme settings (#UIM-195)

### DIFF
--- a/packages/mosaic/form-field/_form-field-theme.scss
+++ b/packages/mosaic/form-field/_form-field-theme.scss
@@ -78,6 +78,10 @@
     .mc-form-field__hint {
         color: mc-color($second, 400);
     }
+
+    .mc-form-field__prefix .mc-icon {
+        color: map-get($foreground, disabled-text);
+    }
 }
 
 @mixin mc-form-field-typography($config) {


### PR DESCRIPTION
The color of the icon in form-field prefix should be defined by the current theme settings.