### PR TITLE
fix(docs): copy icon is clickable so cursor: pointer

### DIFF
--- a/packages/docs/src/app/shared/example-viewer/_example-viewer-theme.scss
+++ b/packages/docs/src/app/shared/example-viewer/_example-viewer-theme.scss
@@ -21,7 +21,10 @@
     .code-copy__icon {
         color: $color;
 
-        &:hover { color: $color_hover; }
+        &:hover {
+            color: $color_hover;
+            cursor: pointer;
+        }
     }
 
     .docs-example-viewer__example {


### PR DESCRIPTION
Copy icon is clickable so cursor must be pointer.