### PR TITLE
fix(select, tree-select): "one more" label will hide if open select (#UIM-352)

### DIFF
--- a/packages/mosaic/select/select.component.ts
+++ b/packages/mosaic/select/select.component.ts
@@ -839,11 +839,10 @@ export class McSelect extends McSelectMixinBase implements
         let visibleItems: number = 0;
         const totalItemsWidth = this.getTotalItemsWidthInMatcher();
         let totalVisibleItemsWidth: number = 0;
-        const itemMargin: number = 4;
 
         this.tags.forEach((tag) => {
             if (tag.nativeElement.offsetTop < tag.nativeElement.offsetHeight) {
-                totalVisibleItemsWidth += tag.nativeElement.getBoundingClientRect().width + itemMargin;
+                totalVisibleItemsWidth += this.getItemWidth(tag.nativeElement);
                 visibleItems++;
             }
         });
@@ -906,14 +905,23 @@ export class McSelect extends McSelectMixinBase implements
         this._renderer.appendChild(this.trigger.nativeElement, triggerClone);
 
         let totalItemsWidth: number = 0;
-        const itemMargin: number = 4;
         triggerClone.querySelectorAll('mc-tag').forEach((item) => {
-            totalItemsWidth += item.getBoundingClientRect().width as number + itemMargin;
+            totalItemsWidth += this.getItemWidth(item);
         });
 
         triggerClone.remove();
 
         return totalItemsWidth;
+    }
+
+    private getItemWidth(element: HTMLElement): number {
+        const computedStyle = window.getComputedStyle(element);
+
+        const width: number = parseInt(computedStyle.width as string);
+        const marginLeft: number = parseInt(computedStyle.marginLeft as string);
+        const marginRight: number = parseInt(computedStyle.marginRight as string);
+
+        return width + marginLeft + marginRight;
     }
 
     /** Handles keyboard events while the select is closed. */

--- a/packages/mosaic/tree-select/tree-select.component.ts
+++ b/packages/mosaic/tree-select/tree-select.component.ts
@@ -787,11 +787,10 @@ export class McTreeSelect extends McTreeSelectMixinBase implements
         let visibleItems: number = 0;
         const totalItemsWidth = this.getTotalItemsWidthInMatcher();
         let totalVisibleItemsWidth: number = 0;
-        const itemMargin: number = 4;
 
         this.tags.forEach((tag) => {
             if (tag.nativeElement.offsetTop < tag.nativeElement.offsetHeight) {
-                totalVisibleItemsWidth += tag.nativeElement.getBoundingClientRect().width + itemMargin;
+                totalVisibleItemsWidth += this.getItemWidth(tag.nativeElement);
                 visibleItems++;
             }
         });
@@ -838,14 +837,23 @@ export class McTreeSelect extends McTreeSelectMixinBase implements
         this.renderer.appendChild(this.trigger.nativeElement, triggerClone);
 
         let totalItemsWidth: number = 0;
-        const itemMargin: number = 4;
         triggerClone.querySelectorAll('mc-tag').forEach((item) => {
-            totalItemsWidth += item.getBoundingClientRect().width as number + itemMargin;
+            totalItemsWidth += this.getItemWidth(item);
         });
 
         triggerClone.remove();
 
         return totalItemsWidth;
+    }
+
+    private getItemWidth(element: HTMLElement): number {
+        const computedStyle = window.getComputedStyle(element);
+
+        const width: number = parseInt(computedStyle.width as string);
+        const marginLeft: number = parseInt(computedStyle.marginLeft as string);
+        const marginRight: number = parseInt(computedStyle.marginRight as string);
+
+        return width + marginLeft + marginRight;
     }
 
     private handleClosedKeydown(event: KeyboardEvent) {


### PR DESCRIPTION
Добавил расчет размеров элемента с учетом margins, до этого был хардкод 4px.

Код в select и tree-select дублируется, но это уберем, когда будем рефакторить, там матчер можно вынести в компонент и всю эту логику убрать в него...