### PR TITLE
fix: input padding without class stepper (#UIM-552)

### DIFF
--- a/packages/mosaic/form-field/form-field.ts
+++ b/packages/mosaic/form-field/form-field.ts
@@ -133,7 +133,7 @@ export class McFormField extends McFormFieldMixinBase implements
     }
 
     get canShowStepper(): boolean {
-        return this.control && !this.disabled && (this.control.focused || this.hovered);
+        return this.hasStepper && !this.disabled && (this.control.focused || this.hovered);
     }
 
     // tslint:disable-next-line:naming-convention


### PR DESCRIPTION
Ошибка : При наведении или фокусе контрола добавляется класс mc-form-field_has-stepper, хотя контрола mc-stepper в разметке отсутствует.
Добавлена проверка на наличие класса mc-stepper