### PR TITLE
chore(common): disabling descending specificity for tables

### DIFF
--- a/packages/mosaic/table/table.scss
+++ b/packages/mosaic/table/table.scss
@@ -25,6 +25,7 @@
         }
     }
 
+    /* stylelint-disable no-descending-specificity */
     & > thead {
         & > tr > th {
             padding-top: 8px;
@@ -40,4 +41,5 @@
             border-bottom: 1px solid transparent;
         }
     }
+    /* stylelint-enable no-descending-specificity */
 }


### PR DESCRIPTION
Fixing linter:styles:json test for CI
