### PR TITLE
fix(datepicker): fixing datepicker toggle button opacity (#UIM-396)

### DIFF
--- a/packages/mosaic/datepicker/_datepicker-theme.scss
+++ b/packages/mosaic/datepicker/_datepicker-theme.scss
@@ -35,6 +35,7 @@ $mc-datepicker-today-fade-amount: 0.2;
         border-color: transparent;
         border-radius: 0;
         background: transparent;
+        opacity: 1;
 
         .mc-icon {
             color: map-get($foreground, icon);


### PR DESCRIPTION
Disabled button has 0.3 opacity by default, but datepicker toggle button should have full opacity.