### PR TITLE
fix(modal): setup modal close button focus styles (#UIM-200)

### DIFF
--- a/packages/mosaic/modal/_modal-theme.scss
+++ b/packages/mosaic/modal/_modal-theme.scss
@@ -37,8 +37,19 @@
             background-color: if($is-dark, transparent, mc-color($second, 60));
         }
 
-        .mc-modal-close-x:hover .mc-icon {
-            color: mix(map-get($foreground, text), mc-color($second), 90%);
+        .mc-modal-close {
+            border: $mc-button-border-size solid transparent;
+
+            &:hover .mc-button-overlay {
+                background-color: transparent;
+            }
+
+            &:hover,
+            &.cdk-keyboard-focused {
+                .mc-icon {
+                    color: mix(map-get($foreground, text), mc-color($second), 90%);
+                }
+            }
         }
     }
 

--- a/packages/mosaic/modal/modal.component.html
+++ b/packages/mosaic/modal/modal.component.html
@@ -28,10 +28,12 @@
              role="document"
         >
             <div class="mc-modal-content" cdkTrapFocus>
-                <button *ngIf="mcClosable" (click)="onClickCloseBtn()" class="mc-modal-close" aria-label="Close">
-                  <span class="mc-modal-close-x">
-                      <i mc-icon="mc-close-L_16" class="mc-icon mc-icon_light" color="second"></i>
-                  </span>
+                <button *ngIf="mcClosable"
+                        mc-button
+                        (click)="onClickCloseBtn()"
+                        class="mc-modal-close mc-button_transparent"
+                        aria-label="Close">
+                    <i mc-icon="mc-close-L_16" class="mc-icon mc-icon_light" color="second"></i>
                 </button>
                 <ng-container [ngSwitch]="true">
                     <ng-container *ngSwitchCase="isModalType('default')"

--- a/packages/mosaic/modal/modal.scss
+++ b/packages/mosaic/modal/modal.scss
@@ -62,22 +62,8 @@
     top: 0;
     right: 0;
 
-    padding: 0;
-
-    border: 0;
-    outline: 0;
-
-    cursor: pointer;
-    background: transparent;
-
-    .mc-modal-close-x {
-        display: block;
-        vertical-align: baseline;
-        text-align: center;
-        width: 56px;
-        height: 56px;
-        line-height: 56px;
-    }
+    width: 56px;
+    height: 56px;
 }
 
 .mc-modal-header {


### PR DESCRIPTION
The close button had no focus state because it wasn't a `mc-button` instance, therefore it wasn't being watched by the  `FocusMonitor`. I've transformed the button into `mc-button` with transparent background and overrode its wrapper `hover` styles (its background wasn't transparent).