### PR TITLE
fix(input): errors with AoT (#UIM-370)

### DIFF
--- a/packages/mosaic/tags/tag-input.ts
+++ b/packages/mosaic/tags/tag-input.ts
@@ -32,7 +32,6 @@ let nextUniqueId = 0;
         '[id]': 'id',
         '[attr.disabled]': 'disabled || null',
         '[attr.placeholder]': 'placeholder || null',
-        '[attr.aria-invalid]': '_tagList && _tagList.ngControl ? _tagList.ngControl.invalid : null',
         '(keydown)': 'keydown($event)',
         '(blur)': 'blur()',
         '(focus)': 'onFocus()',

--- a/packages/mosaic/tags/tag-list.component.spec.ts
+++ b/packages/mosaic/tags/tag-list.component.spec.ts
@@ -1096,20 +1096,6 @@ describe('MatTagList', () => {
             expect(document.activeElement).toBe(nativeInput, 'Expected input to remain focused.');
         }));
 
-        it('should set aria-invalid if the form field is invalid', () => {
-            fixture.componentInstance.control = new FormControl(undefined, [Validators.required]);
-            fixture.detectChanges();
-
-            const input: HTMLInputElement = fixture.nativeElement.querySelector('input');
-
-            expect(input.getAttribute('aria-invalid')).toBe('true');
-
-            fixture.componentInstance.tags.first.selectViaInteraction();
-            fixture.detectChanges();
-
-            expect(input.getAttribute('aria-invalid')).toBe('false');
-        });
-
         describe('keyboard behavior', () => {
             beforeEach(() => {
                 tagListDebugElement = fixture.debugElement.query(By.directive(McTagList));


### PR DESCRIPTION
Убрал выставление атрибута aria-invalid, мы все равно их не используем, где то остались после copy/paste...

Странно, что заметили только сейчас, _tagList стал приватным еще в сентябре прошлого года и локальная сборка с флагом AoT тоже пропускает это...