### PR TITLE
chore(common): setting properties with set and get to private

### DIFF
--- a/packages/cdk/datetime/date-adapter.ts
+++ b/packages/cdk/datetime/date-adapter.ts
@@ -60,8 +60,7 @@ export abstract class DateAdapter<D> {
         return this._localeChanges;
     }
 
-    // tslint:disable-next-line:naming-convention
-    protected _localeChanges = new Subject<void>();
+    private _localeChanges = new Subject<void>();
 
     /**
      * Gets the year component of the given date.

--- a/packages/mosaic/input/input.ts
+++ b/packages/mosaic/input/input.ts
@@ -324,8 +324,7 @@ export class McInput extends mcInputMixinBase implements McFormFieldControl<any>
         }
     }
 
-    // tslint:disable-next-line: naming-convention
-    protected _disabled = false;
+    private _disabled = false;
 
     /**
      * Implemented as part of McFormFieldControl.
@@ -340,8 +339,7 @@ export class McInput extends mcInputMixinBase implements McFormFieldControl<any>
         this._id = value || this.uid;
     }
 
-    // tslint:disable-next-line: naming-convention
-    protected _id: string;
+    private _id: string;
 
     /**
      * Implemented as part of McFormFieldControl.
@@ -356,8 +354,7 @@ export class McInput extends mcInputMixinBase implements McFormFieldControl<any>
         this._required = coerceBooleanProperty(value);
     }
 
-    // tslint:disable-next-line: naming-convention
-    protected _required = false;
+    private _required = false;
 
     // tslint:disable no-reserved-keywords
     /** Input type of the element. */
@@ -379,8 +376,7 @@ export class McInput extends mcInputMixinBase implements McFormFieldControl<any>
     }
     // tslint:enable no-reserved-keywords
 
-    // tslint:disable-next-line: naming-convention
-    protected _type = 'text';
+    private _type = 'text';
 
     /**
      * Implemented as part of McFormFieldControl.

--- a/packages/mosaic/modal/modal.component.ts
+++ b/packages/mosaic/modal/modal.component.ts
@@ -65,8 +65,7 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
     get mcVisible() { return this._mcVisible; }
     set mcVisible(value) { this._mcVisible = value; }
 
-    // tslint:disable-next-line:orthodox-getter-and-setter , naming-convention  could be private?
-    _mcVisible = false;
+    private _mcVisible = false;
 
     @Output() mcVisibleChange = new EventEmitter<boolean>();
 
@@ -81,20 +80,17 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
     @Input()
     get mcClosable() { return this._mcClosable; }
     set mcClosable(value) { this._mcClosable = value; }
-    // tslint:disable-next-line:orthodox-getter-and-setter , naming-convention  could be private?
-    _mcClosable = true;
+    private _mcClosable = true;
 
     @Input()
     get mcMask() { return this._mcMask; }
     set mcMask(value) { this._mcMask = value; }
-    // tslint:disable-next-line:orthodox-getter-and-setter , naming-convention  could be private?
-    _mcMask = true;
+    private _mcMask = true;
 
     @Input()
     get mcMaskClosable() { return this._mcMaskClosable; }
     set mcMaskClosable(value) { this._mcMaskClosable = value; }
-    // tslint:disable-next-line:orthodox-getter-and-setter , naming-convention  could be private?
-    _mcMaskClosable = false;
+    private _mcMaskClosable = false;
 
     @Input() mcMaskStyle: object;
     @Input() mcBodyStyle: object;
@@ -111,8 +107,7 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
     @Input()
     get mcOkLoading() { return this._mcOkLoading; }
     set mcOkLoading(value) { this._mcOkLoading = value; }
-    // tslint:disable-next-line:orthodox-getter-and-setter , naming-convention  could be private?
-    _mcOkLoading = false;
+    private _mcOkLoading = false;
 
     @Input() @Output() mcOnOk: EventEmitter<T> | OnClickCallback<T> = new EventEmitter<T>();
     @Input() mcCancelText: string;
@@ -120,8 +115,7 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
     @Input()
     get mcCancelLoading() { return this._mcCancelLoading; }
     set mcCancelLoading(value) { this._mcCancelLoading = value; }
-    // tslint:disable-next-line:orthodox-getter-and-setter , naming-convention  could be private?
-    _mcCancelLoading = false;
+    private _mcCancelLoading = false;
 
     @Input() @Output() mcOnCancel: EventEmitter<T> | OnClickCallback<T> = new EventEmitter<T>();
 

--- a/packages/mosaic/tags/tag-list.component.ts
+++ b/packages/mosaic/tags/tag-list.component.ts
@@ -283,9 +283,7 @@ export class McTagList extends _McTagListMixinBase implements McFormFieldControl
         descendants: true
     }) tags: QueryList<McTag>;
 
-    // public property with setter - should be private?
-    // tslint:disable-next-line: naming-convention orthodox-getter-and-setter
-    _tabIndex = 0;
+    private _tabIndex = 0;
 
     private _value: any;
 

--- a/packages/mosaic/tags/tag-list.component.ts
+++ b/packages/mosaic/tags/tag-list.component.ts
@@ -283,7 +283,8 @@ export class McTagList extends _McTagListMixinBase implements McFormFieldControl
         descendants: true
     }) tags: QueryList<McTag>;
 
-    private _tabIndex = 0;
+    // tslint:disable-next-line: naming-convention orthodox-getter-and-setter
+    _tabIndex = 0;
 
     private _value: any;
 

--- a/packages/mosaic/textarea/textarea.component.ts
+++ b/packages/mosaic/textarea/textarea.component.ts
@@ -147,11 +147,9 @@ export class McTextarea extends McTextareaMixinBase implements McFormFieldContro
 
     protected uid = `mc-textsrea-${nextUniqueId++}`;
     protected previousNativeValue: any;
-    // tslint:disable:naming-convention
-    protected _disabled = false;
-    protected _id: string;
-    protected _required = false;
-    // tslint:enable:naming-convention
+    private _disabled = false;
+    private _id: string;
+    private _required = false;
 
     private valueAccessor: { value: any };
     private growSubscription: Subscription;


### PR DESCRIPTION
Setting most of the properties with set and get to private.
 Some, like in packages/cdk/tree/padding.ts are keeping as they were to avoid breaking changes.

