### PR TITLE
chore(common): fixing stylelint

### DIFF
--- a/packages/docs/src/styles/_theme-dark.scss
+++ b/packages/docs/src/styles/_theme-dark.scss
@@ -15,5 +15,19 @@ $dark-warning: mc-palette($mc-yellow, 200, 400, 700);
 
 $dark-theme: mc-dark-theme($dark-primary, $dark-second, $dark-error, $dark-info, $dark-success, $dark-warning);
 $dark-theme-red: mc-dark-theme($dark-primary-red, $dark-second, $dark-error, $dark-info, $dark-success, $dark-warning);
-$dark-theme-green: mc-dark-theme($dark-primary-green, $dark-second, $dark-error, $dark-info, $dark-success, $dark-warning);
-$dark-theme-yellow: mc-dark-theme($dark-primary-yellow, $dark-second, $dark-error, $dark-info, $dark-success, $dark-warning);
+$dark-theme-green: mc-dark-theme(
+        $dark-primary-green,
+        $dark-second,
+        $dark-error,
+        $dark-info,
+        $dark-success,
+        $dark-warning
+);
+$dark-theme-yellow: mc-dark-theme(
+        $dark-primary-yellow,
+        $dark-second,
+        $dark-error,
+        $dark-info,
+        $dark-success,
+        $dark-warning
+);

--- a/packages/mosaic-dev/flex-layout/styles.scss
+++ b/packages/mosaic-dev/flex-layout/styles.scss
@@ -13,9 +13,11 @@
 .colorNested > div div:nth-child(1) {
     background-color: #009688;
 }
+
 .colorNested > div div:nth-child(2) {
     background-color: #3949ab;
 }
+
 .colorNested > div div:nth-child(3) {
     background-color: #9c27b0;
 }

--- a/packages/mosaic-dev/splitter/styles.scss
+++ b/packages/mosaic-dev/splitter/styles.scss
@@ -34,12 +34,14 @@ mc-splitter.custom-color > mc-gutter:hover {
     color: black;
 }
 
+/* stylelint-disable no-descending-specificity */
 // custom gutter image
 mc-splitter.custom-gutter > mc-gutter {
     background-repeat: no-repeat;
     background-position: center;
     background-image: url("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUAAAAeCAYAAADkftS9AAAAIklEQVQoU2M4c+bMfxAGAgYYmwGrIIiDjrELjpo5aiZeMwF+yNnOs5KSvgAAAABJRU5ErkJggg==");
 }
+/* stylelint-enable no-descending-specificity */
 
 mc-splitter.custom-gutter > mc-gutter > i {
     display: none;

--- a/packages/mosaic-dev/tooltip/styles.scss
+++ b/packages/mosaic-dev/tooltip/styles.scss
@@ -1,7 +1,7 @@
 @import '~@ptsecurity/mosaic-icons/dist/styles/mc-icons';
 
 @import '../../mosaic/core/visual/prebuilt/default-visual';
- @import '../../mosaic/core/theming/prebuilt/default-theme';
+@import '../../mosaic/core/theming/prebuilt/default-theme';
 //@import '../../mosaic/core/theming/prebuilt/dark-theme';
 
 @include mosaic-visual();

--- a/packages/mosaic-examples/mosaic/datepicker/datepicker-disabled/datepicker-disabled-example.css
+++ b/packages/mosaic-examples/mosaic/datepicker/datepicker-disabled/datepicker-disabled-example.css
@@ -1,7 +1,7 @@
 .example-datepicker-group {
-     display: inline-flex;
-     flex-direction: column;
- }
+    display: inline-flex;
+    flex-direction: column;
+}
 
 .example-datepicker {
     margin-bottom: 10px;

--- a/packages/mosaic/button-toggle/button-toggle.scss
+++ b/packages/mosaic/button-toggle/button-toggle.scss
@@ -15,12 +15,6 @@ $mc-button-toggle-border-radius: 3px;
     display: flex;
     flex-direction: row;
 
-    &:not(.mc-button-toggle-vertical) {
-        .mc-button-toggle:not([disabled]) + .mc-button-toggle:not([disabled]) {
-            margin-left: -$mc-button-toggle-border-size;
-        }
-    }
-
     .mc-button-toggle {
         &:first-of-type:not(:last-of-type) {
             > .mc-button,
@@ -45,6 +39,12 @@ $mc-button-toggle-border-radius: 3px;
 
         &[disabled] {
             outline: 0;
+        }
+    }
+
+    &:not(.mc-button-toggle-vertical) {
+        .mc-button-toggle:not([disabled]) + .mc-button-toggle:not([disabled]) {
+            margin-left: -$mc-button-toggle-border-size;
         }
     }
 }

--- a/packages/mosaic/button-toggle/button-toggle.scss
+++ b/packages/mosaic/button-toggle/button-toggle.scss
@@ -49,6 +49,7 @@ $mc-button-toggle-border-radius: 3px;
     }
 }
 
+/* stylelint-disable no-descending-specificity */
 .mc-button-toggle-vertical {
     flex-direction: column;
 
@@ -93,6 +94,7 @@ $mc-button-toggle-border-radius: 3px;
         }
     }
 }
+/* stylelint-enable no-descending-specificity */
 
 .mc-button-toggle-standalone {
     box-shadow: none;

--- a/packages/mosaic/checkbox/_checkbox-theme.scss
+++ b/packages/mosaic/checkbox/_checkbox-theme.scss
@@ -42,14 +42,6 @@
             }
         }
 
-        & .mc-checkbox-input.cdk-keyboard-focused {
-            + .mc-checkbox-frame {
-                border-color: $state-focused_border-color;
-
-                box-shadow: $state-focused_shadow;
-            }
-        }
-
         &.mc-disabled {
             color: map-get($foreground, text-disabled);
 
@@ -62,6 +54,14 @@
                 & .mc-checkbox-mixedmark {
                     color: map-get($foreground, text-disabled);
                 }
+            }
+        }
+
+        & .mc-checkbox-input.cdk-keyboard-focused {
+            + .mc-checkbox-frame {
+                border-color: $state-focused_border-color;
+
+                box-shadow: $state-focused_shadow;
             }
         }
     }

--- a/packages/mosaic/checkbox/checkbox.scss
+++ b/packages/mosaic/checkbox/checkbox.scss
@@ -28,6 +28,29 @@ $mc-checkbox-mark-stroke-size: 2 / 15 * $mc-checkbox-size !default;
     pointer-events: none;
 }
 
+.mc-checkbox-checkmark,
+.mc-checkbox-mixedmark {
+    display: none;
+
+    position: absolute;
+
+    top: -1px;
+    left: -1px;
+    right: 0;
+    bottom: 0;
+}
+
+.mc-checkbox-frame {
+    @extend %mc-checkbox-outer-box;
+
+    background-color: transparent;
+    border: {
+        width: $mc-checkbox-border-width;
+        style: solid;
+    }
+    box-shadow: $toggle-box-shadow;
+}
+
 .mc-checkbox {
     display: inline-block;
 
@@ -100,29 +123,6 @@ $mc-checkbox-mark-stroke-size: 2 / 15 * $mc-checkbox-size !default;
         left: 0;
         right: 0;
     }
-}
-
-.mc-checkbox-frame {
-    @extend %mc-checkbox-outer-box;
-
-    background-color: transparent;
-    border: {
-        width: $mc-checkbox-border-width;
-        style: solid;
-    }
-    box-shadow: $toggle-box-shadow;
-}
-
-.mc-checkbox-checkmark,
-.mc-checkbox-mixedmark {
-    display: none;
-
-    position: absolute;
-
-    top: -1px;
-    left: -1px;
-    right: 0;
-    bottom: 0;
 }
 
 .mc-checkbox-label-before {

--- a/packages/mosaic/core/styles/common/_animation.scss
+++ b/packages/mosaic/core/styles/common/_animation.scss
@@ -22,12 +22,12 @@
         left: 0;
 
         $lighter: transparent;
-        $darker: rgba(0, 0, 0, .05);
+        $darker: rgba(0, 0, 0, 0.05);
         background: linear-gradient(
-                135deg,
-                $darker 10px, $lighter 10px,
-                $lighter 20px, $darker 20px,
-                $darker 30px, $lighter 30px
+            135deg,
+            $darker 10px, $lighter 10px,
+            $lighter 20px, $darker 20px,
+            $darker 30px, $lighter 30px
         ) repeat;
         background-size: 29px 29px;
         animation: mc-progress 1s linear infinite;

--- a/packages/mosaic/form-field/_form-field-theme.scss
+++ b/packages/mosaic/form-field/_form-field-theme.scss
@@ -23,13 +23,6 @@
                 border-color: mc-color($second, if($is-dark, lighter, darker));
             }
 
-            &.mc-focused:not(.ng-invalid) .mc-form-field__container {
-                $focused-color: map-get(map-get($theme, states), focused-color);
-
-                border-color: $focused-color;
-                box-shadow: 0 0 0 1px $focused-color;
-            }
-
             &.ng-invalid .mc-form-field__container {
                 background-color: if($is-dark, transparent, mc-color($error, lighter));
 
@@ -41,20 +34,28 @@
                 }
             }
 
-            &.ng-invalid.mc-focused .mc-form-field__container {
-                box-shadow: 0 0 0 1px mc-color($error);
-            }
-
             &.mc-disabled .mc-form-field__container {
                 border-color: mix(map-get($foreground, border), map-get($background, overlay-disabled));
 
-                background-color: mix(map-get($background, background-disabled), map-get($background, overlay-disabled));
+                background-color:
+                    mix(map-get($background, background-disabled), map-get($background, overlay-disabled));
 
                 .mc-icon,
                 .mc-input,
                 .mc-textarea {
                     color: mc-color($foreground, text-disabled);
                 }
+            }
+
+            &.mc-focused:not(.ng-invalid) .mc-form-field__container {
+                $focused-color: map-get(map-get($theme, states), focused-color);
+
+                border-color: $focused-color;
+                box-shadow: 0 0 0 1px $focused-color;
+            }
+
+            &.ng-invalid.mc-focused .mc-form-field__container {
+                box-shadow: 0 0 0 1px mc-color($error);
             }
         }
     }

--- a/packages/mosaic/form-field/_form-field-theme.scss
+++ b/packages/mosaic/form-field/_form-field-theme.scss
@@ -34,6 +34,20 @@
                 }
             }
 
+            &.mc-focused {
+                &:not(.ng-invalid) .mc-form-field__container {
+                    $focused-color: map-get(map-get($theme, states), focused-color);
+
+                    border-color: $focused-color;
+                    box-shadow: 0 0 0 1px $focused-color;
+                }
+
+                &.ng-invalid .mc-form-field__container {
+                    box-shadow: 0 0 0 1px mc-color($error);
+                }
+            }
+
+            /* stylelint-disable no-descending-specificity */
             &.mc-disabled .mc-form-field__container {
                 border-color: mix(map-get($foreground, border), map-get($background, overlay-disabled));
 
@@ -46,17 +60,7 @@
                     color: mc-color($foreground, text-disabled);
                 }
             }
-
-            &.mc-focused:not(.ng-invalid) .mc-form-field__container {
-                $focused-color: map-get(map-get($theme, states), focused-color);
-
-                border-color: $focused-color;
-                box-shadow: 0 0 0 1px $focused-color;
-            }
-
-            &.ng-invalid.mc-focused .mc-form-field__container {
-                box-shadow: 0 0 0 1px mc-color($error);
-            }
+            /* stylelint-enable no-descending-specificity */
         }
     }
 

--- a/packages/mosaic/form-field/form-field.scss
+++ b/packages/mosaic/form-field/form-field.scss
@@ -72,16 +72,6 @@ $mc-form-field-border-size: 1px;
     }
 }
 
-.mc-form-field__cleaner {
-    .mc-cleaner {
-        position: absolute;
-
-        top: 0;
-        bottom: 0;
-        right: 0;
-    }
-}
-
 .mc-cleaner {
     display: flex;
 
@@ -97,6 +87,16 @@ $mc-form-field-border-size: 1px;
 
         width: 100%;
         height: 100%;
+    }
+}
+
+.mc-form-field__cleaner {
+    .mc-cleaner {
+        position: absolute;
+
+        top: 0;
+        bottom: 0;
+        right: 0;
     }
 }
 

--- a/packages/mosaic/link/_link-theme.scss
+++ b/packages/mosaic/link/_link-theme.scss
@@ -52,33 +52,33 @@
 
         &.mc-link_underlined .mc-link__text {
             border-bottom-style: solid;
-            border-bottom-color: rgba($color, .32);
+            border-bottom-color: rgba($color, 0.32);
         }
 
         &.mc-link_dashed .mc-link__text {
             border-bottom-style: dashed;
             border-bottom-width: 1px;
-            border-bottom-color: rgba($color, .5);
+            border-bottom-color: rgba($color, 0.5);
 
             &:visited {
-                border-bottom-color: rgba($color, .5);
+                border-bottom-color: rgba($color, 0.5);
             }
 
             &:hover {
-                border-bottom-color: rgba($color_hover, .5);
+                border-bottom-color: rgba($color_hover, 0.5);
             }
         }
 
         &.mc-link_underlined .mc-link__text {
             border-bottom-width: 1px;
-            border-bottom-color: rgba($color, .32);
+            border-bottom-color: rgba($color, 0.32);
 
             &:visited {
-                border-bottom-color: rgba($color, .32);
+                border-bottom-color: rgba($color, 0.32);
             }
 
             &:hover {
-                border-bottom-color: rgba($color_hover, .32);
+                border-bottom-color: rgba($color_hover, 0.32);
             }
         }
 
@@ -91,7 +91,7 @@
             pointer-events: none;
 
             &.mc-link_underlined .mc-link__text {
-                border-bottom-color: rgba($color_disabled, .64);
+                border-bottom-color: rgba($color_disabled, 0.64);
             }
 
             &.mc-link_dashed .mc-link__text {

--- a/packages/mosaic/link/_link-theme.scss
+++ b/packages/mosaic/link/_link-theme.scss
@@ -50,11 +50,6 @@
             margin-right: 4px;
         }
 
-        &.mc-link_underlined .mc-link__text {
-            border-bottom-style: solid;
-            border-bottom-color: rgba($color, 0.32);
-        }
-
         &.mc-link_dashed .mc-link__text {
             border-bottom-style: dashed;
             border-bottom-width: 1px;
@@ -70,6 +65,7 @@
         }
 
         &.mc-link_underlined .mc-link__text {
+            border-bottom-style: solid;
             border-bottom-width: 1px;
             border-bottom-color: rgba($color, 0.32);
 

--- a/packages/mosaic/link/_link-theme.scss
+++ b/packages/mosaic/link/_link-theme.scss
@@ -64,6 +64,7 @@
             }
         }
 
+        /* stylelint-disable no-descending-specificity */
         &.mc-link_underlined .mc-link__text {
             border-bottom-style: solid;
             border-bottom-width: 1px;
@@ -77,6 +78,7 @@
                 border-bottom-color: rgba($color_hover, 0.32);
             }
         }
+        /* stylelint-enable no-descending-specificity */
 
         &[disabled] {
             $color_disabled: mc-color($foreground, text-disabled);

--- a/packages/mosaic/navbar/_navbar-theme.scss
+++ b/packages/mosaic/navbar/_navbar-theme.scss
@@ -16,6 +16,12 @@
         }
     }
 
+    .mc-navbar-brand {
+        .mc-navbar-title {
+            opacity: 0.5;
+        }
+    }
+
     .mc-navbar-item {
         outline: 0;
 
@@ -46,12 +52,6 @@
             .mc-icon {
                 opacity: map-get($navbar, item_state-disabled_opacity);
             }
-        }
-    }
-
-    .mc-navbar-brand {
-        .mc-navbar-title {
-            opacity: 0.5;
         }
     }
 }

--- a/packages/mosaic/progress-spinner/progress-spinner.scss
+++ b/packages/mosaic/progress-spinner/progress-spinner.scss
@@ -12,6 +12,15 @@
     height: 16px;
     overflow: hidden;
 
+    &__circle {
+        fill: none;
+        stroke: black;
+        stroke-dasharray: 273%;
+        stroke-width: 13%;
+        transition: stroke-dashoffset 0.3s;
+        transform-origin: center center;
+    }
+
     &__inner {
         width: 100%;
         height: 100%;
@@ -30,14 +39,5 @@
     &__svg {
         width: 100%;
         height: 100%;
-    }
-
-    &__circle {
-        fill: none;
-        stroke: black;
-        stroke-dasharray: 273%;
-        stroke-width: 13%;
-        transition: stroke-dashoffset 0.3s;
-        transform-origin: center center;
     }
 }

--- a/packages/mosaic/select/select.scss
+++ b/packages/mosaic/select/select.scss
@@ -14,27 +14,6 @@ $mc-select-panel-border-radius: 3px !default;
 $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arrow-margin);
 
 
-
-.mc-select__trigger {
-    display: flex;
-    box-sizing: border-box;
-    position: relative;
-
-    height: 30px;
-
-    cursor: pointer;
-
-    // todo возможно нужно через JS
-    padding: {
-        right: 7px;
-        left: 15px;
-    };
-
-    &.mc-select__trigger_multiple {
-        padding-left: 7px;
-    }
-}
-
 .mc-select {
     box-sizing: border-box;
 
@@ -46,6 +25,26 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
     width: 100%;
 
     outline: none;
+
+    & .mc-select__trigger {
+        display: flex;
+        box-sizing: border-box;
+        position: relative;
+
+        height: 30px;
+
+        cursor: pointer;
+
+        // todo возможно нужно через JS
+        padding: {
+            right: 7px;
+            left: 15px;
+        };
+
+        &.mc-select__trigger_multiple {
+            padding-left: 7px;
+        }
+    }
 
     &.mc-disabled {
         & .mc-select__trigger {

--- a/packages/mosaic/select/select.scss
+++ b/packages/mosaic/select/select.scss
@@ -14,6 +14,27 @@ $mc-select-panel-border-radius: 3px !default;
 $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arrow-margin);
 
 
+
+.mc-select__trigger {
+    display: flex;
+    box-sizing: border-box;
+    position: relative;
+
+    height: 30px;
+
+    cursor: pointer;
+
+    // todo возможно нужно через JS
+    padding: {
+        right: 7px;
+        left: 15px;
+    };
+
+    &.mc-select__trigger_multiple {
+        padding-left: 7px;
+    }
+}
+
 .mc-select {
     box-sizing: border-box;
 
@@ -46,26 +67,6 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
     cursor: default;
     outline: none;
     padding: 0 16px;
-}
-
-.mc-select__trigger {
-    display: flex;
-    box-sizing: border-box;
-    position: relative;
-
-    height: 30px;
-
-    cursor: pointer;
-
-    // todo возможно нужно через JS
-    padding: {
-        right: 7px;
-        left: 15px;
-    };
-
-    &.mc-select__trigger_multiple {
-        padding-left: 7px;
-    }
 }
 
 .mc-select__matcher {
@@ -158,21 +159,19 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
     border-bottom-right-radius: $mc-select-panel-border-radius;
 
     padding: 4px 0;
-}
 
-.mc-select__content {
-    max-height: $mc-select-panel-max-height;
-    overflow: auto;
-}
-
-// Override optgroup and option to scale based on font-size of the trigger.
-.mc-select__panel {
+    // Override optgroup and option to scale based on font-size of the trigger.
     .mc-optgroup-label,
     .mc-option {
         font-size: inherit;
         line-height: $mc-select-item-height;
         height: $mc-select-item-height;
     }
+}
+
+.mc-select__content {
+    max-height: $mc-select-panel-max-height;
+    overflow: auto;
 }
 
 .mc-form-field-type-mc-select {

--- a/packages/mosaic/tags/_tag-theme.scss
+++ b/packages/mosaic/tags/_tag-theme.scss
@@ -40,6 +40,12 @@
             @include mc-tag-color(map-get($tags, error));
         }
 
+        &:hover {
+            & .mc-tag-overlay {
+                background: mc-color($background, overlay-hovered);
+            }
+        }
+
         .mc-icon {
             color: map-get($foreground, icon);
 
@@ -63,12 +69,6 @@
             & .mc-icon {
                 color: map-get($foreground, icon);
                 cursor: default;
-            }
-        }
-
-        &:hover:not(.mc-disabled) {
-            & .mc-tag-overlay {
-                background: mc-color($background, overlay-hovered);
             }
         }
     }

--- a/packages/mosaic/tags/_tag-theme.scss
+++ b/packages/mosaic/tags/_tag-theme.scss
@@ -40,12 +40,6 @@
             @include mc-tag-color(map-get($tags, error));
         }
 
-        &:hover:not(.mc-disabled) {
-            & .mc-tag-overlay {
-                background: mc-color($background, overlay-hovered);
-            }
-        }
-
         .mc-icon {
             color: map-get($foreground, icon);
 
@@ -69,6 +63,12 @@
             & .mc-icon {
                 color: map-get($foreground, icon);
                 cursor: default;
+            }
+        }
+
+        &:hover:not(.mc-disabled) {
+            & .mc-tag-overlay {
+                background: mc-color($background, overlay-hovered);
             }
         }
     }

--- a/packages/mosaic/tags/tag-list.scss
+++ b/packages/mosaic/tags/tag-list.scss
@@ -5,6 +5,12 @@
     flex-direction: row;
 }
 
+.mc-tag-input {
+    border: none;
+    outline: none;
+    background: transparent;
+}
+
 .mc-tags-list__list-container {
     display: flex;
     flex-wrap: wrap;
@@ -29,10 +35,4 @@
     & .mc-cleaner {
         height: 30px;
     }
-}
-
-.mc-tag-input {
-    border: none;
-    outline: none;
-    background: transparent;
 }

--- a/packages/mosaic/tree-select/tree-select.scss
+++ b/packages/mosaic/tree-select/tree-select.scss
@@ -158,6 +158,14 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
     border-bottom-right-radius: $mc-select-panel-border-radius;
 
     padding: 4px 0;
+
+    // Override optgroup and option to scale based on font-size of the trigger.
+    .mc-optgroup-label,
+    .mc-tree-select-option {
+        font-size: inherit;
+        line-height: $mc-select-item-height;
+        height: $mc-select-item-height;
+    }
 }
 
 .mc-tree-select__content {
@@ -165,16 +173,6 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
 
     & .mc-tree-selection {
         height: 100%;
-    }
-}
-
-// Override optgroup and option to scale based on font-size of the trigger.
-.mc-tree-select__panel {
-    .mc-optgroup-label,
-    .mc-tree-select-option {
-        font-size: inherit;
-        line-height: $mc-select-item-height;
-        height: $mc-select-item-height;
     }
 }
 

--- a/packages/mosaic/tree-select/tree-select.scss
+++ b/packages/mosaic/tree-select/tree-select.scss
@@ -37,6 +37,7 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
     }
 }
 
+/* stylelint-disable no-descending-specificity */
 .mc-tree-select__trigger {
     display: flex;
     box-sizing: border-box;
@@ -60,6 +61,7 @@ $mc-select-placeholder-arrow-space: 2 * ($mc-select-arrow-size + $mc-select-arro
         }
     }
 }
+/* stylelint-enable no-descending-specificity */
 
 .mc-tree-select__matcher {
     display: flex;


### PR DESCRIPTION
Fixing zero before dot, max-length, indent, duplicate, and no-descending-specificity rules.

Due to [stylelint/stylelint#4271](https://github.com/stylelint/stylelint/issues/4271) no-descending-specificity rule ignores parent specificity, so to make our SCSS component-like code valid we need to switch it off when needed