### PR TITLE
feat(docs): setting version from INavbarProperty to custom property

### DIFF
--- a/packages/docs/src/app/components/navbar/navbar-property.ts
+++ b/packages/docs/src/app/components/navbar/navbar-property.ts
@@ -10,31 +10,26 @@ export interface INavbarProperty {
 
     // Applies in NavbarProperty.setValue for updating selected value
     updateSelected: boolean;
-
-    customActions?: (i: number) => void;
 }
 
 export class NavbarProperty {
     data: any[];
     currentValue: any;
     private readonly property: string;
-    customActions;
 
     constructor(navbarProperty: INavbarProperty) {
         this.data = navbarProperty.data;
         this.currentValue = this.data[0];
         this.property = navbarProperty.property;
-        if (navbarProperty.customActions) { this.customActions = navbarProperty.customActions; }
+
         this.init();
     }
 
     setValue(i: number) {
-        localStorage.setItem(this.property, `${i}`);
-        if (this.customActions) { this.customActions(i); }
         this.currentValue = this.data[i];
+        localStorage.setItem(this.property, `${i}`);
         if (this.updateTemplate) { this.updateTemplate(i); }
         if (this.updateSelected) { this.updateSelected(i); }
-
     }
 
     init() {

--- a/packages/docs/src/app/components/navbar/navbar-property.ts
+++ b/packages/docs/src/app/components/navbar/navbar-property.ts
@@ -10,26 +10,31 @@ export interface INavbarProperty {
 
     // Applies in NavbarProperty.setValue for updating selected value
     updateSelected: boolean;
+
+    customActions?: (i: number) => void;
 }
 
 export class NavbarProperty {
     data: any[];
     currentValue: any;
     private readonly property: string;
+    customActions;
 
     constructor(navbarProperty: INavbarProperty) {
         this.data = navbarProperty.data;
         this.currentValue = this.data[0];
         this.property = navbarProperty.property;
-
+        if (navbarProperty.customActions) { this.customActions = navbarProperty.customActions; }
         this.init();
     }
 
     setValue(i: number) {
-        this.currentValue = this.data[i];
         localStorage.setItem(this.property, `${i}`);
+        if (this.customActions) { this.customActions(i); }
+        this.currentValue = this.data[i];
         if (this.updateTemplate) { this.updateTemplate(i); }
         if (this.updateSelected) { this.updateSelected(i); }
+
     }
 
     init() {

--- a/packages/docs/src/app/components/navbar/navbar.component.ts
+++ b/packages/docs/src/app/components/navbar/navbar.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core';
 
 import { INavbarProperty, NavbarProperty } from './navbar-property';
+import { mosaicVersion } from '../../shared/version/version';
 
 
 @Component({
@@ -9,6 +10,8 @@ import { INavbarProperty, NavbarProperty } from './navbar-property';
     styleUrls: ['./navbar.scss']
 })
 export class NavbarComponent {
+    mosaicVersion = mosaicVersion;
+
     /*To add navbar property create new private property of type INavbarProperty
     and instantiate new NavbarProperty(property: INavbarProperty)*/
     versionSwitch: NavbarProperty;
@@ -74,25 +77,54 @@ export class NavbarComponent {
         updateSelected: true
     };
 
+    // To add new version to dropdown add new object to the end of data array,
+    // number of first (current) version is taken from package.json, rest should be specified
+    // run npm show @ptsecurity/mosaic versions --json to see all mosaic versions
     private versionProperty: INavbarProperty = {
         property: 'PT_version',
         data: [
             {
-                number: '8.0',
+                number: '8.1.0',
                 date: '9 октября',
-                selected: true
+                selected: false,
+                link: '//mosaic.ptsecurity.com'
+            },
+            {
+                number: '7.-.-',
+                date: '9 октября',
+                selected: false,
+                link: '//mosaic.ptsecurity.com'
             }
         ],
+
         updateTemplate: false,
-        updateSelected: true
+        updateSelected: false,
+        customActions: function(i) {
+            if (!location.origin.match(this.data[i].link) && !location.origin.match('localhost')) {
+                location.href = `${this.data[i].link}${location.pathname}${location.search}${location.hash}`;
+            }
+        }
     };
 
     constructor() {
+        this.setSelectedVersion();
+
         this.versionSwitch = new NavbarProperty(this.versionProperty);
         this.colorSwitch = new NavbarProperty(this.activeColorProperty);
         this.themeSwitch = new NavbarProperty(this.themeProperty);
         this.languageSwitch = new NavbarProperty(this.languageProperty);
     }
 
+    setSelectedVersion() {
+        /* Если мы находимся на последней версии - обновляем ее из package.json
+        Если нет - последние версии предыдущих мажоров должны быть указаны в массиве*/
+        if (location.origin.match(this.versionProperty.data[0].link)) {
+            this.versionProperty.data[0].number =  this.mosaicVersion;
+        }
+        // Определяем выбранную версию
+        this.versionProperty.data.forEach((version) => {
+            if(version.number == this.mosaicVersion) version.selected = true;
+        })
+    }
 
 }

--- a/packages/docs/src/app/components/navbar/navbar.component.ts
+++ b/packages/docs/src/app/components/navbar/navbar.component.ts
@@ -78,11 +78,9 @@ export class NavbarComponent {
     };
 
     // To add new version to dropdown add new object to the end of data array,
-    // number of first (current) version is taken from package.json, rest should be specified
+    // number of current version is taken from package.json, rest should be specified
     // run npm show @ptsecurity/mosaic versions --json to see all mosaic versions
-    private versionProperty: INavbarProperty = {
-        property: 'PT_version',
-        data: [
+    private versionData = [
             {
                 number: '8.1.0',
                 date: '9 октября',
@@ -90,41 +88,42 @@ export class NavbarComponent {
                 link: '//mosaic.ptsecurity.com'
             },
             {
-                number: '7.-.-',
+                number: '8.-.-',
                 date: '9 октября',
                 selected: false,
-                link: '//mosaic.ptsecurity.com'
+                link: '//v8.mosaic.ptsecurity.com'
             }
-        ],
-
-        updateTemplate: false,
-        updateSelected: false,
-        customActions: function(i) {
-            if (!location.origin.match(this.data[i].link) && !location.origin.match('localhost')) {
-                location.href = `${this.data[i].link}${location.pathname}${location.search}${location.hash}`;
-            }
-        }
-    };
+        ];
 
     constructor() {
         this.setSelectedVersion();
 
-        this.versionSwitch = new NavbarProperty(this.versionProperty);
         this.colorSwitch = new NavbarProperty(this.activeColorProperty);
         this.themeSwitch = new NavbarProperty(this.themeProperty);
         this.languageSwitch = new NavbarProperty(this.languageProperty);
     }
 
+    goToVersion(i: number) {
+        const link = this.versionData[i].link;
+        if (!location.origin.match(link)) {
+            location.href = `${link}${location.pathname}${location.search}${location.hash}`;
+        }
+        this.versionSwitch.setValue(i)
+    }
+
     setSelectedVersion() {
         /* Если мы находимся на последней версии - обновляем ее из package.json
         Если нет - последние версии предыдущих мажоров должны быть указаны в массиве*/
-        if (location.origin.match(this.versionProperty.data[0].link)) {
-            this.versionProperty.data[0].number =  this.mosaicVersion;
+        if (location.origin.match(this.versionData[0].link)) {
+            this.versionData[0].number =  this.mosaicVersion;
+            this.versionData[0].selected = true;
+        } else {
+            // Определяем выбранную версию
+            this.versionData.forEach((version) => {
+                if(version.number == this.mosaicVersion) version.selected = true;
+            })
         }
-        // Определяем выбранную версию
-        this.versionProperty.data.forEach((version) => {
-            if(version.number == this.mosaicVersion) version.selected = true;
-        })
+
     }
 
 }

--- a/packages/docs/src/app/components/navbar/navbar.component.ts
+++ b/packages/docs/src/app/components/navbar/navbar.component.ts
@@ -123,7 +123,5 @@ export class NavbarComponent {
                 if(version.number == this.mosaicVersion) version.selected = true;
             })
         }
-
     }
-
 }

--- a/packages/docs/src/app/components/navbar/navbar.component.ts
+++ b/packages/docs/src/app/components/navbar/navbar.component.ts
@@ -88,7 +88,7 @@ export class NavbarComponent {
                 link: '//mosaic.ptsecurity.com'
             },
             {
-                number: '8.-.-',
+                number: '8.0.0',
                 date: '9 октября',
                 selected: false,
                 link: '//v8.mosaic.ptsecurity.com'

--- a/packages/docs/src/app/components/navbar/navbar.template.html
+++ b/packages/docs/src/app/components/navbar/navbar.template.html
@@ -6,13 +6,13 @@
 
     <div class="docs-navbar-version">
         <button mc-button class="mc-button mc-button_transparent" [mcDropdownTriggerFor]="versionDropdown">
-            Версия {{versionSwitch.currentValue.number}}
+            Версия {{mosaicVersion}}
             <i mc-icon="mc-angle-down-L_16" class="docs-navbar-version__icon"></i>
         </button>
 
         <mc-dropdown #versionDropdown="mcDropdown" class="docs-navbar-version__dropdown">
-            <button mc-dropdown-item *ngFor="let version of versionSwitch.data; let i = index"
-                    [class.mc-selected]="version.selected" (click)="versionSwitch.setValue(i)"
+            <button mc-dropdown-item *ngFor="let version of versionData; let i = index"
+                    (click)="goToVersion(i)" [class.mc-selected]="version.selected"
                     [class.docs-navbar-version_bold]="version.number.length < 4">
                 <span class="docs-navbar-version__item">
                     <span class="docs-navbar-version__num">{{version.number}}</span>


### PR DESCRIPTION
Now the selected version is not saving in localStorage. Considering the fact, that version is defined by domain and package.json, the current and selected version is taken with the use of static data array and version from  package.json.