### PR TITLE
feat(docs): setting content width

### DIFF
--- a/packages/docs/src/app/components/main-layout/main-layout.component.scss
+++ b/packages/docs/src/app/components/main-layout/main-layout.component.scss
@@ -5,7 +5,7 @@
 }
 
 .content {
-    max-width: calc(100% - 600px); // for Edge
+    width: calc(100% - 600px); // for Edge
     margin: {
         top: 64px;
         left: 300px;


### PR DESCRIPTION
setting content width to calc(100% - 600px) for empty examples and correct view in Edge

