### PR TITLE
fix(docs): fixing codes examples  white-space

### DIFF
--- a/packages/docs/src/styles/_markdown.scss
+++ b/packages/docs/src/styles/_markdown.scss
@@ -69,7 +69,7 @@
     }
 
     &__code {
-        white-space: pre-line;
+        white-space: pre-wrap;
     }
 
     &__pre>&__code {


### PR DESCRIPTION
white-space: pre-line was breaking code's indents, to save them and to keep text's translation to a new line it was switched to white-space: pre-wrap;

