### PR TITLE
fix(docs): Autocomplete with active search - selection incorrect (#UIM-518)

### DIFF
--- a/packages/mosaic-examples/mosaic/tags/tags-autocomplete/tags-autocomplete-example.html
+++ b/packages/mosaic-examples/mosaic/tags/tags-autocomplete/tags-autocomplete-example.html
@@ -9,7 +9,9 @@
                [formControl]="control"
                [mcAutocomplete]="autocomplete"
                [mcTagInputFor]="tagList"
-               (mcTagInputTokenEnd)="onCreate($event)">
+               (mcTagInputTokenEnd)="onCreate($event)"
+               [mcTagInputAddOnBlur]="false"
+               (blur)="addOnBlurFunc($event)">
     </mc-tag-list>
     <mc-autocomplete #autocomplete (optionSelected)="onSelect($event)">
         <mc-option *ngIf="tagInput.value" [value]="{ new: true, value: tagInput.value }">

--- a/packages/mosaic-examples/mosaic/tags/tags-autocomplete/tags-autocomplete-example.ts
+++ b/packages/mosaic-examples/mosaic/tags/tags-autocomplete/tags-autocomplete-example.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, ViewChild } from '@angular/core';
 import { FormControl } from '@angular/forms';
-import { McAutocompleteSelectedEvent } from '@ptsecurity/mosaic/autocomplete';
+import { McAutocomplete, McAutocompleteSelectedEvent } from '@ptsecurity/mosaic/autocomplete';
 import { McTagInputEvent, McTagList } from '@ptsecurity/mosaic/tags';
 import { merge } from 'rxjs';
 import { map } from 'rxjs/operators';
@@ -17,6 +17,7 @@ import { map } from 'rxjs/operators';
 export class TagsAutocompleteExample {
     @ViewChild('tagList', { static: false }) tagList: McTagList;
     @ViewChild('tagInput', { static: false }) tagInput: ElementRef<HTMLInputElement>;
+    @ViewChild('autocomplete', { static: false }) autocomplete: McAutocomplete;
 
     control = new FormControl();
 
@@ -49,20 +50,40 @@ export class TagsAutocompleteExample {
         );
     }
 
+    addOnBlurFunc(event: FocusEvent) {
+        const target: HTMLElement = event.relatedTarget as HTMLElement;
+
+        if (!target || target.tagName !== 'MC-OPTION') {
+            const mcTagEvent: McTagInputEvent = {
+                input: this.tagInput.nativeElement,
+                value : this.tagInput.nativeElement.value
+            };
+
+            this.onCreate(mcTagEvent);
+        }
+    }
+
     onCreate(event: McTagInputEvent): void {
         const input = event.input;
         const value = event.value;
 
         if ((value || '').trim()) {
-            this.selectedTags.push(value.trim());
+            const isOptionSelected = this.autocomplete.options.some((option) => option.selected);
+            if (!isOptionSelected) {
+                this.selectedTags.push(value.trim());
+            }
         }
 
         if (input) {
             input.value = '';
         }
+
+        this.control.setValue(null);
     }
 
     onSelect(event: McAutocompleteSelectedEvent): void {
+        event.option.deselect();
+
         if (event.option.value.new) {
             this.selectedTags.push(event.option.value.value);
         } else {


### PR DESCRIPTION
Как оказалось это из-за создания тега по onBlur и ранее в дев пример был добавлен способ для обхода подобного поведения.
В итоге поправил пример в доках, но из-за невозможности собрать и запустить документацию не смог проверить.