### PR TITLE
fix(docs): fix light theme in dev docs

### DIFF
--- a/packages/mosaic-dev/main.scss
+++ b/packages/mosaic-dev/main.scss
@@ -1,5 +1,5 @@
 $mc-icons-font-path: "~@ptsecurity/mosaic-icons/dist/fonts";
 @import '~@ptsecurity/mosaic-icons/dist/styles/mc-icons';
 
-// @import '../../mosaic/core/theming/prebuilt/default-theme';
+// @import '../mosaic/core/theming/prebuilt/default-theme';
 @import '../mosaic/core/theming/prebuilt/dark-theme';


### PR DESCRIPTION
Для светлой темы был указан неправильный путь