### PR TITLE
chore(common): cdk tslint fix

### DIFF
--- a/packages/cdk/a11y/key-manager/focus-key-manager.ts
+++ b/packages/cdk/a11y/key-manager/focus-key-manager.ts
@@ -14,14 +14,14 @@ export interface IFocusableOption extends ListKeyManagerOption {
 }
 
 export class FocusKeyManager<T> extends ListKeyManager<IFocusableOption & T> {
-    private _origin: FocusOrigin = 'program';
+    private origin: FocusOrigin = 'program';
 
     /**
      * Sets the focus origin that will be passed in to the items for any subsequent `focus` calls.
      * @param origin Focus origin to be used when focusing items.
      */
     setFocusOrigin(origin: FocusOrigin): this {
-        this._origin = origin;
+        this.origin = origin;
 
         return this;
     }
@@ -36,7 +36,7 @@ export class FocusKeyManager<T> extends ListKeyManager<IFocusableOption & T> {
         super.setActiveItem(item);
 
         if (this.activeItem) {
-            this.activeItem.focus(this._origin);
+            this.activeItem.focus(this.origin);
         }
     }
 }

--- a/packages/cdk/a11y/key-manager/list-key-manager.ts
+++ b/packages/cdk/a11y/key-manager/list-key-manager.ts
@@ -40,18 +40,31 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
     change = new Subject<number>();
 
     previousActiveItemIndex = -1;
-    private _activeItemIndex = -1;
-    private _activeItem: T;
-    private _wrap: boolean = false;
-    private _letterKeyStream = new Subject<string>();
-    private _typeaheadSubscription = Subscription.EMPTY;
-    private _vertical = true;
-    private _horizontal: 'ltr' | 'rtl' | null;
 
-    private _scrollSize: number = 0;
+    // Index of the currently active item.
+    get activeItemIndex(): number {
+        return this._activeItemIndex;
+    }
+
+    private _activeItemIndex = -1;
+
+    // The active item.
+    get activeItem(): T | null {
+        return this._activeItem;
+    }
+
+    private _activeItem: T;
+
+    private wrap: boolean = false;
+    private letterKeyStream = new Subject<string>();
+    private typeaheadSubscription = Subscription.EMPTY;
+    private vertical = true;
+    private horizontal: 'ltr' | 'rtl' | null;
+
+    private scrollSize: number = 0;
 
     // Buffer for the letters that the user has pressed when the typeahead option is turned on.
-    private _pressedLetters: string[] = [];
+    private pressedLetters: string[] = [];
 
     constructor(private _items: QueryList<T>) {
         if (_items instanceof QueryList) {
@@ -71,7 +84,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
     }
 
     withScrollSize(scrollSize: number): this {
-        this._scrollSize = scrollSize;
+        this.scrollSize = scrollSize;
 
         return this;
     }
@@ -82,7 +95,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
      */
 
     withWrap(): this {
-        this._wrap = true;
+        this.wrap = true;
 
         return this;
     }
@@ -92,7 +105,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
      * @param enabled Whether vertical selection should be enabled.
      */
     withVerticalOrientation(enabled: boolean = true): this {
-        this._vertical = enabled;
+        this.vertical = enabled;
 
         return this;
     }
@@ -103,7 +116,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
      * @param direction Direction in which the selection can be moved.
      */
     withHorizontalOrientation(direction: 'ltr' | 'rtl' | null): this {
-        this._horizontal = direction;
+        this.horizontal = direction;
 
         return this;
     }
@@ -118,18 +131,18 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
             throw Error('ListKeyManager items in typeahead mode must implement the `getLabel` method.');
         }
 
-        this._typeaheadSubscription.unsubscribe();
+        this.typeaheadSubscription.unsubscribe();
 
         // Debounce the presses of non-navigational keys, collect the ones that correspond to letters and convert those
         // letters back into a string. Afterwards find the first item that starts with that string and select it.
-        this._typeaheadSubscription = this._letterKeyStream.pipe(
-            tap((keyCode) => this._pressedLetters.push(keyCode)),
+        this.typeaheadSubscription = this.letterKeyStream.pipe(
+            tap((keyCode) => this.pressedLetters.push(keyCode)),
             debounceTime(debounceInterval),
-            filter(() => this._pressedLetters.length > 0),
-            map(() => this._pressedLetters.join(''))
+            filter(() => this.pressedLetters.length > 0),
+            map(() => this.pressedLetters.join(''))
         ).subscribe((inputString) => {
             if (searchLetterIndex === -1) {
-                this._pressedLetters = [];
+                this.pressedLetters = [];
 
                 return;
             }
@@ -151,7 +164,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
                 }
             }
 
-            this._pressedLetters = [];
+            this.pressedLetters = [];
         });
 
         return this;
@@ -182,6 +195,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
      * @param event Keyboard event to be used for determining which element should be active.
      */
     onKeydown(event: KeyboardEvent): void {
+        // tslint:disable-next-line: deprecation
         const keyCode = event.keyCode;
 
         switch (keyCode) {
@@ -191,7 +205,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
                 return;
 
             case DOWN_ARROW:
-                if (this._vertical) {
+                if (this.vertical) {
                     this.setNextItemActive();
                     break;
                 } else {
@@ -199,7 +213,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
                 }
 
             case UP_ARROW:
-                if (this._vertical) {
+                if (this.vertical) {
                     this.setPreviousItemActive();
                     break;
                 } else {
@@ -207,10 +221,10 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
                 }
 
             case RIGHT_ARROW:
-                if (this._horizontal === 'ltr') {
+                if (this.horizontal === 'ltr') {
                     this.setNextItemActive();
                     break;
-                } else if (this._horizontal === 'rtl') {
+                } else if (this.horizontal === 'rtl') {
                     this.setPreviousItemActive();
                     break;
                 } else {
@@ -218,10 +232,10 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
                 }
 
             case LEFT_ARROW:
-                if (this._horizontal === 'ltr') {
+                if (this.horizontal === 'ltr') {
                     this.setPreviousItemActive();
                     break;
-                } else if (this._horizontal === 'rtl') {
+                } else if (this.horizontal === 'rtl') {
                     this.setNextItemActive();
                     break;
                 } else {
@@ -232,9 +246,9 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
                 // Attempt to use the `event.key` which also maps it to the user's keyboard language,
                 // otherwise fall back to resolving alphanumeric characters via the keyCode.
                 if (event.key && event.key.length === 1) {
-                    this._letterKeyStream.next(event.key.toLocaleUpperCase());
+                    this.letterKeyStream.next(event.key.toLocaleUpperCase());
                 } else if ((keyCode >= A && keyCode <= Z) || (keyCode >= ZERO && keyCode <= NINE)) {
-                    this._letterKeyStream.next(String.fromCharCode(keyCode));
+                    this.letterKeyStream.next(String.fromCharCode(keyCode));
                 }
 
                 // Note that we return here, in order to avoid preventing
@@ -242,58 +256,48 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
                 return;
         }
 
-        this._pressedLetters = [];
+        this.pressedLetters = [];
         event.preventDefault();
-    }
-
-    // Index of the currently active item.
-    get activeItemIndex(): number {
-        return this._activeItemIndex;
-    }
-
-    // The active item.
-    get activeItem(): T | null {
-        return this._activeItem;
     }
 
     // Sets the active item to the first enabled item in the list.
     setFirstItemActive(): void {
-        this._setActiveItemByIndex(0, 1);
+        this.setActiveItemByIndex(0, 1);
     }
 
     // Sets the active item to the last enabled item in the list.
     setLastItemActive(): void {
-        this._setActiveItemByIndex(this._items.length - 1, -1);
+        this.setActiveItemByIndex(this._items.length - 1, -1);
     }
 
     // Sets the active item to the next enabled item in the list.
     setNextItemActive(): void {
-        this._activeItemIndex < 0 ? this.setFirstItemActive() : this._setActiveItemByDelta(1);
+        this._activeItemIndex < 0 ? this.setFirstItemActive() : this.setActiveItemByDelta(1);
     }
 
     // Sets the active item to a previous enabled item in the list.
     setPreviousItemActive(): void {
-        this._activeItemIndex < 0 && this._wrap ? this.setLastItemActive()
-            : this._setActiveItemByDelta(-1);
+        this._activeItemIndex < 0 && this.wrap ? this.setLastItemActive()
+            : this.setActiveItemByDelta(-1);
     }
 
-    setNextPageItemActive(delta: number = this._scrollSize): void {
+    setNextPageItemActive(delta: number = this.scrollSize): void {
         const nextItemIndex = this._activeItemIndex + delta;
 
         if (nextItemIndex >= this._items.length) {
             this.setLastItemActive();
         } else {
-            this._setActiveItemByDelta(delta);
+            this.setActiveItemByDelta(delta);
         }
     }
 
-    setPreviousPageItemActive(delta: number = this._scrollSize): void {
+    setPreviousPageItemActive(delta: number = this.scrollSize): void {
         const nextItemIndex = this._activeItemIndex - delta;
 
         if (nextItemIndex <= 0) {
             this.setFirstItemActive();
         } else {
-            this._setActiveItemByDelta(-delta);
+            this.setActiveItemByDelta(-delta);
         }
     }
 
@@ -307,6 +311,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
      * Allows setting the active item without any other effects.
      * @param item Item to be set as active or index Index of the item to be set as active..
      */
+    // tslint:disable-next-line:unified-signatures
     updateActiveItem(item: number | T): void;
 
     updateActiveItem(item: any): void {
@@ -321,15 +326,15 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
      * Predicate function that can be used to check whether an item should be skipped
      * by the key manager. By default, disabled items are skipped.
      */
-    private _skipPredicateFn = (item: T) => item.disabled;
+    private skipPredicateFn = (item: T) => item.disabled;
 
     /**
      * This method sets the active item, given a list of items and the delta between the
      * currently active item and the new active item. It will calculate differently
      * depending on whether wrap mode is turned on.
      */
-    private _setActiveItemByDelta(delta: number): void {
-        this._wrap ? this._setActiveInWrapMode(delta) : this._setActiveInDefaultMode(delta);
+    private setActiveItemByDelta(delta: number): void {
+        this.wrap ? this.setActiveInWrapMode(delta) : this.setActiveInDefaultMode(delta);
     }
 
     /**
@@ -337,14 +342,14 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
      * down the list until it finds an item that is not disabled, and it will wrap if it
      * encounters either end of the list.
      */
-    private _setActiveInWrapMode(delta: number): void {
-        const items = this._getItemsArray();
+    private setActiveInWrapMode(delta: number): void {
+        const items = this.getItemsArray();
 
         for (let i = 1; i <= items.length; i++) {
             const index = (this._activeItemIndex + (delta * i) + items.length) % items.length;
             const item = items[index];
 
-            if (!this._skipPredicateFn(item)) {
+            if (!this.skipPredicateFn(item)) {
                 this.setActiveItem(index);
 
                 return;
@@ -357,8 +362,8 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
      * continue to move down the list until it finds an item that is not disabled. If
      * it encounters either end of the list, it will stop and not wrap.
      */
-    private _setActiveInDefaultMode(delta: number): void {
-        this._setActiveItemByIndex(this._activeItemIndex + delta, delta);
+    private setActiveInDefaultMode(delta: number): void {
+        this.setActiveItemByIndex(this._activeItemIndex + delta, delta);
     }
 
     /**
@@ -366,13 +371,13 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
      * item is disabled, it will move in the fallbackDelta direction until it either
      * finds an enabled item or encounters the end of the list.
      */
-    private _setActiveItemByIndex(index: number, fallbackDelta: number): void {
-        const items = this._getItemsArray();
+    private setActiveItemByIndex(index: number, fallbackDelta: number): void {
+        const items = this.getItemsArray();
 
         if (!items[index]) { return; }
 
         let curIndex = index;
-        while (this._skipPredicateFn(items[curIndex])) {
+        while (this.skipPredicateFn(items[curIndex])) {
             curIndex += fallbackDelta;
 
             if (!items[curIndex]) { return; }
@@ -382,7 +387,7 @@ export class ListKeyManager<T extends ListKeyManagerOption> {
     }
 
     /** Returns the items as an array. */
-    private _getItemsArray(): T[] {
+    private getItemsArray(): T[] {
         return this._items instanceof QueryList ? this._items.toArray() : this._items;
     }
 }

--- a/packages/cdk/schematics/ng-add/index.spec.ts
+++ b/packages/cdk/schematics/ng-add/index.spec.ts
@@ -1,4 +1,3 @@
-import { Tree } from '@angular-devkit/schematics';
 import { SchematicTestRunner } from '@angular-devkit/schematics/testing';
 import { getFileContent } from '@schematics/angular/utility/test';
 
@@ -7,15 +6,15 @@ import { createTestApp } from '../testing';
 
 describe('CDK ng-add', () => {
   let runner: SchematicTestRunner;
-  let appTree: Tree;
+  let appTree;
 
   beforeEach(() => {
     runner = new SchematicTestRunner('schematics', require.resolve('../collection.json'));
     appTree = createTestApp(runner);
   });
 
-  it('should update the package.json', () => {
-    const tree = runner.runSchematic('ng-add', {}, appTree);
+  it('should update the package.json', async () => {
+    const tree = await runner.runSchematicAsync('ng-add', {}, appTree).toPromise();
     const packageJson = JSON.parse(getFileContent(tree, '/package.json'));
     const dependencies = packageJson.dependencies;
 

--- a/packages/cdk/schematics/ng-add/index.ts
+++ b/packages/cdk/schematics/ng-add/index.ts
@@ -10,6 +10,7 @@ export const cdkVersion = loadPackageVersionGracefully('@ptsecurity/cdk');
  * Schematic factory entry-point for the `ng-add` schematic. The ng-add schematic will be
  * automatically executed if developers run `ng add @ptsecurity/cdk`.
  */
+// tslint:disable-next-line:no-default-export
 export default function(): Rule {
     return (host: Tree) => {
         // By default, the CLI already installs the package that has been installed through `ng add`.
@@ -21,6 +22,7 @@ export default function(): Rule {
 /** Loads the full version from the given Angular package gracefully. */
 function loadPackageVersionGracefully(packageName: string): string | null {
     try {
+        // tslint:disable-next-line:non-literal-require
         return require(`${packageName}/package.json`).version;
     } catch {
         return null;

--- a/packages/cdk/schematics/testing/test-app.ts
+++ b/packages/cdk/schematics/testing/test-app.ts
@@ -5,11 +5,11 @@ import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/te
 /** Create a base app used for testing. */
 export async function createTestApp(runner: SchematicTestRunner, appOptions = {}, tree?: Tree):
     Promise<UnitTestTree> {
-    const workspaceTree = runner.runExternalSchematic('@schematics/angular', 'workspace', {
+    const workspaceTree = await runner.runExternalSchematicAsync('@schematics/angular', 'workspace', {
         name: 'workspace',
         version: '8.0.0',
         newProjectRoot: 'projects'
-    }, tree);
+    }, tree).toPromise();
 
     return runner.runExternalSchematicAsync('@schematics/angular', 'application',
         {name: 'mosaic', ...appOptions}, workspaceTree).toPromise();

--- a/packages/cdk/schematics/utils/build-component.ts
+++ b/packages/cdk/schematics/utils/build-component.ts
@@ -193,14 +193,14 @@ export function buildComponent(options: ComponentOptions,
 
         options.module = findModuleFromOptions(host, options);
 
-        const parsedPath = parseName(options.path!, options.name);
+        const parsedPath = parseName(options.path, options.name);
 
         options.name = parsedPath.name;
         options.path = parsedPath.path;
         options.selector = options.selector || buildSelector(options, project.prefix);
 
         validateName(options.name);
-        validateHtmlSelector(options.selector!);
+        validateHtmlSelector(options.selector);
 
         // In case the specified style extension is not part of the supported CSS supersets,
         // we generate the stylesheets with the "css" extension. This ensures that we don't
@@ -223,14 +223,14 @@ export function buildComponent(options: ComponentOptions,
         // The resolved contents can be used inside EJS templates.
         const resolvedFiles = {};
 
-        for (const key in additionalFiles) {
+        Object.keys(additionalFiles).forEach((key) => {
             if (additionalFiles[key]) {
                 const fileContent = readFileSync(join(schematicFilesPath, additionalFiles[key]), 'utf-8');
 
                 // Interpolate the additional files with the base EJS template context.
                 resolvedFiles[key] = interpolateTemplate(fileContent)(baseTemplateContext);
             }
-        }
+        });
 
         const templateSource = apply(url(schematicFilesUrl), [
             options.skipTests ? filter((path) => !path.endsWith('.spec.ts')) : noop(),

--- a/packages/cdk/schematics/utils/build-component.ts
+++ b/packages/cdk/schematics/utils/build-component.ts
@@ -223,14 +223,14 @@ export function buildComponent(options: ComponentOptions,
         // The resolved contents can be used inside EJS templates.
         const resolvedFiles = {};
 
-        Object.keys(additionalFiles).forEach((key) => {
+        for (const key in additionalFiles) {
             if (additionalFiles[key]) {
                 const fileContent = readFileSync(join(schematicFilesPath, additionalFiles[key]), 'utf-8');
 
                 // Interpolate the additional files with the base EJS template context.
                 resolvedFiles[key] = interpolateTemplate(fileContent)(baseTemplateContext);
             }
-        });
+        }
 
         const templateSource = apply(url(schematicFilesUrl), [
             options.skipTests ? filter((path) => !path.endsWith('.spec.ts')) : noop(),

--- a/packages/cdk/schematics/utils/parse5-element.ts
+++ b/packages/cdk/schematics/utils/parse5-element.ts
@@ -4,7 +4,7 @@ import { DefaultTreeElement } from 'parse5';
 
 /** Determines the indentation of child elements for the given Parse5 element. */
 export function getChildElementIndentation(element: DefaultTreeElement) {
-    const spaceAmount = 2;
+    const spaceAmount: number = 2;
     const childElement = element.childNodes
         .find((node) => node.tagName) as DefaultTreeElement | null;
 
@@ -19,7 +19,7 @@ export function getChildElementIndentation(element: DefaultTreeElement) {
         childElement.sourceCodeLocation.startCol :
         // In case there is no child element, we just assume that child elements should be indented
         // by two spaces.
-        element.sourceCodeLocation.startCol + spaceAmount;
+        <number> element.sourceCodeLocation.startCol + spaceAmount;
 
     // Since Parse5 does not set the `startCol` properties as zero-based, we need to subtract
     // one column in order to have a proper zero-based offset for the indentation.

--- a/packages/cdk/schematics/utils/version-agnostic-typescript.ts
+++ b/packages/cdk/schematics/utils/version-agnostic-typescript.ts
@@ -20,9 +20,11 @@ import typescript = require('typescript');
 let ts: typeof typescript;
 
 try {
+    // tslint:disable-next-line:no-var-requires
   ts = require('@schematics/angular/node_modules/typescript');
 } catch {
   try {
+      // tslint:disable-next-line:no-var-requires
     ts = require('typescript');
   } catch {
     throw new SchematicsException('Error: Could not find a TypeScript version for the ' +

--- a/packages/cdk/testing/type-in-element.ts
+++ b/packages/cdk/testing/type-in-element.ts
@@ -1,5 +1,6 @@
 import { dispatchFakeEvent } from './dispatch-events';
 
+
 /**
  * Focuses an input, sets its value and dispatches
  * the `input` event, simulating the user typing.

--- a/packages/cdk/tree/padding.ts
+++ b/packages/cdk/tree/padding.ts
@@ -67,13 +67,14 @@ export class CdkTreeNodePadding<T> implements OnDestroy {
 
     /** The padding indent value for the tree node. Returns a string with px numbers if not null. */
     protected paddingIndent(): string | null {
+        const basicPadding = 12;
         const nodeLevel = (this.treeNode.data && this.tree.treeControl.getLevel)
             ? this.tree.treeControl.getLevel(this.treeNode.data)
             : null;
 
         const level = this._level || nodeLevel;
 
-        return level ? `${(level * this._indent) + 12}px` : '12px';
+        return `${level ? (level * this._indent) + basicPadding : basicPadding}px`;
     }
 
     protected setPadding() {

--- a/packages/cdk/tree/tree._spec.ts
+++ b/packages/cdk/tree/tree._spec.ts
@@ -14,6 +14,7 @@ import { CdkTree } from './tree';
 import { getTreeControlFunctionsMissingError } from './tree-errors';
 
 
+// tslint:disable-next-line:max-func-body-length
 xdescribe('CdkTree', () => {
     /** Represents an indent for expectNestedTreeToMatch */
     const _ = {};
@@ -913,6 +914,7 @@ class FakeDataSource extends DataSource<TestData> {
         return combineLatest<TestData[]>(streams)
             .pipe(map(([data]) => {
                 this.treeControl.dataNodes = data;
+
                 return data;
             }));
     }
@@ -959,6 +961,7 @@ function expectFlatTreeToMatch(treeElement: Element, expectedPaddingIndent: numb
     function checkNode(node: Element, expectedNode: any[]) {
         const actualTextContent = node.textContent!.trim();
         const expectedTextContent = expectedNode[expectedNode.length - 1];
+
         if (actualTextContent !== expectedTextContent) {
             missedExpectations.push(
                 `Expected node contents to be ${expectedTextContent} but was ${actualTextContent}`);

--- a/tslint.json
+++ b/tslint.json
@@ -18,6 +18,7 @@
         "no-non-null-assertion": false,
         "strict-type-predicates": false,
         "no-unbound-method": [true, {"ignore-static": true, "whitelist": ["expect"], "allow-typeof": true }],
-        "mocha-no-side-effect-code": [true, { "ignore": "xdescribe|xit" }]
+        "mocha-no-side-effect-code": [true, { "ignore": "xdescribe|xit" }],
+        "no-for-in": false
     }
 }


### PR DESCRIPTION
tslint naming-convention, no-unnecessary-type-assertion, member-ordering, deprecation,  no-require-imports, no-for-in rules, magic-numbers are fixed.

deprecated runSchematic function is replaced with runSchematicAsync, and runExternalSchematic with runExternalSchematicAsync.

for in is replaced with Object.keys().forEach()

