### PR TITLE
feat(docs): adding modal examples

### DIFF
--- a/packages/docs/src/assets/stackblitz/mosaic-module.ts
+++ b/packages/docs/src/assets/stackblitz/mosaic-module.ts
@@ -13,6 +13,7 @@ import { McListModule } from '@ptsecurity/mosaic/list';
 import { McModalModule } from '@ptsecurity/mosaic/modal';
 import { McPopoverModule } from '@ptsecurity/mosaic/popover';
 import { McProgressBarModule } from '@ptsecurity/mosaic/progress-bar';
+import { McProgressSpinnerModule } from '@ptsecurity/mosaic/progress-spinner';
 import { McRadioModule } from '@ptsecurity/mosaic/radio';
 import { McSelectModule } from '@ptsecurity/mosaic/select';
 import { McTimepickerModule } from '@ptsecurity/mosaic/timepicker';
@@ -32,6 +33,7 @@ import { McTreeSelectModule } from '@ptsecurity/mosaic/tree-select';
         McInputModule,
         McRadioModule,
         McProgressBarModule,
+        McProgressSpinnerModule,
         McTimepickerModule,
         McSelectModule,
         McListModule,

--- a/packages/mosaic-examples/mosaic/modal/modal-component/modal-component-example.css
+++ b/packages/mosaic-examples/mosaic/modal/modal-component/modal-component-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/packages/mosaic-examples/mosaic/modal/modal-component/modal-component-example.html
+++ b/packages/mosaic-examples/mosaic/modal/modal-component/modal-component-example.html
@@ -1,0 +1,1 @@
+<button mc-button color="primary" (click)="openModal()">Open Modal</button>

--- a/packages/mosaic-examples/mosaic/modal/modal-component/modal-component-example.ts
+++ b/packages/mosaic-examples/mosaic/modal/modal-component/modal-component-example.ts
@@ -1,0 +1,69 @@
+// tslint:disable:no-console
+import { Component, Input } from '@angular/core';
+import { McModalRef, McModalService } from '@ptsecurity/mosaic/modal';
+
+
+/**
+ * @title Component Modal
+ */
+@Component({
+    selector: 'modal-component-example',
+    templateUrl: 'modal-component-example.html',
+    styleUrls: ['modal-component-example.css']
+})
+export class ModalComponentExample {
+    componentModal: McModalRef;
+
+    constructor(private modalService: McModalService) {}
+
+    openModal() {
+        this.componentModal = this.modalService.open({
+            mcComponent: McModalCustomComponent,
+            mcComponentParams: {
+                title: 'Title',
+                subtitle: 'Subtitle'
+            }
+        });
+
+        this.componentModal.afterOpen.subscribe(() => {
+            console.log('[afterOpen] emitted!');
+        });
+
+        this.componentModal.afterClose.subscribe((action: 'save' | 'close') => {
+            console.log(`[afterClose] emitted, chosen action: ${action}`);
+        });
+    }
+}
+
+@Component({
+    selector: 'mc-modal-full-custom-component',
+    template: `
+        <mc-modal-title>
+            Modal Title
+        </mc-modal-title>
+
+        <mc-modal-body>
+            <h2>{{ title }}</h2>
+            <h4>{{ subtitle }}</h4>
+            <p>
+                <span>Get Modal instance in component</span>
+                <button mc-button color="primary" (click)="destroyModal('close')">destroy modal in the component</button>
+            </p>
+        </mc-modal-body>
+
+        <div mc-modal-footer>
+            <button mc-button color="primary" (click)="destroyModal('save')">Save</button>
+            <button mc-button autofocus (click)="destroyModal('close')">Close</button>
+        </div>
+  `
+})
+export class McModalCustomComponent {
+    @Input() title: string;
+    @Input() subtitle: string;
+
+    constructor(private modal: McModalRef) { }
+
+    destroyModal(action: 'save' | 'close') {
+        this.modal.destroy(action);
+    }
+}

--- a/packages/mosaic-examples/mosaic/modal/modal-overview/modal-overview-example.css
+++ b/packages/mosaic-examples/mosaic/modal/modal-overview/modal-overview-example.css
@@ -1,1 +1,3 @@
-/** No CSS for this example */
+.modal-example-button {
+    margin-right: 18px;
+}

--- a/packages/mosaic-examples/mosaic/modal/modal-overview/modal-overview-example.html
+++ b/packages/mosaic-examples/mosaic/modal/modal-overview/modal-overview-example.html
@@ -1,1 +1,3 @@
-<button mc-button color="primary" (click)="openModal()">Open Modal</button>
+<button mc-button color="second" class="modal-example-button" (click)="showConfirmModal()">Open Confirm Modal</button>
+<button mc-button color="primary" class="modal-example-button" (click)="showSuccessModal()">Open Success Modal</button>
+<button mc-button color="error" class="modal-example-button" (click)="showDeleteModal()">Open Delete Modal</button>

--- a/packages/mosaic-examples/mosaic/modal/modal-overview/modal-overview-example.ts
+++ b/packages/mosaic-examples/mosaic/modal/modal-overview/modal-overview-example.ts
@@ -1,5 +1,6 @@
-import { Component, Input } from '@angular/core';
-import { McModalRef, McModalService } from '@ptsecurity/mosaic/modal';
+// tslint:disable:no-console
+import { Component } from '@angular/core';
+import { McModalService } from '@ptsecurity/mosaic/modal';
 
 
 /**
@@ -12,46 +13,35 @@ import { McModalRef, McModalService } from '@ptsecurity/mosaic/modal';
 })
 export class ModalOverviewExample {
 
-    constructor(
-        private modalService: McModalService
-    ) {}
+    constructor(private modalService: McModalService) {}
 
-    openModal() {
-        this.modalService.open({
-            mcComponent: McModalCustomComponent
+    showConfirmModal() {
+        this.modalService.confirm({
+            mcContent   : 'Save changes?',
+            mcOkText    : 'Save',
+            mcCancelText: 'Cancel',
+            mcOnOk      : () => console.log('OK')
         });
     }
-}
 
-@Component({
-    selector: 'mc-modal-full-custom-component',
-    template: `
-        <mc-modal-title>
-            Modal Title
-        </mc-modal-title>
+    showSuccessModal() {
+        this.modalService.success({
+            mcContent   : 'All changes are saved!',
+            mcOkText    : 'ОК',
+            mcCancelText: 'Cancel',
+            mcOnOk      : () => console.log('OK')
+        });
+    }
 
-        <mc-modal-body>
-            <h2>{{ title }}</h2>
-            <h4>{{ subtitle }}</h4>
-            <p>
-                <span>Get Modal instance in component</span>
-                <button mc-button color="primary" (click)="destroyModal()">destroy modal in the component</button>
-            </p>
-        </mc-modal-body>
-
-        <div mc-modal-footer>
-            <button mc-button color="primary" >Save</button>
-            <button mc-button autofocus>Close</button>
-        </div>
-  `
-})
-export class McModalCustomComponent {
-    @Input() title: string;
-    @Input() subtitle: string;
-
-    constructor(private modal: McModalRef) { }
-
-    destroyModal() {
-        this.modal.destroy({ data: 'this the result data' });
+    showDeleteModal() {
+        this.modalService.delete({
+            mcContent   : 'The tasks, policies and tags associated with the customer will be deleted too. Delete selected customer?',
+            mcOkType    : 'error',
+            mcOkText    : 'Delete',
+            mcCancelText: 'Cancel',
+            mcWidth     : '480px',
+            mcOnOk      : () => console.log('Delete'),
+            mcOnCancel  : () => console.log('Cancel')
+        });
     }
 }

--- a/packages/mosaic-examples/mosaic/modal/modal-template/modal-template-example.css
+++ b/packages/mosaic-examples/mosaic/modal/modal-template/modal-template-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/packages/mosaic-examples/mosaic/modal/modal-template/modal-template-example.html
+++ b/packages/mosaic-examples/mosaic/modal/modal-template/modal-template-example.html
@@ -1,0 +1,17 @@
+<button mc-button color="primary" class="modal-example-button" (click)="createTplModal(tplTitle, tplContent, tplFooter)">Delete</button>
+
+<ng-template #tplTitle>
+    <span>Title</span>
+</ng-template>
+
+<ng-template #tplContent>
+    <p>content...</p>
+    <p>content...</p>
+    <p>content...</p>
+    <p>content...</p>
+    <p>content...</p>
+</ng-template>
+
+<ng-template #tplFooter>
+    <button mc-button color="primary" (click)="destroyTplModal()">Save</button>
+</ng-template>

--- a/packages/mosaic-examples/mosaic/modal/modal-template/modal-template-example.ts
+++ b/packages/mosaic-examples/mosaic/modal/modal-template/modal-template-example.ts
@@ -1,0 +1,33 @@
+// tslint:disable:no-console
+import { Component, TemplateRef } from '@angular/core';
+import { McModalRef, McModalService } from '@ptsecurity/mosaic/modal';
+
+
+/**
+ * @title Template Modal
+ */
+@Component({
+    selector: 'modal-template-example',
+    templateUrl: 'modal-template-example.html',
+    styleUrls: ['modal-template-example.css']
+})
+export class ModalTemplateExample {
+    tplModal: McModalRef;
+
+    constructor(private modalService: McModalService) {}
+
+    createTplModal(tplTitle: TemplateRef<{}>, tplContent?: TemplateRef<{}>, tplFooter?: TemplateRef<{}>) {
+        this.tplModal = this.modalService.create({
+            mcTitle       : tplTitle,
+            mcContent     : tplContent,
+            mcFooter      : tplFooter,
+            mcClosable    : true,
+            mcOnOk        : () => console.log('Click ok')
+        });
+    }
+
+    destroyTplModal() {
+        this.tplModal.triggerOk();
+        this.tplModal.destroy();
+    }
+}

--- a/packages/mosaic-examples/mosaic/modal/module.ts
+++ b/packages/mosaic-examples/mosaic/modal/module.ts
@@ -4,12 +4,16 @@ import { McButtonModule } from '@ptsecurity/mosaic/button';
 import { McIconModule } from '@ptsecurity/mosaic/icon';
 import { McModalModule } from '@ptsecurity/mosaic/modal';
 
-import { McModalCustomComponent, ModalOverviewExample } from './modal-overview/modal-overview-example';
+import { ModalComponentExample, McModalCustomComponent } from './modal-component/modal-component-example';
+import { ModalOverviewExample } from './modal-overview/modal-overview-example';
+import { ModalTemplateExample } from './modal-template/modal-template-example';
 
 
 const EXAMPLES = [
     ModalOverviewExample,
-    McModalCustomComponent
+    ModalComponentExample,
+    McModalCustomComponent,
+    ModalTemplateExample
 ];
 
 @NgModule({

--- a/packages/mosaic/modal/modal.md
+++ b/packages/mosaic/modal/modal.md
@@ -1,5 +1,46 @@
+`McModalService` позволяет создавать и управлять модальными окнами.
+
+
+### Simple modal
+
+С помощью McModalService можно открывать модальные окна трех стандартных типов: `confirm`, `success` и `delete`.
 <!-- example(modal-overview) -->
 
+Также можно открыть модальное окно типа `custom` при помощи метода `open()` или создать модальное окно нужного типа методом `create()`.
+
+В методах `McModalService` можно настраивать заголовок, контент и футер модального окна
+при помощи свойств: `mcTitle`, `mcContent` и `mcFooter` (за исключением метода `confirm()` с предустановленным `mcFooter`).
+Все они могут принимают на вход строку или `TemplateRef`, а в `mcFooter` можно передавать массив параметров кнопок, например:
+```
+mcFooter: [{
+    label: 'button 1',
+    type: 'primary',
+    loading: () => isLoading,
+    onClick: (componentInstance: any) => {
+        componentInstance.title = 'title in inner component is changed';
+    }
+}, {
+    label: 'button 2',
+    type: 'primary',
+    autoFocus: true,
+    show: () => isShown,
+    onClick: (componentInstance: any) => {
+        componentInstance.title = 'title in inner component is changed';
+    }
+}]
+```
+
+### Template modal
+
 <!-- example(modal-template) -->
+
+### Modal with custom component
+
+Свойство mcComponent позволяет передавать в методы `McModalService` кастомный компонент. 
+Входные параметры с декоратором Input, определенные в копоненте модального окна, можно передать из методов `open()` и др.
+при помощи свойства `mcComponentParams`.
+
+McModalService позволяет подписаться на события при помощи параметров `mcAfterOpen`, `mcAfterClose`, `mcOnOk` и `mcOnCancel`,
+или способом, показанным ниже: 
 
 <!-- example(modal-component) -->

--- a/packages/mosaic/modal/modal.md
+++ b/packages/mosaic/modal/modal.md
@@ -1,1 +1,5 @@
 <!-- example(modal-overview) -->
+
+<!-- example(modal-template) -->
+
+<!-- example(modal-component) -->


### PR DESCRIPTION
Добавлены базовый пример модального окна, пример с шаблонами и пример с кастомным компонентом. В примере с кастомномным компонентом показана передача параметров Input и подписка на события afterOpen и afterClose с передачей параметров из кастомного компонента.
В модуль stackblitz добавлен McProgressSpinnerModule.

