### PR TITLE
fix(docs): fixing routing for not githab platforms

### DIFF
--- a/packages/docs/src/app/components/main-layout/main-layout.component.ts
+++ b/packages/docs/src/app/components/main-layout/main-layout.component.ts
@@ -15,8 +15,19 @@ export class MainLayoutComponent {
 
     constructor(private router: Router,
                 private route: ActivatedRoute) {
+        const href = location.href;
 
-        this.setNextRoute();
+        if(href.match('github')) {
+            this.setNextRoute();
+        } else {
+            this.setDefaultRoute();
+        }
+    }
+
+    setDefaultRoute() {
+        if (location.pathname === '/') {
+            this.router.navigate(['button/overview'], this.extras);
+        }
     }
 
     setNextRoute() {
@@ -29,5 +40,4 @@ export class MainLayoutComponent {
         }
         localStorage.removeItem('PT_nextRoute');
     }
-
 }


### PR DESCRIPTION
setNextRoute function was developed to set routing for GitHub due to its 404.html problem. But it was breaking routing for other platforms, so setDefaultRoute function was written for them.

