### PR TITLE
build: adding yaml check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,6 +67,12 @@ jobs:
             - attach_workspace: *attach_options
             - run: yarn run linter:mosaic
 
+    lint_yaml:
+        <<: *job_defaults
+        steps:
+            - attach_workspace: *attach_options
+            - run: yarn run linter:yaml
+
     build_mosaic_docs:
         <<: *job_defaults
         steps:
@@ -193,6 +199,9 @@ workflows:
                   requires:
                       - install
             - lint_mosaic:
+                  requires:
+                      - install
+            - lint_yaml:
                   requires:
                       - install
             - build_cdk:

--- a/package.json
+++ b/package.json
@@ -139,7 +139,8 @@
         "wallaby-webpack": "^3.9.13",
         "webpack": "^4.39.1",
         "webpack-cli": "^3.3.6",
-        "webpack-dev-server": "^3.7.2"
+        "webpack-dev-server": "^3.7.2",
+        "yaml-lint": "^1.2.4"
     },
     "scripts": {
         "serve:dev-app": "gulp serve:devapp",
@@ -163,6 +164,7 @@
         "publish": "ts-node --project ./scripts/tsconfig.deploy.json ./scripts/deploy/publish-artifacts.ts",
         "linter:mosaic": "gulp tslint",
         "linter:styles": "gulp stylelint",
+        "linter:yaml": "yamllint **/*.yml --ignore=node_modules/**/*.yml",
         "release:stage": "ts-node --project tools/release/ tools/release/stage-release.ts",
         "release:publish": "ts-node --project tools/release/ tools/release/publish-release.ts",
         "server-dev": "webpack-dev-server --config tools/webpack/webpack.config.js",

--- a/tools/gulp/tasks/lint.ts
+++ b/tools/gulp/tasks/lint.ts
@@ -10,7 +10,7 @@ import { execNodeTask } from '../utils/helpers';
 /* tslint:disable:no-var-requires */
 const madge = require('madge');
 
-/** Globs that matchall SCSS or CSS files that should be linted. */
+/** Globs that match all SCSS or CSS files that should be linted. */
 const styleGlobs = [
     'packages/**/*.+(css|scss)'
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -8242,7 +8242,7 @@ js-tokens@^3.0.2:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
   integrity sha1-mGbfOVECEw449/mWvOtlRDIJwls=
 
-js-yaml@3.x, js-yaml@^3.13.1:
+js-yaml@3.x, js-yaml@^3.10.0, js-yaml@^3.13.1:
   version "3.13.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
   integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
@@ -8667,6 +8667,13 @@ lead@^1.0.0:
   dependencies:
     flush-write-stream "^1.0.2"
 
+leprechaun@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/leprechaun/-/leprechaun-0.0.2.tgz#8b96514a9e634c53fbe59a8094f3378c8fb2084d"
+  integrity sha1-i5ZRSp5jTFP75ZqAlPM3jI+yCE0=
+  dependencies:
+    log-symbols "^1.0.2"
+
 less-loader@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-5.0.0.tgz#498dde3a6c6c4f887458ee9ed3f086a12ad1b466"
@@ -9062,6 +9069,11 @@ lodash.keys@~2.4.1:
     lodash._shimkeys "~2.4.1"
     lodash.isobject "~2.4.1"
 
+lodash.merge@^4.6.1:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
+
 lodash.noop@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/lodash.noop/-/lodash.noop-3.0.1.tgz#38188f4d650a3a474258439b96ec45b32617133c"
@@ -9171,6 +9183,13 @@ lodash@^4.0.0, lodash@^4.16.6, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.11,
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+log-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"
+  integrity sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
+  dependencies:
+    chalk "^1.0.0"
 
 log-symbols@^2.1.0, log-symbols@^2.2.0:
   version "2.2.0"
@@ -16242,6 +16261,18 @@ yallist@^3.0.0, yallist@^3.0.2, yallist@^3.0.3:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yaml-lint@^1.2.4:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/yaml-lint/-/yaml-lint-1.2.4.tgz#0dec2d1ef4e5ec999bba1e34d618fc60498d1bc5"
+  integrity sha512-qpKE0szyKsE9TrlVPi+bxKxVAjl30QjNAOyOxy7noQdf/WCCYUlT4xiCRxMG48eyeBzMBtBN6PgGfaB0MJePNw==
+  dependencies:
+    glob "^7.1.2"
+    js-yaml "^3.10.0"
+    leprechaun "0.0.2"
+    lodash.merge "^4.6.1"
+    lodash.snakecase "^4.1.1"
+    nconf "^0.10.0"
 
 yaml@^1.7.2:
   version "1.7.2"


### PR DESCRIPTION
yaml check job is added to .circleci\config.yml.

Right now yaml lint is done through package.json only. It seems, that because of yaml lint execution file is placed not in bin directory, our usual gulp task('taskName', execNodeTask()) wouldn't work.

Also, thought this package check file for errors, it doesn't really do much linting, just checking that file is valid.


