### PR TITLE
fix(timepicker): remove parseValidator (#UIM-464)

### DIFF
--- a/packages/mosaic/timepicker/timepicker.ts
+++ b/packages/mosaic/timepicker/timepicker.ts
@@ -278,7 +278,6 @@ export class McTimepicker<D> extends McTimepickerMixinBase
             // To avoid cyclic dependency https://stackoverflow.com/a/49578414
             const control = this.ngControl.control as FormControl;
             const myValidators = [
-                () => this.parseValidator(),
                 () => this.minTimeValidator(),
                 () => this.maxTimeValidator()
             ];
@@ -718,12 +717,6 @@ export class McTimepicker<D> extends McTimepickerMixinBase
             minutes: this.dateAdapter.getMinutes(dateVal),
             seconds: this.dateAdapter.getSeconds(dateVal)
         };
-    }
-
-    private parseValidator(): ValidationErrors | null {
-        return this.currentDateTimeInput === undefined ?
-            { mcTimepickerParse: { text: this.elementRef.nativeElement.value } } :
-            null;
     }
 
     private minTimeValidator(): ValidationErrors | null {


### PR DESCRIPTION
### Reviwers
@mikeozornin, @Fost 

### Summary
Исправлена ошибка валидации при пустом поле ввода
Странный валдатор, повторяет логику `requiered`  
Плюс форматом занимается мозаик, у макс и мин валидаторов, присутствует проверка, что таймпикер имеет значение.


![2020-06-11-17-57-29-O6L0N](https://user-images.githubusercontent.com/6462193/84402387-082de800-ac0d-11ea-9576-6316096e64df.gif)
