### PR TITLE
fix(tags): logic for one more does not work in examples (#UIM-147)

### DIFF
--- a/packages/mosaic/tags/tag.scss
+++ b/packages/mosaic/tags/tag.scss
@@ -4,7 +4,7 @@
 $mc-tag-border-width: 1px;
 $mc-tag-border-radius: 4px;
 
-$mc-tag-height: 22px;
+$mc-tag-height: 24px;
 
 $mc-tag-icon-padding: 3px;
 
@@ -28,6 +28,8 @@ $mc-tag-icon-padding: 3px;
     cursor: default;
 
     outline: none;
+
+    box-sizing: border-box;
 
     &.mc-left-icon {
         padding-left: $mc-tag-icon-padding;

--- a/tools/webpack/default_index.ejs
+++ b/tools/webpack/default_index.ejs
@@ -5,6 +5,11 @@
         <title><%= htmlWebpackPlugin.options.title %></title>
         <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
         <link href="https://fonts.googleapis.com/css?family=Roboto+Mono:300,400,500" rel="stylesheet">
+
+        <script
+            crossorigin="anonymous"
+            src="https://polyfill.io/v3/polyfill.min.js?features=Element.prototype.remove%2CNodeList.prototype.forEach%2CElement.prototype.matches">
+        </script>
     </head>
     <body class="mc-app-background">
         <app></app>


### PR DESCRIPTION
не нашел в core-js полифила для remove...
поэтому пока добавил в index через script.

Еще заметил, что packages\mosaic-dev\index.html не используется, а вместо него используется tools\webpack\default_index.ejs - видимо index.html нужно удалить.