### PR TITLE
feat(docs): added examples for card and splitter (#UIM-290)

### DIFF
--- a/packages/mosaic-examples/mosaic/card/card-overview/card-overview-example.css
+++ b/packages/mosaic-examples/mosaic/card/card-overview/card-overview-example.css
@@ -1,0 +1,9 @@
+/** No CSS for this example */
+
+.mc-card {
+    margin-right: 1rem;
+    margin-bottom: 0.5rem;
+    padding: 0.3rem;
+    width: 180px;
+    display: block;
+}

--- a/packages/mosaic-examples/mosaic/card/card-overview/card-overview-example.html
+++ b/packages/mosaic-examples/mosaic/card/card-overview/card-overview-example.html
@@ -1,0 +1,22 @@
+<div class="layout-row layout-wrap block">
+    <mc-card class="mc-card_info">
+        <div class="mc-title">Info</div>
+        <div class="mc-body"><span class="mc-caption_mono">mc-card_info</span></div>
+    </mc-card>
+    <mc-card class="mc-card_warning">
+        <div class="mc-title">Warning</div>
+        <div class="mc-body"><span class="mc-caption_mono">mc-card_warning</span></div>
+    </mc-card>
+    <mc-card class="mc-card_success">
+        <div class="mc-title">Success</div>
+        <div class="mc-body"><span class="mc-caption_mono">mc-card_success</span></div>
+    </mc-card>
+    <mc-card class="mc-card_error">
+        <div class="mc-title">Error</div>
+        <div class="mc-body"><span class="mc-caption_mono">mc-card_error</span></div>
+    </mc-card>
+    <mc-card class="mc-card_white">
+        <div class="mc-title">White</div>
+        <div class="mc-body"><span class="mc-caption_mono">mc-card_white</span></div>
+    </mc-card>
+</div>

--- a/packages/mosaic-examples/mosaic/card/card-overview/card-overview-example.ts
+++ b/packages/mosaic-examples/mosaic/card/card-overview/card-overview-example.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+
+/**
+ * @title Basic Card
+ */
+@Component({
+    selector: 'card-overview-example',
+    templateUrl: 'card-overview-example.html',
+    styleUrls: ['card-overview-example.css']
+})
+export class CardOverviewExample {}

--- a/packages/mosaic-examples/mosaic/card/module.ts
+++ b/packages/mosaic-examples/mosaic/card/module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { McCardModule } from '@ptsecurity/mosaic/card';
+
+import { CardOverviewExample } from './card-overview/card-overview-example';
+
+
+const EXAMPLES = [
+    CardOverviewExample
+];
+
+@NgModule({
+    imports: [
+        FormsModule,
+        McCardModule
+    ],
+    declarations: EXAMPLES,
+    exports: EXAMPLES
+})
+export class CardExamplesModule {}

--- a/packages/mosaic-examples/mosaic/splitter/module.ts
+++ b/packages/mosaic-examples/mosaic/splitter/module.ts
@@ -1,0 +1,26 @@
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { McSplitterModule } from '@ptsecurity/mosaic/splitter';
+
+import { SplitterFixedExample } from './splitter-fixed/splitter-fixed-example';
+import { SplitterNestedExample } from './splitter-nested/splitter-nested-example';
+import { SplitterOverviewExample } from './splitter-overview/splitter-overview-example';
+import { SplitterVerticalExample } from './splitter-vertical/splitter-vertical-example';
+
+
+const EXAMPLES = [
+    SplitterOverviewExample,
+    SplitterFixedExample,
+    SplitterVerticalExample,
+    SplitterNestedExample
+];
+
+@NgModule({
+    imports: [
+        FormsModule,
+        McSplitterModule
+    ],
+    declarations: EXAMPLES,
+    exports: EXAMPLES
+})
+export class SplitterExamplesModule {}

--- a/packages/mosaic-examples/mosaic/splitter/splitter-fixed/splitter-fixed-example.css
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-fixed/splitter-fixed-example.css
@@ -1,5 +1,3 @@
-/** No CSS for this example */
-
 mc-splitter {
     display: flex;
     border: 1px solid black;

--- a/packages/mosaic-examples/mosaic/splitter/splitter-fixed/splitter-fixed-example.css
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-fixed/splitter-fixed-example.css
@@ -1,0 +1,20 @@
+/** No CSS for this example */
+
+mc-splitter {
+    display: flex;
+    border: 1px solid black;
+    height: 100px;
+    margin: 2px;
+}
+
+.mc-splitter-area_fixed-width {
+    min-width: 200px;
+}
+
+div[mc-splitter-area] {
+    background: #c5c0c0
+}
+
+.flex {
+    flex: 1;
+}

--- a/packages/mosaic-examples/mosaic/splitter/splitter-fixed/splitter-fixed-example.html
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-fixed/splitter-fixed-example.html
@@ -1,0 +1,5 @@
+<mc-splitter>
+    <div mc-splitter-area class="mc-splitter-area_fixed-width">first (with min-width)</div>
+    <div mc-splitter-area class="flex">second</div>
+    <div mc-splitter-area>third</div>
+</mc-splitter>

--- a/packages/mosaic-examples/mosaic/splitter/splitter-fixed/splitter-fixed-example.ts
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-fixed/splitter-fixed-example.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+
+/**
+ * @title Basic Splitter
+ */
+@Component({
+    selector: 'splitter-fixed-example',
+    templateUrl: 'splitter-fixed-example.html',
+    styleUrls: ['splitter-fixed-example.css']
+})
+export class SplitterFixedExample {}

--- a/packages/mosaic-examples/mosaic/splitter/splitter-nested/splitter-nested-example.css
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-nested/splitter-nested-example.css
@@ -1,5 +1,3 @@
-/** No CSS for this example */
-
 mc-splitter.with-border {
     border: 1px solid black;
     height: 300px;

--- a/packages/mosaic-examples/mosaic/splitter/splitter-nested/splitter-nested-example.css
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-nested/splitter-nested-example.css
@@ -1,0 +1,31 @@
+/** No CSS for this example */
+
+mc-splitter.with-border {
+    border: 1px solid black;
+    height: 300px;
+    margin: 2px;
+}
+
+mc-splitter.without-border {
+    height: 300px;
+}
+
+.with-border > div[mc-splitter-area] {
+    background: #c5c0c0
+}
+
+.without-border > div[mc-splitter-area] {
+    background: #b3b3b3;
+}
+
+.nested-splitter > div[mc-splitter-area] {
+    background: #9f9f9f;
+}
+
+.flex {
+    flex: 1;
+}
+
+.layout-column {
+    flex-direction: column;
+}

--- a/packages/mosaic-examples/mosaic/splitter/splitter-nested/splitter-nested-example.html
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-nested/splitter-nested-example.html
@@ -1,0 +1,17 @@
+<mc-splitter class="with-border">
+    <div mc-splitter-area>left</div>
+    <div mc-splitter-area class="flex">
+        <mc-splitter class="without-border flex" [direction]="'vertical'">
+            <div mc-splitter-area>top</div>
+            <div mc-splitter-area class="layout-column flex">
+                <mc-splitter class="flex nested-splitter">
+                    <div mc-splitter-area>center-left</div>
+                    <div mc-splitter-area class="flex">center</div>
+                    <div mc-splitter-area>center-right</div>
+                </mc-splitter>
+            </div>
+            <div mc-splitter-area>bottom</div>
+        </mc-splitter>
+    </div>
+    <div mc-splitter-area>right</div>
+</mc-splitter>

--- a/packages/mosaic-examples/mosaic/splitter/splitter-nested/splitter-nested-example.ts
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-nested/splitter-nested-example.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+
+/**
+ * @title Basic Splitter
+ */
+@Component({
+    selector: 'splitter-nested-example',
+    templateUrl: 'splitter-nested-example.html',
+    styleUrls: ['splitter-nested-example.css']
+})
+export class SplitterNestedExample {}

--- a/packages/mosaic-examples/mosaic/splitter/splitter-overview/splitter-overview-example.css
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-overview/splitter-overview-example.css
@@ -1,5 +1,3 @@
-/** No CSS for this example */
-
 mc-splitter {
     border: 1px solid black;
     height: 100px;

--- a/packages/mosaic-examples/mosaic/splitter/splitter-overview/splitter-overview-example.css
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-overview/splitter-overview-example.css
@@ -1,0 +1,15 @@
+/** No CSS for this example */
+
+mc-splitter {
+    border: 1px solid black;
+    height: 100px;
+    margin: 2px;
+}
+
+div[mc-splitter-area] {
+    background: #c5c0c0
+}
+
+.flex {
+    flex: 1;
+}

--- a/packages/mosaic-examples/mosaic/splitter/splitter-overview/splitter-overview-example.html
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-overview/splitter-overview-example.html
@@ -1,0 +1,5 @@
+<mc-splitter>
+    <div mc-splitter-area>first</div>
+    <div mc-splitter-area class="flex">second</div>
+    <div mc-splitter-area>third</div>
+</mc-splitter>

--- a/packages/mosaic-examples/mosaic/splitter/splitter-overview/splitter-overview-example.ts
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-overview/splitter-overview-example.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+
+/**
+ * @title Basic Splitter
+ */
+@Component({
+    selector: 'splitter-overview-example',
+    templateUrl: 'splitter-overview-example.html',
+    styleUrls: ['splitter-overview-example.css']
+})
+export class SplitterOverviewExample {}

--- a/packages/mosaic-examples/mosaic/splitter/splitter-vertical/splitter-vertical-example.css
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-vertical/splitter-vertical-example.css
@@ -1,5 +1,3 @@
-/** No CSS for this example */
-
 mc-splitter {
     display: flex;
     border: 1px solid black;

--- a/packages/mosaic-examples/mosaic/splitter/splitter-vertical/splitter-vertical-example.css
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-vertical/splitter-vertical-example.css
@@ -1,0 +1,20 @@
+/** No CSS for this example */
+
+mc-splitter {
+    display: flex;
+    border: 1px solid black;
+    height: 400px;
+    margin: 2px;
+}
+
+.mc-splitter-area_fixed-height {
+    min-height: 100px;
+}
+
+div[mc-splitter-area] {
+    background: #c5c0c0
+}
+
+.flex {
+    flex: 1;
+}

--- a/packages/mosaic-examples/mosaic/splitter/splitter-vertical/splitter-vertical-example.html
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-vertical/splitter-vertical-example.html
@@ -1,0 +1,5 @@
+<mc-splitter [direction]="'vertical'">
+    <div mc-splitter-area class="mc-splitter-area_fixed-height">first (with min-height)</div>
+    <div mc-splitter-area class="flex">second</div>
+    <div mc-splitter-area>third</div>
+</mc-splitter>

--- a/packages/mosaic-examples/mosaic/splitter/splitter-vertical/splitter-vertical-example.ts
+++ b/packages/mosaic-examples/mosaic/splitter/splitter-vertical/splitter-vertical-example.ts
@@ -1,0 +1,12 @@
+import { Component } from '@angular/core';
+
+
+/**
+ * @title Basic Splitter
+ */
+@Component({
+    selector: 'splitter-vertical-example',
+    templateUrl: 'splitter-vertical-example.html',
+    styleUrls: ['splitter-vertical-example.css']
+})
+export class SplitterVerticalExample {}

--- a/packages/mosaic/card/card.md
+++ b/packages/mosaic/card/card.md
@@ -1,28 +1,2 @@
-Mosaic cards are controls to display statuses/states/messages.
-
+#### With default parameters
 <!-- example(card-overview) -->
-
-### Properties
-There are four properties to interact with control:
-
-| Property           | Description                                                                 |
-|--------------------|-----------------------------------------------------------------------------|
-| `[status]`        |  Enum value Status(Info, Success, Warning, Error). Default value is Status.Info. It set color visual state of control.|
-| `[mode]`        |  There are two values 'color' and 'white'. This affects how the background is displayed. Default value is 'color' |
-| `[readonly]`        |  When set to 'true' control is switched to not interactive mode. It can't be focused or selected |
-| `[selected]`        |  It switch control to the selected visual state. |
-
-### Events
-There is one output event:
-
-| Event           | Description                                                                 |
-|--------------------|-----------------------------------------------------------------------------|
-| `(selectedChange)`        |  It happens when user click on control and and [readonly] set to 'false'|
-
-### Content
-It is possible to add additional content on the left and on the right side from main content
-by using attributes 'content-left' and 'content-right'.
-
-### Theming
-
-### Accessibility

--- a/packages/mosaic/splitter/splitter.md
+++ b/packages/mosaic/splitter/splitter.md
@@ -1,0 +1,11 @@
+#### With default parameters
+<!-- example(splitter-overview) -->
+
+### With fixed width of the first block
+<!-- example(splitter-fixed) -->
+
+### Vertical
+<!-- example(splitter-vertical) -->
+
+### Nested
+<!-- example(splitter-nested) -->


### PR DESCRIPTION
Классы flex и layout-column почему то в доках недоступны временно сделал их в самом примере.