### PR TITLE
fix(validation): validation does not work after build with optimization=true (#UIM-349)

### DIFF
--- a/packages/mosaic/core/validation/validation.ts
+++ b/packages/mosaic/core/validation/validation.ts
@@ -21,22 +21,6 @@ export const MC_VALIDATION = new InjectionToken<McValidationOptions>(
     );
 
 
-export enum ControlTypes {
-    FormControl = 'FormControlDirective',
-    FormControlName = 'FormControlName',
-    ModelControl = 'NgModel'
-}
-
-function getControlType(constructorName: string): ControlTypes {
-    if (constructorName === ControlTypes.FormControl || constructorName === ControlTypes.FormControlName) {
-        return ControlTypes.FormControl;
-    } else if (constructorName === ControlTypes.ModelControl) {
-        return  ControlTypes.ModelControl;
-    }
-
-    throw Error(`Unknown constructor name: ${constructorName}`);
-}
-
 function setValidState(control: AbstractControl, validator: ValidatorFn): void {
     if (!control) { return; }
 
@@ -49,10 +33,14 @@ function setValidState(control: AbstractControl, validator: ValidatorFn): void {
 /** This function do next:
  * - run validation on submitting parent form
  * - prevent validation in required validator if form doesn't submitted
- * - if control focused and untouched validation will be prevented
+ * - if control focused validation will be prevented
  */
-export function setMosaicValidation(validators: Validator[], parentForm: NgForm, ngControl: NgControl) {
+export function setMosaicValidation(component) {
+    const ngControl = component.ngControl;
+
     if (!ngControl) { return; }
+
+    const parentForm: NgForm = component.parentForm || component.parentFormGroup;
 
     if (parentForm) {
         parentForm.ngSubmit.subscribe(() => {
@@ -61,49 +49,56 @@ export function setMosaicValidation(validators: Validator[], parentForm: NgForm,
         });
     }
 
-    if (getControlType(ngControl.constructor.name) === ControlTypes.ModelControl) {
-        if (!validators) { return; }
+    if (component.ngModel) {
+        setMosaicValidationForModelControl(component, component.rawValidators, parentForm);
+    } else if (component.formControlName) {
+        setMosaicValidationForFormControl(component, parentForm, ngControl);
+    }
+}
+export function setMosaicValidationForModelControl(component, validators: Validator[], parentForm: NgForm) {
+    if (!validators) { return; }
 
-        validators.forEach((validator: Validator) => {
-            // tslint:disable-next-line: no-unbound-method
-            const originalValidate = validator.validate;
+    validators.forEach((validator: Validator) => {
+        // tslint:disable-next-line: no-unbound-method
+        const originalValidate = validator.validate;
 
-            if (validator instanceof RequiredValidator) {
-                // changed required validation logic
-                validator.validate = (control: AbstractControl): ValidationErrors | null => {
-                    if (parentForm && !parentForm.submitted) { return null; }
+        if (validator instanceof RequiredValidator) {
+            // changed required validation logic
+            validator.validate = (control: AbstractControl): ValidationErrors | null => {
+                if (parentForm && !parentForm.submitted) { return null; }
 
-                    return originalValidate.call(validator, control);
-                };
-            } else {
-                // changed all other validation logic
-                validator.validate = (control: AbstractControl): ValidationErrors | null => {
-                    if (this.focused) { return null; }
+                return originalValidate.call(validator, control);
+            };
+        } else {
+            // changed all other validation logic
+            validator.validate = (control: AbstractControl): ValidationErrors | null => {
+                if (component.focused) { return null; }
 
-                    return originalValidate.call(validator, control);
-                };
+                return originalValidate.call(validator, control);
+            };
+        }
+    });
+}
+
+export function setMosaicValidationForFormControl(component, parentForm: NgForm, ngControl: NgControl) {
+    const originalValidator = ngControl.control!.validator;
+
+    // changed required validation logic after initialization
+    if (ngControl.invalid && ngControl.errors!.required) {
+        setValidState(ngControl.control!, originalValidator!);
+    }
+
+    // check dynamic updates
+    ngControl.statusChanges!
+        .subscribe(() => {
+            // changed required validation logic
+            if (ngControl.invalid && !parentForm.submitted && ngControl.errors!.required) {
+                setValidState(ngControl.control!, originalValidator!);
+            }
+
+            // changed all other validation logic
+            if (ngControl.invalid && component.focused) {
+                setValidState(ngControl.control!, originalValidator!);
             }
         });
-    } else if (getControlType(ngControl.constructor.name) === ControlTypes.FormControl) {
-        const originalValidator = ngControl.control!.validator;
-
-        // changed required validation logic after initialization
-        if (ngControl.invalid && ngControl.errors!.required) {
-            setValidState(ngControl.control!, originalValidator!);
-        }
-
-        // check dynamic updates
-        ngControl.statusChanges!
-            .subscribe(() => {
-                // changed required validation logic
-                if (ngControl.invalid && !parentForm.submitted && ngControl.errors!.required) {
-                    setValidState(ngControl.control!, originalValidator!);
-                }
-
-                // changed all other validation logic
-                if (ngControl.invalid && this.focused) {
-                    setValidState(ngControl.control!, originalValidator!);
-                }
-            });
-    }
 }

--- a/packages/mosaic/input/input.ts
+++ b/packages/mosaic/input/input.ts
@@ -14,6 +14,7 @@ import {
     Self
 } from '@angular/core';
 import {
+    FormControlName,
     FormGroupDirective,
     NG_VALIDATORS,
     NgControl,
@@ -427,9 +428,11 @@ export class McInput extends McInputMixinBase implements McFormFieldControl<any>
     // tslint:disable-next-line: naming-convention
     constructor(
         protected elementRef: ElementRef,
-        @Optional() @Self() @Inject(NG_VALIDATORS) private rawValidators: Validator[],
+        @Optional() @Self() @Inject(NG_VALIDATORS) public rawValidators: Validator[],
         @Optional() @Inject(MC_VALIDATION) private mcValidation: McValidationOptions,
         @Optional() @Self() ngControl: NgControl,
+        @Optional() @Self() public ngModel: NgModel,
+        @Optional() @Self() public formControlName: FormControlName,
         @Optional() parentForm: NgForm,
         @Optional() parentFormGroup: FormGroupDirective,
         defaultErrorStateMatcher: ErrorStateMatcher,
@@ -451,7 +454,7 @@ export class McInput extends McInputMixinBase implements McFormFieldControl<any>
         if (!this.ngControl) { return; }
 
         if (this.mcValidation.useValidation) {
-            setMosaicValidation.call(this, this.rawValidators, this.parentForm || this.parentFormGroup, this.ngControl);
+            setMosaicValidation(this);
         }
     }
 

--- a/packages/mosaic/select/select.component.ts
+++ b/packages/mosaic/select/select.component.ts
@@ -39,10 +39,12 @@ import {
 } from '@angular/core';
 import {
     ControlValueAccessor,
+    FormControlName,
     FormGroupDirective,
     NG_VALIDATORS,
     NgControl,
     NgForm,
+    NgModel,
     Validator
 } from '@angular/forms';
 import { ActiveDescendantKeyManager } from '@ptsecurity/cdk/a11y';
@@ -498,12 +500,14 @@ export class McSelect extends McSelectMixinBase implements
         private readonly _renderer: Renderer2,
         defaultErrorStateMatcher: ErrorStateMatcher,
         elementRef: ElementRef,
-        @Optional() @Inject(NG_VALIDATORS) private rawValidators: Validator[],
+        @Optional() @Inject(NG_VALIDATORS) public rawValidators: Validator[],
         @Optional() private readonly _dir: Directionality,
         @Optional() parentForm: NgForm,
         @Optional() parentFormGroup: FormGroupDirective,
         @Optional() private readonly _parentFormField: McFormField,
         @Self() @Optional() ngControl: NgControl,
+        @Optional() @Self() public ngModel: NgModel,
+        @Optional() @Self() public formControlName: FormControlName,
         @Attribute('tabindex') tabIndex: string,
         @Inject(MC_SELECT_SCROLL_STRATEGY) private readonly _scrollStrategyFactory,
         @Optional() @Inject(MC_VALIDATION) private mcValidation: McValidationOptions
@@ -546,7 +550,7 @@ export class McSelect extends McSelectMixinBase implements
 
     ngAfterContentInit() {
         if (this.mcValidation.useValidation) {
-            setMosaicValidation.call(this, this.rawValidators, this.parentForm || this.parentFormGroup, this.ngControl);
+            setMosaicValidation(this);
         }
 
         this.initKeyManager();

--- a/packages/mosaic/tags/tag-list.component.ts
+++ b/packages/mosaic/tags/tag-list.component.ts
@@ -21,7 +21,16 @@ import {
     Self,
     ViewEncapsulation
 } from '@angular/core';
-import { ControlValueAccessor, FormGroupDirective, NG_VALIDATORS, NgControl, NgForm, Validator } from '@angular/forms';
+import {
+    ControlValueAccessor,
+    FormControlName,
+    FormGroupDirective,
+    NG_VALIDATORS,
+    NgControl,
+    NgForm,
+    NgModel,
+    Validator
+} from '@angular/forms';
 import { FocusKeyManager } from '@ptsecurity/cdk/a11y';
 import { BACKSPACE, END, HOME } from '@ptsecurity/cdk/keycodes';
 import {
@@ -339,12 +348,14 @@ export class McTagList extends McTagListMixinBase implements McFormFieldControl<
         protected elementRef: ElementRef<HTMLElement>,
         private changeDetectorRef: ChangeDetectorRef,
         defaultErrorStateMatcher: ErrorStateMatcher,
-        @Optional() @Inject(NG_VALIDATORS) private rawValidators: Validator[],
+        @Optional() @Inject(NG_VALIDATORS) public rawValidators: Validator[],
         @Optional() @Inject(MC_VALIDATION) private mcValidation: McValidationOptions,
         @Optional() private dir: Directionality,
         @Optional() parentForm: NgForm,
         @Optional() parentFormGroup: FormGroupDirective,
-        @Optional() @Self() ngControl: NgControl
+        @Optional() @Self() ngControl: NgControl,
+        @Optional() @Self() public ngModel: NgModel,
+        @Optional() @Self() public formControlName: FormControlName
     ) {
         super(defaultErrorStateMatcher, parentForm, parentFormGroup, ngControl);
 
@@ -355,7 +366,7 @@ export class McTagList extends McTagListMixinBase implements McFormFieldControl<
 
     ngAfterContentInit() {
         if (this.mcValidation.useValidation) {
-            setMosaicValidation.call(this, this.rawValidators, this.parentForm || this.parentFormGroup, this.ngControl);
+            setMosaicValidation(this);
         }
 
         this.keyManager = new FocusKeyManager<McTag>(this.tags)

--- a/packages/mosaic/tree-select/tree-select.component.ts
+++ b/packages/mosaic/tree-select/tree-select.component.ts
@@ -35,7 +35,16 @@ import {
     ViewChildren,
     ViewEncapsulation
 } from '@angular/core';
-import { ControlValueAccessor, FormGroupDirective, NG_VALIDATORS, NgControl, NgForm, Validator } from '@angular/forms';
+import {
+    ControlValueAccessor,
+    FormControlName,
+    FormGroupDirective,
+    NG_VALIDATORS,
+    NgControl,
+    NgForm,
+    NgModel,
+    Validator
+} from '@angular/forms';
 import {
     DOWN_ARROW,
     END,
@@ -409,21 +418,23 @@ export class McTreeSelect extends McTreeSelectMixinBase implements
     private tempValues: string | string[] | null;
 
     constructor(
-        public elementRef: ElementRef,
+        elementRef: ElementRef,
         readonly changeDetectorRef: ChangeDetectorRef,
         private readonly viewportRuler: ViewportRuler,
         private readonly ngZone: NgZone,
         private readonly renderer: Renderer2,
         defaultErrorStateMatcher: ErrorStateMatcher,
         @Attribute('tabindex') tabIndex: string,
-        @Optional() @Inject(NG_VALIDATORS) private rawValidators: Validator[],
-        @Optional() @Inject(MC_VALIDATION) private mcValidation: McValidationOptions,
         @Inject(MC_SELECT_SCROLL_STRATEGY) private readonly scrollStrategyFactory,
+        @Optional() @Inject(NG_VALIDATORS) public rawValidators: Validator[],
+        @Optional() @Inject(MC_VALIDATION) private mcValidation: McValidationOptions,
         @Optional() private readonly dir: Directionality,
         @Optional() parentForm: NgForm,
         @Optional() parentFormGroup: FormGroupDirective,
         @Optional() private readonly parentFormField: McFormField,
-        @Optional() @Self() ngControl: NgControl
+        @Optional() @Self() ngControl: NgControl,
+        @Optional() @Self() public ngModel: NgModel,
+        @Optional() @Self() public formControlName: FormControlName
     ) {
         super(elementRef, defaultErrorStateMatcher, parentForm, parentFormGroup, ngControl);
 
@@ -464,7 +475,7 @@ export class McTreeSelect extends McTreeSelectMixinBase implements
         if (!this.tree) { return; }
 
         if (this.mcValidation.useValidation) {
-            setMosaicValidation.call(this, this.rawValidators, this.parentForm || this.parentFormGroup, this.ngControl);
+            setMosaicValidation(this);
         }
 
         this.tree.resetFocusedItemOnBlur = false;


### PR DESCRIPTION
Оказалось, что при "optimization": true невозможно использовать такую конструкцию `ngControl.constructor.name`

И параметров по настройке этого через angular.json нет
https://github.com/angular/angular-cli/issues/14487
https://github.com/angular/angular-cli/issues/3861
https://github.com/angular/angular-cli/issues/14487

Решил переписать реализацию, мне она не сильно нравится из-за избыточности, но лучшего варианта Я не придумал.