### PR TITLE
fix(datepicker): Line-height changes (#UIM-399)

### DIFF
--- a/packages/mosaic/datepicker/_datepicker-theme.scss
+++ b/packages/mosaic/datepicker/_datepicker-theme.scss
@@ -141,6 +141,7 @@ $mc-datepicker-today-fade-amount: 0.2;
             size: mc-font-size($config, caption);
             weight: mc-font-weight($config, body);
         }
+        line-height: mc-font-size($config, caption);
     }
 
     .mc-calendar__body-today {


### PR DESCRIPTION
В стилях календаря используется стили body для line-height и при определении типографики в проекте верстка ломается.