### PR TITLE
fix(input): need notify if mc-cleaner used with input that have type=number (#UIM-332)

### DIFF
--- a/packages/mosaic/form-field/form-field-errors.ts
+++ b/packages/mosaic/form-field/form-field-errors.ts
@@ -1,3 +1,7 @@
 export function getMcFormFieldMissingControlError(): Error {
   return Error('mc-form-field must contain a McFormFieldControl.');
 }
+
+export function getMcFormFieldYouCanNotUseCleanerInNumberInputError(): Error {
+  return Error(`You can't use mc-cleaner with input that have type="number"`);
+}

--- a/packages/mosaic/form-field/form-field.ts
+++ b/packages/mosaic/form-field/form-field.ts
@@ -20,7 +20,10 @@ import { startWith } from 'rxjs/operators';
 
 import { McCleaner } from './cleaner';
 import { McFormFieldControl } from './form-field-control';
-import { getMcFormFieldMissingControlError } from './form-field-errors';
+import {
+    getMcFormFieldMissingControlError,
+    getMcFormFieldYouCanNotUseCleanerInNumberInputError
+} from './form-field-errors';
 import { McFormFieldNumberControl } from './form-field-number-control';
 import { McHint } from './hint';
 import { McPrefix } from './prefix';
@@ -81,11 +84,11 @@ export class McFormField extends McFormFieldMixinBase implements
     @ContentChild(McFormFieldControl, { static: false }) control: McFormFieldControl<any>;
     @ContentChild(McFormFieldNumberControl, { static: false }) numberControl: McFormFieldNumberControl<any>;
     @ContentChild(McStepper, { static: false }) stepper: McStepper;
+    @ContentChild(McCleaner, { static: false }) cleaner: McCleaner | null;
 
     @ContentChildren(McHint) hint: QueryList<McHint>;
     @ContentChildren(McSuffix) suffix: QueryList<McSuffix>;
     @ContentChildren(McPrefix) prefix: QueryList<McPrefix>;
-    @ContentChildren(McCleaner) cleaner: QueryList<McCleaner>;
 
     @ViewChild('connectionContainer', { static: true }) connectionContainerRef: ElementRef;
 
@@ -102,6 +105,11 @@ export class McFormField extends McFormFieldMixinBase implements
     }
 
     ngAfterContentInit() {
+        if (this.numberControl && this.hasCleaner) {
+            this.cleaner = null;
+            throw getMcFormFieldYouCanNotUseCleanerInNumberInputError();
+        }
+
         this.validateControlChild();
 
         if (this.control.controlType) {
@@ -225,7 +233,7 @@ export class McFormField extends McFormFieldMixinBase implements
     }
 
     get hasCleaner(): boolean {
-        return this.cleaner && this.cleaner.length > 0;
+        return !!this.cleaner;
     }
 
     get hasStepper(): boolean {

--- a/packages/mosaic/input/input.spec.ts
+++ b/packages/mosaic/input/input.spec.ts
@@ -1,5 +1,11 @@
 import { Component, Provider, Type } from '@angular/core';
-import { ComponentFixture, fakeAsync, TestBed, ComponentFixtureAutoDetect } from '@angular/core/testing';
+import {
+    ComponentFixture,
+    fakeAsync,
+    TestBed,
+    ComponentFixtureAutoDetect,
+    flush
+} from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { DOWN_ARROW, ESCAPE, UP_ARROW } from '@ptsecurity/cdk/keycodes';
@@ -9,7 +15,11 @@ import {
     dispatchFakeEvent,
     dispatchKeyboardEvent
 } from '@ptsecurity/cdk/testing';
-import { McFormField, McFormFieldModule } from '@ptsecurity/mosaic/form-field';
+import {
+    getMcFormFieldYouCanNotUseCleanerInNumberInputError,
+    McFormField,
+    McFormFieldModule
+} from '@ptsecurity/mosaic/form-field';
 import { McIconModule } from '@ptsecurity/mosaic/icon';
 
 import { McInput, McInputModule } from './index';
@@ -379,6 +389,18 @@ class McNumberInputMaxMinStepInput {
     step: number = 0.5;
     bigStep: number = 2;
 }
+
+@Component({
+    template: `
+        <mc-form-field>
+            <input mcInput [(ngModel)]="value" type="number">
+            <mc-cleaner></mc-cleaner>
+        </mc-form-field>
+    `
+})
+class McNumberInputWithCleaner {
+    value: number = 0;
+}
 // tslint:enable no-unnecessary-class
 
 // tslint:disable no-magic-numbers
@@ -400,11 +422,24 @@ describe('McNumberInput', () => {
         expect(icons.length).toBe(2);
     }));
 
-    it('should not have stepper initially', fakeAsync(() => {
+    it('should throw error with stepper', fakeAsync(() => {
+        const fixture = createComponent(McNumberInputWithCleaner);
+
+        expect(() => {
+            try {
+                fixture.detectChanges();
+                flush();
+            } catch {
+                flush();
+            }
+        }).toThrow(getMcFormFieldYouCanNotUseCleanerInNumberInputError());
+    }));
+
+    it('should throw an exception with mc-cleaner', fakeAsync(() => {
         const fixture = createComponent(McNumberInput);
         fixture.detectChanges();
 
-        const mcStepper = fixture.debugElement.query(By.css('mc-stepper'));
+        const mcStepper = fixture.debugElement.query(By.css('mc-cleaner'));
 
         expect(mcStepper).toBeNull();
     }));


### PR DESCRIPTION
Добавлено исключение на использование mc-cleaner в form-field совместно с numberInput.