### PR TITLE
chore(common): fixing tslint errors

### DIFF
--- a/packages/mosaic/schematics/ng-add/index.ts
+++ b/packages/mosaic/schematics/ng-add/index.ts
@@ -6,6 +6,7 @@ import { Schema } from './schema';
 import { mosaicVersion, requiredAngularVersionRange } from './version-names';
 
 
+// tslint:disable-next-line:no-default-export
 export default function(options: Schema): Rule {
 
     return (host: Tree, context: SchematicContext) => {

--- a/packages/mosaic/schematics/ng-add/package-config.ts
+++ b/packages/mosaic/schematics/ng-add/package-config.ts
@@ -2,7 +2,9 @@ import { Tree } from '@angular-devkit/schematics';
 
 
 function sortObjectByKeys(obj: object) {
-    return Object.keys(obj).sort().reduce((result, key) => (result[key] = obj[key]) && result, {});
+    const initialValue: object = {};
+
+    return Object.keys(obj).sort().reduce((result, key) => (result[key] = obj[key]) && result, initialValue);
 }
 
 export function getPackageVersionFromPackageJson(tree: Tree, name: string): string | null {
@@ -20,6 +22,7 @@ export function getPackageVersionFromPackageJson(tree: Tree, name: string): stri
 }
 
 export function addPackageToPackageJson(host: Tree, pkg: string, version: string): Tree {
+    const space: number = 4;
 
     if (host.exists('package.json')) {
 
@@ -35,7 +38,7 @@ export function addPackageToPackageJson(host: Tree, pkg: string, version: string
             json.dependencies = sortObjectByKeys(json.dependencies);
         }
 
-        host.overwrite('package.json', JSON.stringify(json, null, 4));
+        host.overwrite('package.json', JSON.stringify(json, null, space));
     }
 
     return host;

--- a/packages/mosaic/schematics/ng-add/setup-project.ts
+++ b/packages/mosaic/schematics/ng-add/setup-project.ts
@@ -47,9 +47,11 @@ function addAnimationsModule(options: Schema) {
 
         if (options.animations) {
             if (hasNgModuleImport(host, appModulePath, noopAnimationsModuleName)) {
-                return console.warn(chalk.red(`Could not set up "${chalk.bold(browserAnimationsModuleName)}" ` +
+                console.warn(chalk.red(`Could not set up "${chalk.bold(browserAnimationsModuleName)}" ` +
                     `because "${chalk.bold(noopAnimationsModuleName)}" is already imported. Please manually ` +
                     `set up browser animations.`));
+
+                return;
             }
 
             addModuleImportToRootModule(host, browserAnimationsModuleName,

--- a/packages/mosaic/schematics/ng-add/theming/theming.ts
+++ b/packages/mosaic/schematics/ng-add/theming/theming.ts
@@ -1,14 +1,15 @@
 import { normalize } from '@angular-devkit/core';
+import { WorkspaceProject, WorkspaceSchema } from '@angular-devkit/core/src/experimental/workspace';
 import { SchematicsException, Tree } from '@angular-devkit/schematics';
 import { getProjectFromWorkspace, getProjectStyleFile, getProjectTargetOptions } from '@angular/cdk/schematics';
 import { InsertChange } from '@schematics/angular/utility/change';
-import { WorkspaceProject, WorkspaceSchema } from '@angular-devkit/core/src/experimental/workspace';
+import { getWorkspace } from '@schematics/angular/utility/config';
 import chalk from 'chalk';
 import { join } from 'path';
 
-import { createCustomTheme } from './create-custom-theme';
 import { Schema } from '../schema';
-import { getWorkspace } from '@schematics/angular/utility/config';
+
+import { createCustomTheme } from './create-custom-theme';
 
 
 /** Path segment that can be found in paths that refer to a prebuilt theme. */


### PR DESCRIPTION
Fixing no-default-export, ordered-import, no-void-expression, no-magic-numbers errors.

console.warn is removed from return, because it returns void and there is no point in console.warn in return statement, also it fixes no-void-expression tslint error.

Default export is used for Schematics.