### PR TITLE
fix(modal): change mask click handler to mousedown handler (#UIM-169)

### DIFF
--- a/packages/mosaic/modal/modal.component.html
+++ b/packages/mosaic/modal/modal.component.html
@@ -12,7 +12,7 @@
          [style.zIndex]="mcZIndex"
     ></div>
     <div
-        (click)="onClickMask($event)"
+        (mousedown)="onClickMask($event)"
         class="mc-modal-wrap {{ mcWrapClassName }}"
         [style.zIndex]="mcZIndex"
         [style.display]="hidden ? 'none' : ''"


### PR DESCRIPTION
If a click was started over the modal body (`mousedown`) but was finished outside the body (`mouseup`), modal mask `click` handler was triggered. In order to fix it, the mask's handler type was changed from `click` to `mousedown`, so the click should be started **outside** the modal body to be handled by the mask.