### PR TITLE
fix(modal): for apply changes need run changeDetection (#UIM-348)

### DIFF
--- a/packages/mosaic/modal/modal.component.ts
+++ b/packages/mosaic/modal/modal.component.ts
@@ -41,7 +41,6 @@ type AnimationState = 'enter' | 'leave' | null;
     selector: 'mc-modal',
     templateUrl: './modal.component.html',
     styleUrls: ['./modal.css'],
-    changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     host: {
         '(keydown)': 'onKeyDown($event)'
@@ -120,7 +119,7 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
     @Input() @Output() mcOnCancel: EventEmitter<T> | OnClickCallback<T> = new EventEmitter<T>();
 
     @ViewChild('modalContainer', { static: true }) modalContainer: ElementRef;
-    @ViewChild('bodyContainer', { read: ViewContainerRef, static: false}) bodyContainer: ViewContainerRef;
+    @ViewChild('bodyContainer', { read: ViewContainerRef, static: false }) bodyContainer: ViewContainerRef;
     // Only aim to focus the ok button that needs to be auto focused
     @ViewChildren('autoFocusedButton', { read: ElementRef }) autoFocusedButtons: QueryList<ElementRef>;
 
@@ -168,7 +167,6 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
         private changeDetector: ChangeDetectorRef,
         @Inject(DOCUMENT) private document: any
     ) {
-
         super();
     }
 


### PR DESCRIPTION
Поковырял то что есть и пришел к выводу, что пока проще всего отключить ChangeDetectionStrategy.OnPush в McModalComponent.

@Fost посмотри, возможно Я не совсем понял реализацию и есть другой вариант решения этой проблемы.