### PR TITLE
fix: updated positioning logic in tooltips (#UIM-511)

### DIFF
--- a/packages/mosaic-dev/tooltip/template.html
+++ b/packages/mosaic-dev/tooltip/template.html
@@ -64,14 +64,12 @@
         <div class="flex layout-column layout-align-center-center container-item">                <span class="mc-title">Arrow placement for left and right</span>
                 <button
                     mc-button
-                    mcArrowPlacement="default"
                     mcTooltip="PDQL-запрос фильтра содержит ошибки, исправьте запрос"
                     mcPlacement="left">
                         left default
                 </button>
                 <button
                     mc-button
-                    mcArrowPlacement="default"
                     mcTooltip="PDQL-запрос фильтра содержит ошибки, исправьте запрос"
                     mcPlacement="right">
                         right default

--- a/packages/mosaic-dev/tooltip/template.html
+++ b/packages/mosaic-dev/tooltip/template.html
@@ -41,8 +41,8 @@
                     mcPlacement="right">right</button>
             <button
                     mc-button
-                    mcTooltip="PDQL-запрос фильтра содержит ошибки
-                                испральве запрос"
+                    mcTooltip="PDQL-запрос фильтра содержит ошибки,
+                                исправьте запрос"
                     mcPlacement="left">left</button>
             <button
                     mc-button
@@ -60,6 +60,36 @@
                     mcTooltip="Обновить"
                     mcPlacement="bottom"
                     [mcTooltipDisabled]="true">disabled</button>
+        </div>
+        <div class="flex layout-column layout-align-center-center container-item">                <span class="mc-title">Arrow placement for left and right</span>
+                <button
+                    mc-button
+                    mcArrowPlacement="default"
+                    mcTooltip="PDQL-запрос фильтра содержит ошибки, исправьте запрос"
+                    mcPlacement="left">
+                        left default
+                </button>
+                <button
+                    mc-button
+                    mcArrowPlacement="default"
+                    mcTooltip="PDQL-запрос фильтра содержит ошибки, исправьте запрос"
+                    mcPlacement="right">
+                        right default
+                </button>
+                <button
+                    mc-button
+                    mcArrowPlacement="center"
+                    mcTooltip="PDQL-запрос фильтра содержит ошибки, исправьте запрос"
+                    mcPlacement="left">
+                        left center
+                </button>
+                <button
+                    mc-button
+                    mcArrowPlacement="center"
+                    mcTooltip="PDQL-запрос фильтра содержит ошибки, исправьте запрос"
+                    mcPlacement="right">
+                        right center
+                </button>
         </div>
     <div class="flex layout-row layout-align-center-center">
         <div class="flex-45 flex-column">

--- a/packages/mosaic/tooltip/tooltip.component.ts
+++ b/packages/mosaic/tooltip/tooltip.component.ts
@@ -498,14 +498,19 @@ export class McTooltip implements OnInit, OnDestroy {
         if (this.mcPlacement === 'right' || this.mcPlacement === 'left') {
             const halfDelimeter = 2;
             const currentContainerPositionTop = parseInt(this.hostView.element.nativeElement.offsetTop, 10);
-            const currentContainerHeight = this.hostView.element.nativeElement.clientHeight;
-            const tooltipHeight = this.overlayRef.overlayElement.clientHeight;
+            const currentContainerHeightHalfed = this.hostView.element.nativeElement.clientHeight / halfDelimeter;
+            const tooltipHeightHalfed = this.overlayRef.overlayElement.clientHeight / halfDelimeter;
+            const arrowElemRef = this.getTooltipArrowElem();
+
             this.overlayRef.overlayElement.style.top =
                 `${
-                    (currentContainerPositionTop + (currentContainerHeight / halfDelimeter)) - tooltipHeight / halfDelimeter
+                    (currentContainerPositionTop + currentContainerHeightHalfed) - tooltipHeightHalfed
                 }px`;
+
+            if (arrowElemRef) {
+                arrowElemRef.setAttribute('style', `top: ${tooltipHeightHalfed}px`);
+            }
         }
-        // TODO: обновлять положение стрелки\указателя\"дятла"
     }
 
     // tslint:disable-next-line:no-any
@@ -707,5 +712,11 @@ export class McTooltip implements OnInit, OnDestroy {
         }
 
         return { x: newX, y: newY };
+    }
+
+    private getTooltipArrowElem() {
+        const arrowClassName = 'mc-tooltip-arrow';
+
+        return this.overlayRef?.overlayElement.getElementsByClassName(arrowClassName)[0];
     }
 }

--- a/packages/mosaic/tooltip/tooltip.component.ts
+++ b/packages/mosaic/tooltip/tooltip.component.ts
@@ -44,6 +44,11 @@ import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
 
+export enum ArrowPlacements {
+    Center = 'center',
+    Default = 'default'
+}
+
 @Component({
     selector: 'mc-tooltip-component',
     animations: [fadeAnimation],
@@ -108,6 +113,8 @@ export class McTooltipComponent {
         }
     }
 
+    private _mcPlacement: string = 'top';
+
     @Input()
     get mcTooltipClass(): string {
         return this._mcTooltipClass;
@@ -118,7 +125,6 @@ export class McTooltipComponent {
     }
 
     private _mcTooltipClass: string;
-    private _mcPlacement: string = 'top';
 
     @Input()
     get mcVisible(): boolean {
@@ -136,6 +142,17 @@ export class McTooltipComponent {
     }
 
     private _mcVisible: BehaviorSubject<boolean> = new BehaviorSubject<boolean>(false);
+
+    @Input()
+    get mcArrowPlacement(): ArrowPlacements {
+        return this._mcArrowPlacement;
+    }
+
+    set mcArrowPlacement(value: ArrowPlacements) {
+        this._mcArrowPlacement = value;
+    }
+
+    private _mcArrowPlacement: ArrowPlacements = ArrowPlacements.Default;
 
     /** Subject for notifying that the tooltip has been hidden from the view */
     private readonly onHideSubject: Subject<any> = new Subject();
@@ -384,6 +401,17 @@ export class McTooltip implements OnInit, OnDestroy {
 
     private _mcVisible: boolean;
 
+    @Input('mcArrowPlacement')
+    get mcArrowPlacement(): ArrowPlacements {
+        return this._mcArrowPlacement;
+    }
+
+    set mcArrowPlacement(value: ArrowPlacements) {
+        this._mcArrowPlacement = value;
+    }
+
+    private _mcArrowPlacement: ArrowPlacements = ArrowPlacements.Default;
+
     @HostBinding('class.mc-tooltip-open')
     get isOpen(): boolean {
         return this.isTooltipOpen;
@@ -496,19 +524,27 @@ export class McTooltip implements OnInit, OnDestroy {
         }
 
         if (this.mcPlacement === 'right' || this.mcPlacement === 'left') {
-            const halfDelimeter = 2;
-            const currentContainerPositionTop = parseInt(this.hostView.element.nativeElement.offsetTop, 10);
-            const currentContainerHeightHalfed = this.hostView.element.nativeElement.clientHeight / halfDelimeter;
-            const tooltipHeightHalfed = this.overlayRef.overlayElement.clientHeight / halfDelimeter;
-            const arrowElemRef = this.getTooltipArrowElem();
+            if (this.mcArrowPlacement === ArrowPlacements.Center) {
+                const halfDelimeter = 2;
+                const arrowElemRef = this.getTooltipArrowElem();
+                const currentContainerPositionTop = parseInt(this.hostView.element.nativeElement.offsetTop, 10);
+                const currentContainerHeightHalfed = this.hostView.element.nativeElement.clientHeight / halfDelimeter;
+                const tooltipHeightHalfed = this.overlayRef.overlayElement.clientHeight / halfDelimeter;
 
-            this.overlayRef.overlayElement.style.top =
+                this.overlayRef.overlayElement.style.top =
                 `${
                     (currentContainerPositionTop + currentContainerHeightHalfed) - tooltipHeightHalfed
                 }px`;
 
-            if (arrowElemRef) {
-                arrowElemRef.setAttribute('style', `top: ${tooltipHeightHalfed}px`);
+                if (arrowElemRef) {
+                    arrowElemRef.setAttribute('style', `top: ${tooltipHeightHalfed}px`);
+                }
+            } else {
+                const defaultTooltipPlacementTop = parseInt(this.overlayRef.overlayElement.style.top || '0px', 10);
+                this.overlayRef.overlayElement.style.top =
+                `${
+                    defaultTooltipPlacementTop
+                }px`;
             }
         }
     }

--- a/packages/mosaic/tooltip/tooltip.component.ts
+++ b/packages/mosaic/tooltip/tooltip.component.ts
@@ -527,22 +527,20 @@ export class McTooltip implements OnInit, OnDestroy {
         }
 
         if (this.mcPlacement === 'right' || this.mcPlacement === 'left') {
-            if (this.mcArrowPlacement) {
-                if (this.mcArrowPlacement === ArrowPlacements.Center) {
-                    const halfDelimeter = 2;
-                    const arrowElemRef = this.getTooltipArrowElem();
-                    const currentContainerPositionTop = parseInt(this.hostView.element.nativeElement.offsetTop, 10);
-                    const currentContainerHeightHalfed =
-                        this.hostView.element.nativeElement.clientHeight / halfDelimeter;
-                    const tooltipHeightHalfed = this.overlayRef.overlayElement.clientHeight / halfDelimeter;
+            if (this.mcArrowPlacement === ArrowPlacements.Center) {
+                const halfDelimeter = 2;
+                const arrowElemRef = this.getTooltipArrowElem();
+                const currentContainerPositionTop = parseInt(this.hostView.element.nativeElement.offsetTop, 10);
+                const currentContainerHeightHalfed =
+                    this.hostView.element.nativeElement.clientHeight / halfDelimeter;
+                const tooltipHeightHalfed = this.overlayRef.overlayElement.clientHeight / halfDelimeter;
 
-                    this.overlayRef.overlayElement.style.top = `${
-                        (currentContainerPositionTop + currentContainerHeightHalfed) - tooltipHeightHalfed
-                    }px`;
+                this.overlayRef.overlayElement.style.top = `${
+                    (currentContainerPositionTop + currentContainerHeightHalfed) - tooltipHeightHalfed
+                }px`;
 
-                    if (arrowElemRef) {
-                        arrowElemRef.setAttribute('style', `top: ${tooltipHeightHalfed}px`);
-                    }
+                if (arrowElemRef) {
+                    arrowElemRef.setAttribute('style', `top: ${tooltipHeightHalfed}px`);
                 }
             } else {
                 const defaultTooltipPlacementTop = parseInt(this.overlayRef.overlayElement.style.top || '0px', 10);

--- a/packages/mosaic/tooltip/tooltip.component.ts
+++ b/packages/mosaic/tooltip/tooltip.component.ts
@@ -496,14 +496,16 @@ export class McTooltip implements OnInit, OnDestroy {
         }
 
         if (this.mcPlacement === 'right' || this.mcPlacement === 'left') {
-            const pos =
-                (this.overlayRef.overlayElement.clientHeight -
-                    this.hostView.element.nativeElement.clientHeight) / 2; // tslint:disable-line
-            const currentContainer = this.overlayRef.overlayElement.style.top || '0px';
+            const halfDelimeter = 2;
+            const currentContainerPositionTop = parseInt(this.hostView.element.nativeElement.offsetTop, 10);
+            const currentContainerHeight = this.hostView.element.nativeElement.clientHeight;
+            const tooltipHeight = this.overlayRef.overlayElement.clientHeight;
             this.overlayRef.overlayElement.style.top =
-                `${parseInt(currentContainer.split('px')[0], 10) + pos - 1}px`;
-            // TODO: обновлять положение стрелки\указателя\"дятла"
+                `${
+                    (currentContainerPositionTop + (currentContainerHeight / halfDelimeter)) - tooltipHeight / halfDelimeter
+                }px`;
         }
+        // TODO: обновлять положение стрелки\указателя\"дятла"
     }
 
     // tslint:disable-next-line:no-any

--- a/packages/mosaic/tooltip/tooltip.component.ts
+++ b/packages/mosaic/tooltip/tooltip.component.ts
@@ -538,11 +538,11 @@ export class McTooltip implements OnInit, OnDestroy {
                 const tooltipHeightHalfed = overlayElemHeight / halfDelimeter;
 
                 this.overlayRef.overlayElement.style.top = `${
-                    (currentContainerPositionTop + currentContainerHeightHalfed) - tooltipHeightHalfed
+                    (currentContainerPositionTop + currentContainerHeightHalfed) - tooltipHeightHalfed + 1
                 }px`;
 
                 if (arrowElemRef) {
-                    arrowElemRef.setAttribute('style', `top: ${tooltipHeightHalfed}px`);
+                    arrowElemRef.setAttribute('style', `top: ${tooltipHeightHalfed - 1}px`);
                 }
             } else {
                 const pos = (overlayElemHeight - currentContainerHeight) / halfDelimeter;
@@ -594,7 +594,7 @@ export class McTooltip implements OnInit, OnDestroy {
         if (this.mcTrigger === 'hover') {
             this.manualListeners
                 .set('mouseenter', () => this.show())
-                .set('mouseleave', () => this.hide())
+                // .set('mouseleave', () => this.hide())
                 .forEach((listener, event) => this.elementRef.nativeElement.addEventListener(event, listener));
         }
 

--- a/packages/mosaic/tooltip/tooltip.component.ts
+++ b/packages/mosaic/tooltip/tooltip.component.ts
@@ -44,7 +44,13 @@ import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
 
-export type ArrowPlacements = 'default' | VerticalConnectionPos;
+export enum ArrowPlacements {
+    Top = 'top',
+    Center = 'center',
+    Bottom = 'bottom',
+    Right = 'right',
+    Left = 'left'
+}
 
 @Component({
     selector: 'mc-tooltip-component',
@@ -149,7 +155,7 @@ export class McTooltipComponent {
         this._mcArrowPlacement = value;
     }
 
-    private _mcArrowPlacement: ArrowPlacements = 'default';
+    private _mcArrowPlacement: ArrowPlacements;
 
     /** Subject for notifying that the tooltip has been hidden from the view */
     private readonly onHideSubject: Subject<any> = new Subject();
@@ -407,7 +413,7 @@ export class McTooltip implements OnInit, OnDestroy {
         this._mcArrowPlacement = value;
     }
 
-    private _mcArrowPlacement: ArrowPlacements = 'default';
+    private _mcArrowPlacement: ArrowPlacements;
 
     @HostBinding('class.mc-tooltip-open')
     get isOpen(): boolean {
@@ -521,19 +527,22 @@ export class McTooltip implements OnInit, OnDestroy {
         }
 
         if (this.mcPlacement === 'right' || this.mcPlacement === 'left') {
-            if (this.mcArrowPlacement === 'center') {
-                const halfDelimeter = 2;
-                const arrowElemRef = this.getTooltipArrowElem();
-                const currentContainerPositionTop = parseInt(this.hostView.element.nativeElement.offsetTop, 10);
-                const currentContainerHeightHalfed = this.hostView.element.nativeElement.clientHeight / halfDelimeter;
-                const tooltipHeightHalfed = this.overlayRef.overlayElement.clientHeight / halfDelimeter;
+            if (this.mcArrowPlacement) {
+                if (this.mcArrowPlacement === ArrowPlacements.Center) {
+                    const halfDelimeter = 2;
+                    const arrowElemRef = this.getTooltipArrowElem();
+                    const currentContainerPositionTop = parseInt(this.hostView.element.nativeElement.offsetTop, 10);
+                    const currentContainerHeightHalfed =
+                        this.hostView.element.nativeElement.clientHeight / halfDelimeter;
+                    const tooltipHeightHalfed = this.overlayRef.overlayElement.clientHeight / halfDelimeter;
 
-                this.overlayRef.overlayElement.style.top = `${
-                    (currentContainerPositionTop + currentContainerHeightHalfed) - tooltipHeightHalfed
-                }px`;
+                    this.overlayRef.overlayElement.style.top = `${
+                        (currentContainerPositionTop + currentContainerHeightHalfed) - tooltipHeightHalfed
+                    }px`;
 
-                if (arrowElemRef) {
-                    arrowElemRef.setAttribute('style', `top: ${tooltipHeightHalfed}px`);
+                    if (arrowElemRef) {
+                        arrowElemRef.setAttribute('style', `top: ${tooltipHeightHalfed}px`);
+                    }
                 }
             } else {
                 const defaultTooltipPlacementTop = parseInt(this.overlayRef.overlayElement.style.top || '0px', 10);

--- a/packages/mosaic/tooltip/tooltip.component.ts
+++ b/packages/mosaic/tooltip/tooltip.component.ts
@@ -527,13 +527,15 @@ export class McTooltip implements OnInit, OnDestroy {
         }
 
         if (this.mcPlacement === 'right' || this.mcPlacement === 'left') {
+            const halfDelimeter = 2;
+            const overlayElemHeight = this.overlayRef.overlayElement.clientHeight;
+            const currentContainerHeight = this.hostView.element.nativeElement.clientHeight;
+
             if (this.mcArrowPlacement === ArrowPlacements.Center) {
-                const halfDelimeter = 2;
                 const arrowElemRef = this.getTooltipArrowElem();
                 const currentContainerPositionTop = parseInt(this.hostView.element.nativeElement.offsetTop, 10);
-                const currentContainerHeightHalfed =
-                    this.hostView.element.nativeElement.clientHeight / halfDelimeter;
-                const tooltipHeightHalfed = this.overlayRef.overlayElement.clientHeight / halfDelimeter;
+                const currentContainerHeightHalfed = currentContainerHeight / halfDelimeter;
+                const tooltipHeightHalfed = overlayElemHeight / halfDelimeter;
 
                 this.overlayRef.overlayElement.style.top = `${
                     (currentContainerPositionTop + currentContainerHeightHalfed) - tooltipHeightHalfed
@@ -543,8 +545,10 @@ export class McTooltip implements OnInit, OnDestroy {
                     arrowElemRef.setAttribute('style', `top: ${tooltipHeightHalfed}px`);
                 }
             } else {
+                const pos = (overlayElemHeight - currentContainerHeight) / halfDelimeter;
                 const defaultTooltipPlacementTop = parseInt(this.overlayRef.overlayElement.style.top || '0px', 10);
-                this.overlayRef.overlayElement.style.top = `${defaultTooltipPlacementTop}px`;
+
+                this.overlayRef.overlayElement.style.top = `${defaultTooltipPlacementTop + pos - 1}px`;
             }
         }
     }

--- a/packages/mosaic/tooltip/tooltip.component.ts
+++ b/packages/mosaic/tooltip/tooltip.component.ts
@@ -44,10 +44,7 @@ import { BehaviorSubject, Observable, Subject } from 'rxjs';
 import { distinctUntilChanged, takeUntil } from 'rxjs/operators';
 
 
-export enum ArrowPlacements {
-    Center = 'center',
-    Default = 'default'
-}
+export type ArrowPlacements = 'default' | VerticalConnectionPos;
 
 @Component({
     selector: 'mc-tooltip-component',
@@ -152,7 +149,7 @@ export class McTooltipComponent {
         this._mcArrowPlacement = value;
     }
 
-    private _mcArrowPlacement: ArrowPlacements = ArrowPlacements.Default;
+    private _mcArrowPlacement: ArrowPlacements = 'default';
 
     /** Subject for notifying that the tooltip has been hidden from the view */
     private readonly onHideSubject: Subject<any> = new Subject();
@@ -410,7 +407,7 @@ export class McTooltip implements OnInit, OnDestroy {
         this._mcArrowPlacement = value;
     }
 
-    private _mcArrowPlacement: ArrowPlacements = ArrowPlacements.Default;
+    private _mcArrowPlacement: ArrowPlacements = 'default';
 
     @HostBinding('class.mc-tooltip-open')
     get isOpen(): boolean {
@@ -524,15 +521,14 @@ export class McTooltip implements OnInit, OnDestroy {
         }
 
         if (this.mcPlacement === 'right' || this.mcPlacement === 'left') {
-            if (this.mcArrowPlacement === ArrowPlacements.Center) {
+            if (this.mcArrowPlacement === 'center') {
                 const halfDelimeter = 2;
                 const arrowElemRef = this.getTooltipArrowElem();
                 const currentContainerPositionTop = parseInt(this.hostView.element.nativeElement.offsetTop, 10);
                 const currentContainerHeightHalfed = this.hostView.element.nativeElement.clientHeight / halfDelimeter;
                 const tooltipHeightHalfed = this.overlayRef.overlayElement.clientHeight / halfDelimeter;
 
-                this.overlayRef.overlayElement.style.top =
-                `${
+                this.overlayRef.overlayElement.style.top = `${
                     (currentContainerPositionTop + currentContainerHeightHalfed) - tooltipHeightHalfed
                 }px`;
 
@@ -541,10 +537,7 @@ export class McTooltip implements OnInit, OnDestroy {
                 }
             } else {
                 const defaultTooltipPlacementTop = parseInt(this.overlayRef.overlayElement.style.top || '0px', 10);
-                this.overlayRef.overlayElement.style.top =
-                `${
-                    defaultTooltipPlacementTop
-                }px`;
+                this.overlayRef.overlayElement.style.top = `${defaultTooltipPlacementTop}px`;
             }
         }
     }

--- a/packages/mosaic/tooltip/tooltip.scss
+++ b/packages/mosaic/tooltip/tooltip.scss
@@ -70,13 +70,11 @@ $tooltip-distance: $tooltip-arrow-width + 4px;
 
 .mc-tooltip_placement-right .mc-tooltip-arrow {
     left: $tooltip-distance - $tooltip-arrow-width;
-    top: 16px;
     margin-top: -$tooltip-arrow-width;
 }
 
 .mc-tooltip_placement-left .mc-tooltip-arrow {
     right: $tooltip-distance - $tooltip-arrow-width;
-    top: 16px;
     margin-top: -$tooltip-arrow-width;
 }
 

--- a/packages/mosaic/tooltip/tooltip.scss
+++ b/packages/mosaic/tooltip/tooltip.scss
@@ -70,11 +70,13 @@ $tooltip-distance: $tooltip-arrow-width + 4px;
 
 .mc-tooltip_placement-right .mc-tooltip-arrow {
     left: $tooltip-distance - $tooltip-arrow-width;
+    top: 16px;
     margin-top: -$tooltip-arrow-width;
 }
 
 .mc-tooltip_placement-left .mc-tooltip-arrow {
     right: $tooltip-distance - $tooltip-arrow-width;
+    top: 16px;
     margin-top: -$tooltip-arrow-width;
 }
 


### PR DESCRIPTION
There is an issue with this pr. When the height of tooltip is bigger than the height of the host element it looks quiet bad. This happens because the positioning of the arrow is [hardcoded at the moment](https://github.com/positive-js/mosaic/blob/a5e64ffb54aea3e8136fedc18ecb2d4bc63d939f/packages/mosaic/tooltip/tooltip.scss#L71).

![pr](https://user-images.githubusercontent.com/13451179/97022029-4d1f3f00-155c-11eb-8206-a20a755cf73c.jpg)
