### PR TITLE
fix(button): correct focus border for buttons in dark theme

### DIFF
--- a/packages/mosaic/button/_button-theme.scss
+++ b/packages/mosaic/button/_button-theme.scss
@@ -60,7 +60,7 @@
                 $focused-color: map-get(map-get($theme, states), focused-color);
 
                 border-color: $focused-color;
-                box-shadow: inset 0 0 0 1px white, 0 0 0 1px $focused-color;
+                box-shadow: inset 0 0 0 1px map-get($background, background), 0 0 0 1px $focused-color;
             }
         }
 


### PR DESCRIPTION
Fix buttons focus border in dark mode (UIM-488)