### PR TITLE
chore(common): renaming constants for extends

### DIFF
--- a/packages/mosaic/checkbox/checkbox.ts
+++ b/packages/mosaic/checkbox/checkbox.ts
@@ -75,7 +75,8 @@ export class McCheckboxBase {
     }
 }
 
-export const mcCheckboxMixinBase:
+// tslint:disable-next-line:naming-convention
+export const McCheckboxMixinBase:
     HasTabIndexCtor &
     CanColorCtor &
     CanDisableCtor &
@@ -109,7 +110,7 @@ export const mcCheckboxMixinBase:
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class McCheckbox extends mcCheckboxMixinBase implements ControlValueAccessor,
+export class McCheckbox extends McCheckboxMixinBase implements ControlValueAccessor,
     AfterViewInit, OnDestroy, CanColor, CanDisable, HasTabIndex {
 
     /**

--- a/packages/mosaic/dropdown/dropdown-item.ts
+++ b/packages/mosaic/dropdown/dropdown-item.ts
@@ -20,7 +20,8 @@ import { MC_DROPDOWN_PANEL, McDropdownPanel } from './dropdown-panel';
 // Boilerplate for applying mixins to McDropdownItem.
 /** @docs-private */
 export class McDropdownItemBase {}
-export const mcDropdownItemMixinBase: CanDisableCtor & typeof McDropdownItemBase =
+// tslint:disable-next-line:naming-convention
+export const McDropdownItemMixinBase: CanDisableCtor & typeof McDropdownItemBase =
     mixinDisabled(McDropdownItemBase);
 
 /**
@@ -50,7 +51,7 @@ export const mcDropdownItemMixinBase: CanDisableCtor & typeof McDropdownItemBase
         <i *ngIf="triggersNestedDropdown" mc-icon="mc-angle-right-M_16" class="mc-dropdown__trigger"></i>
     `
 })
-export class McDropdownItem extends mcDropdownItemMixinBase
+export class McDropdownItem extends McDropdownItemMixinBase
     implements IFocusableOption, CanDisable, OnDestroy {
 
     /** ARIA role for the dropdown item. */

--- a/packages/mosaic/form-field/form-field.ts
+++ b/packages/mosaic/form-field/form-field.ts
@@ -35,7 +35,8 @@ export class McFormFieldBase {
     constructor(public _elementRef: ElementRef) {}
 }
 
-export const mcFormFieldMixinBase: CanColorCtor & typeof McFormFieldBase = mixinColor(McFormFieldBase);
+// tslint:disable-next-line:naming-convention
+export const McFormFieldMixinBase: CanColorCtor & typeof McFormFieldBase = mixinColor(McFormFieldBase);
 
 @Component({
     selector: 'mc-form-field',
@@ -74,7 +75,7 @@ export const mcFormFieldMixinBase: CanColorCtor & typeof McFormFieldBase = mixin
     changeDetection: ChangeDetectionStrategy.OnPush
 })
 
-export class McFormField extends mcFormFieldMixinBase implements
+export class McFormField extends McFormFieldMixinBase implements
     AfterContentInit, AfterContentChecked, AfterViewInit, CanColor {
 
     @ContentChild(McFormFieldControl, {static: false}) control: McFormFieldControl<any>;

--- a/packages/mosaic/input/input.ts
+++ b/packages/mosaic/input/input.ts
@@ -54,7 +54,8 @@ export class McInputBase {
     }
 }
 
-export const mcInputMixinBase: CanUpdateErrorStateCtor & typeof McInputBase = mixinErrorState(McInputBase);
+// tslint:disable-next-line:naming-convention
+export const McInputMixinBase: CanUpdateErrorStateCtor & typeof McInputBase = mixinErrorState(McInputBase);
 
 
 @Directive({
@@ -259,7 +260,7 @@ export class McNumberInput implements McFormFieldNumberControl<any> {
     },
     providers: [{ provide: McFormFieldControl, useExisting: McInput }]
 })
-export class McInput extends mcInputMixinBase implements McFormFieldControl<any>, OnChanges,
+export class McInput extends McInputMixinBase implements McFormFieldControl<any>, OnChanges,
     OnDestroy, DoCheck, CanUpdateErrorState {
 
     /** An object used to control when error messages are shown. */

--- a/packages/mosaic/list/list-selection.component.ts
+++ b/packages/mosaic/list/list-selection.component.ts
@@ -221,7 +221,7 @@ export class McListSelectionChange {
 export class McListSelectionBase {}
 
 // tslint:disable-next-line:naming-convention
-export const _McListSelectionMixinBase: CanDisableCtor & HasTabIndexCtor & typeof McListSelectionBase
+export const McListSelectionMixinBase: CanDisableCtor & HasTabIndexCtor & typeof McListSelectionBase
     = mixinTabIndex(mixinDisabled(McListSelectionBase));
 
 @Component({
@@ -243,7 +243,7 @@ export const _McListSelectionMixinBase: CanDisableCtor & HasTabIndexCtor & typeo
     providers: [MC_SELECTION_LIST_VALUE_ACCESSOR],
     preserveWhitespaces: false
 })
-export class McListSelection extends _McListSelectionMixinBase implements
+export class McListSelection extends McListSelectionMixinBase implements
     IFocusableOption, CanDisable, HasTabIndex, AfterContentInit, ControlValueAccessor, HasTabIndex {
 
     keyManager: FocusKeyManager<McListOption>;

--- a/packages/mosaic/progress-bar/progress-bar.component.ts
+++ b/packages/mosaic/progress-bar/progress-bar.component.ts
@@ -20,7 +20,8 @@ export class McProgressBarBase {
     constructor(public _elementRef: ElementRef) {}
 }
 
-export const _McProgressBarMixinBase:
+// tslint:disable-next-line:naming-convention
+export const McProgressBarMixinBase:
     CanColorCtor &
     typeof McProgressBarBase =
         mixinColor(McProgressBarBase);
@@ -36,7 +37,7 @@ export const _McProgressBarMixinBase:
         '[attr.id]': 'id'
     }
 })
-export class McProgressBar extends _McProgressBarMixinBase implements CanColor {
+export class McProgressBar extends McProgressBarMixinBase implements CanColor {
     @Input() id: string = `mc-progress-bar-${idIterator++}`;
     @Input() value: number = 0;
     @Input() mode: ProgressBarMode = 'determinate';

--- a/packages/mosaic/progress-spinner/progress-spinner.component.ts
+++ b/packages/mosaic/progress-spinner/progress-spinner.component.ts
@@ -20,7 +20,8 @@ export class McProgressSpinnerBase {
     constructor(public _elementRef: ElementRef) {}
 }
 
-export const _McProgressSpinnerMixinBase:
+// tslint:disable-next-line:naming-convention
+export const McProgressSpinnerMixinBase:
     CanColorCtor &
     typeof McProgressSpinnerBase =
         mixinColor(McProgressSpinnerBase);
@@ -38,7 +39,7 @@ const MAX_DASH_ARRAY = 273;
         '[attr.id]': 'id'
     }
 })
-export class McProgressSpinner extends _McProgressSpinnerMixinBase implements CanColor {
+export class McProgressSpinner extends McProgressSpinnerMixinBase implements CanColor {
     @Input() id: string = `mc-progress-spinner-${idIterator++}`;
     @Input() value: number = 0;
     @Input() mode: ProgressSpinnerMode = 'determinate';

--- a/packages/mosaic/radio/radio.component.ts
+++ b/packages/mosaic/radio/radio.component.ts
@@ -36,7 +36,8 @@ export class McRadioChange {
 // Boilerplate for applying mixins to McRadioGroup.
 /** @docs-private */
 export class McRadioGroupBase {}
-export const mcRadioGroupMixinBase: CanDisableCtor & typeof McRadioGroupBase = mixinDisabled(McRadioGroupBase);
+// tslint:disable-next-line:naming-convention
+export const McRadioGroupMixinBase: CanDisableCtor & typeof McRadioGroupBase = mixinDisabled(McRadioGroupBase);
 
 /**
  * Provider Expression that allows mc-radio-group to register as a ControlValueAccessor. This
@@ -59,7 +60,7 @@ export const MC_RADIO_GROUP_CONTROL_VALUE_ACCESSOR: any = {
     },
     inputs: ['disabled']
 })
-export class McRadioGroup extends mcRadioGroupMixinBase
+export class McRadioGroup extends McRadioGroupMixinBase
     implements AfterContentInit, ControlValueAccessor, CanDisable {
 
     /** Name of the radio button group. All radio buttons inside this group will use this name. */
@@ -285,7 +286,8 @@ export class McRadioButtonBase {
     constructor(public _elementRef: ElementRef) {}
 }
 
-export const mcRadioButtonMixinBase:
+// tslint:disable-next-line:naming-convention
+export const McRadioButtonMixinBase:
     CanColorCtor &
     HasTabIndexCtor &
     typeof McRadioButtonBase =
@@ -307,7 +309,7 @@ export const mcRadioButtonMixinBase:
         '[class.mc-disabled]': 'disabled'
     }
 })
-export class McRadioButton extends mcRadioButtonMixinBase
+export class McRadioButton extends McRadioButtonMixinBase
     implements OnInit, AfterViewInit, OnDestroy, CanColor, HasTabIndex {
 
     /** Whether this radio button is checked. */

--- a/packages/mosaic/tabs/tab-group.ts
+++ b/packages/mosaic/tabs/tab-group.ts
@@ -84,7 +84,8 @@ export class McTabGroupBase {
     // tslint:disable-next-line:naming-convention
     constructor(public _elementRef: ElementRef) { }
 }
-export const mcTabGroupMixinBase:
+// tslint:disable-next-line:naming-convention
+export const McTabGroupMixinBase:
     CanColorCtor &
     typeof McTabGroupBase =
     mixinColor(mixinDisabled(McTabGroupBase));
@@ -107,7 +108,7 @@ export const mcTabGroupMixinBase:
         '[class.mc-tab-group_inverted-header]': 'headerPosition === "below"'
     }
 })
-export class McTabGroup extends mcTabGroupMixinBase implements AfterContentInit,
+export class McTabGroup extends McTabGroupMixinBase implements AfterContentInit,
     AfterContentChecked, OnDestroy, CanColor {
     lightTab: boolean;
 

--- a/packages/mosaic/tabs/tab-label-wrapper.ts
+++ b/packages/mosaic/tabs/tab-label-wrapper.ts
@@ -9,7 +9,8 @@ import {
 // Boilerplate for applying mixins to McTabLabelWrapper.
 /** @docs-private */
 export class McTabLabelWrapperBase {}
-export const mcTabLabelWrapperMixinBase: CanDisableCtor &
+// tslint:disable-next-line:naming-convention
+export const McTabLabelWrapperMixinBase: CanDisableCtor &
     typeof McTabLabelWrapperBase = mixinDisabled(McTabLabelWrapperBase);
 
 /**
@@ -24,7 +25,7 @@ export const mcTabLabelWrapperMixinBase: CanDisableCtor &
         '[attr.aria-disabled]': '!!disabled'
     }
 })
-export class McTabLabelWrapper extends mcTabLabelWrapperMixinBase implements CanDisable {
+export class McTabLabelWrapper extends McTabLabelWrapperMixinBase implements CanDisable {
     constructor(public elementRef: ElementRef) {
         super();
     }

--- a/packages/mosaic/tabs/tab-nav-bar/tab-nav-bar.ts
+++ b/packages/mosaic/tabs/tab-nav-bar/tab-nav-bar.ts
@@ -28,7 +28,8 @@ export class McTabNavBase {
     // tslint:disable-next-line:naming-convention
     constructor(public _elementRef: ElementRef) {}
 }
-export const mcTabNavMixinBase: CanColorCtor &
+// tslint:disable-next-line:naming-convention
+export const McTabNavMixinBase: CanColorCtor &
     typeof McTabNavBase = mixinColor(McTabNavBase);
 
 /**
@@ -44,7 +45,7 @@ export const mcTabNavMixinBase: CanColorCtor &
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class McTabNav extends mcTabNavMixinBase
+export class McTabNav extends McTabNavMixinBase
     implements CanColor {
         constructor(elementRef: ElementRef) {
             super(elementRef);
@@ -53,7 +54,8 @@ export class McTabNav extends mcTabNavMixinBase
 
 // Boilerplate for applying mixins to McTabLink.
 export class McTabLinkBase {}
-export const mcTabLinkMixinBase: HasTabIndexCtor & CanDisableCtor &
+// tslint:disable-next-line:naming-convention
+export const McTabLinkMixinBase: HasTabIndexCtor & CanDisableCtor &
     typeof McTabLinkBase = mixinTabIndex(mixinDisabled(McTabLinkBase));
 
 /**
@@ -72,7 +74,7 @@ export const mcTabLinkMixinBase: HasTabIndexCtor & CanDisableCtor &
         '[class.mc-active]': 'active'
     }
 })
-export class McTabLink extends mcTabLinkMixinBase
+export class McTabLink extends McTabLinkMixinBase
     implements OnDestroy, CanDisable, HasTabIndex {
     /** Whether the link is active. */
     @Input()

--- a/packages/mosaic/tabs/tab.ts
+++ b/packages/mosaic/tabs/tab.ts
@@ -25,7 +25,8 @@ import { McTabLabel } from './tab-label';
 
 
 export class McTabBase {}
-export const mcTabMixinBase: CanDisableCtor & typeof McTabBase = mixinDisabled(
+// tslint:disable-next-line:naming-convention
+export const McTabMixinBase: CanDisableCtor & typeof McTabBase = mixinDisabled(
     McTabBase
 );
 
@@ -40,7 +41,7 @@ export const mcTabMixinBase: CanDisableCtor & typeof McTabBase = mixinDisabled(
     encapsulation: ViewEncapsulation.None,
     exportAs: 'mcTab'
 })
-export class McTab extends mcTabMixinBase
+export class McTab extends McTabMixinBase
     implements OnInit, CanDisable, OnChanges, OnDestroy {
     /** @docs-private */
     get content(): TemplatePortal | null {

--- a/packages/mosaic/tags/tag-list.component.ts
+++ b/packages/mosaic/tags/tag-list.component.ts
@@ -47,7 +47,7 @@ export class McTagListBase {
 }
 
 // tslint:disable-next-line:naming-convention
-export const _McTagListMixinBase: CanUpdateErrorStateCtor & typeof McTagListBase = mixinErrorState(McTagListBase);
+export const McTagListMixinBase: CanUpdateErrorStateCtor & typeof McTagListBase = mixinErrorState(McTagListBase);
 
 
 // Increasing integer for generating unique ids for tag-list components.
@@ -79,7 +79,7 @@ export class McTagListChange {
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush
 })
-export class McTagList extends _McTagListMixinBase implements McFormFieldControl<any>,
+export class McTagList extends McTagListMixinBase implements McFormFieldControl<any>,
     ControlValueAccessor, AfterContentInit, DoCheck, OnInit, OnDestroy, CanUpdateErrorState {
 
     readonly controlType: string = 'mc-tag-list';

--- a/packages/mosaic/tags/tag.component.ts
+++ b/packages/mosaic/tags/tag.component.ts
@@ -71,7 +71,7 @@ export class McTagBase {
 }
 
 // tslint:disable-next-line:naming-convention
-export const _McTagMixinBase: CanColorCtor & CanDisableCtor & typeof McTagBase = mixinColor(mixinDisabled(McTagBase));
+export const McTagMixinBase: CanColorCtor & CanDisableCtor & typeof McTagBase = mixinColor(mixinDisabled(McTagBase));
 
 
 @Component({
@@ -101,7 +101,7 @@ export const _McTagMixinBase: CanColorCtor & CanDisableCtor & typeof McTagBase =
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None
 })
-export class McTag extends _McTagMixinBase implements IFocusableOption, OnDestroy, CanColor, CanDisable {
+export class McTag extends McTagMixinBase implements IFocusableOption, OnDestroy, CanColor, CanDisable {
     /** Emits when the tag is focused. */
     readonly onFocus = new Subject<McTagEvent>();
 

--- a/packages/mosaic/toggle/toggle.component.ts
+++ b/packages/mosaic/toggle/toggle.component.ts
@@ -29,7 +29,8 @@ export class McToggleBase {
     constructor(public _elementRef: ElementRef) {}
 }
 
-export const mcToggleMixinBase:
+// tslint:disable-next-line: naming-convention
+export const McToggleMixinBase:
     HasTabIndexCtor &
     CanDisableCtor &
     CanColorCtor &
@@ -66,7 +67,7 @@ export class McToggleChange {
         ])
     ]
 })
-export class McToggleComponent extends mcToggleMixinBase
+export class McToggleComponent extends McToggleMixinBase
     implements ControlValueAccessor, CanColor, CanDisable, HasTabIndex {
 
     @ViewChild('input', {static: false}) inputElement: ElementRef;

--- a/packages/mosaic/vertical-navbar/vertical-navbar-item.component.ts
+++ b/packages/mosaic/vertical-navbar/vertical-navbar-item.component.ts
@@ -42,7 +42,8 @@ class McVerticalNavbarItemBase {
     constructor(public _elementRef: ElementRef) {}
 }
 
-export const _McVerticalNavbarMixinBase: CanDisableCtor & typeof McVerticalNavbarItemBase
+// tslint:disable-next-line:naming-convention
+export const McVerticalNavbarMixinBase: CanDisableCtor & typeof McVerticalNavbarItemBase
     = mixinDisabled(McVerticalNavbarItemBase);
 
 
@@ -58,7 +59,7 @@ export const _McVerticalNavbarMixinBase: CanDisableCtor & typeof McVerticalNavba
         '[attr.tabindex]': 'disabled ? -1 : 0'
     }
 })
-export class McVerticalNavbarItem extends _McVerticalNavbarMixinBase implements CanDisable, OnDestroy {
+export class McVerticalNavbarItem extends McVerticalNavbarMixinBase implements CanDisable, OnDestroy {
     @Input() tabIndex: number = 0;
 
     constructor(


### PR DESCRIPTION
Right now naming-convention is disabled for all such constants. Naming convention should be updated in order to remove tslint:disable-next-line:naming-convention comments

