### PR TITLE
fix(visual): Maked text of class name more visible on the dark theme

### DIFF
--- a/packages/mosaic-examples/mosaic/typography/typography-overview/typography-overview-example.css
+++ b/packages/mosaic-examples/mosaic/typography/typography-overview/typography-overview-example.css
@@ -1,3 +1,7 @@
+small {
+    color: rgba(0, 0, 0, 0.3);
+}
+
 .typography-group {
     margin-bottom: 20px;
 }

--- a/packages/mosaic-examples/mosaic/typography/typography-overview/typography-overview-example.css
+++ b/packages/mosaic-examples/mosaic/typography/typography-overview/typography-overview-example.css
@@ -1,5 +1,5 @@
 small {
-    color: rgba(0, 0, 0, 0.3);
+    color: rgba(0, 0, 0, 0.5);
 }
 
 .typography-group {

--- a/packages/mosaic-examples/mosaic/typography/typography-overview/typography-overview-example.css
+++ b/packages/mosaic-examples/mosaic/typography/typography-overview/typography-overview-example.css
@@ -1,7 +1,3 @@
-small {
-    color: rgba(0, 0, 0, 0.5);
-}
-
 .typography-group {
     margin-bottom: 20px;
 }

--- a/packages/mosaic-examples/mosaic/typography/typography-overview/typography-overview-example.html
+++ b/packages/mosaic-examples/mosaic/typography/typography-overview/typography-overview-example.html
@@ -1,18 +1,18 @@
 <div class="typography-group">
-    <small>mc-display-3</small>
+    <div class="mc-caption">mc-display-3</div>
     <div class="mc-display-3">Display 3</div>
-    <small>mc-display-2</small>
+    <div class="mc-caption">mc-display-2</div>
     <div class="mc-display-2">Display 2</div>
-    <small>mc-display-1</small>
+    <div class="mc-caption">mc-display-1</div>
     <div class="mc-display-1">Display 1</div>
 </div>
 
 <div class="typography-group">
-    <small>mc-headline</small>
+    <div class="mc-caption">mc-headline</div>
     <div class="mc-headline">Headline</div>
-    <small>mc-title</small>
+    <div class="mc-caption">mc-title</div>
     <div class="mc-title">Title</div>
-    <small>mc-subheading</small>
+    <div class="mc-caption">mc-subheading</div>
     <div class="mc-subheading">Subheading</div>
 </div>
 

--- a/packages/mosaic-examples/mosaic/typography/typography-overview/typography-overview-example.html
+++ b/packages/mosaic-examples/mosaic/typography/typography-overview/typography-overview-example.html
@@ -1,8 +1,10 @@
 <div class="typography-group">
     <div class="mc-caption">mc-display-3</div>
     <div class="mc-display-3">Display 3</div>
+
     <div class="mc-caption">mc-display-2</div>
     <div class="mc-display-2">Display 2</div>
+
     <div class="mc-caption">mc-display-1</div>
     <div class="mc-display-1">Display 1</div>
 </div>
@@ -10,8 +12,10 @@
 <div class="typography-group">
     <div class="mc-caption">mc-headline</div>
     <div class="mc-headline">Headline</div>
+
     <div class="mc-caption">mc-title</div>
     <div class="mc-title">Title</div>
+
     <div class="mc-caption">mc-subheading</div>
     <div class="mc-subheading">Subheading</div>
 </div>


### PR DESCRIPTION
The text of class name made more visible on the dark theme (set for text opacity: 0.5)