### PR TITLE
feat(modal): implementation by guideline hotkey ctrl+enter (#UIM-441)

### DIFF
--- a/packages/mosaic-dev/modal/module.ts
+++ b/packages/mosaic-dev/modal/module.ts
@@ -85,6 +85,7 @@ export class ModalDemoComponent {
             mcFooter: [{
                 label: 'button 1',
                 type: 'primary',
+                mcModalMainAction: true,
                 loading: () => isLoading,
                 onClick: (componentInstance: any) => {
                     componentInstance.title = 'title in inner component is changed';

--- a/packages/mosaic-dev/modal/template.html
+++ b/packages/mosaic-dev/modal/template.html
@@ -19,7 +19,7 @@
     <p>some contents...</p>
 </ng-template>
 <ng-template #tplFooter>
-    <button mc-button color="primary" (click)="destroyTplModal()">Close after submit</button>
+    <button mc-button mc-modal-main-action color="primary" (click)="destroyTplModal()">Close after submit</button>
 </ng-template>
 
 <p class="mc-headline">Modal with custom component</p>

--- a/packages/mosaic/modal/modal.component.html
+++ b/packages/mosaic/modal/modal.component.html
@@ -88,6 +88,7 @@
                         mc-button
                         #autoFocusedButton
                         [attr.autofocus]="button.autoFocus"
+                        [attr.mc-modal-main-action]="button.mcModalMainAction"
                         *ngIf="getButtonCallableProp(button, 'show')"
                         [disabled]="getButtonCallableProp(button, 'disabled')"
                         [class.mc-progress]="getButtonCallableProp(button, 'loading')"

--- a/packages/mosaic/modal/modal.component.ts
+++ b/packages/mosaic/modal/modal.component.ts
@@ -218,6 +218,7 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
         if (this.contentComponentRef) {
             this.bodyContainer.insert(this.contentComponentRef.hostView);
         }
+        this.getElement().getElementsByTagName('button')[0]?.focus();
 
         for (const autoFocusedButton of this.autoFocusedButtons.toArray()) {
             if (autoFocusedButton.nativeElement.autofocus) {
@@ -226,20 +227,7 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
                 break;
             }
         }
-        const footer = this.getMcFooter();
-        if (footer) {
-            const buttons = Array.from(footer.getElementsByTagName('button'));
-            if (buttons) {
-                const primaryBtn = buttons.find((item) => item.className.indexOf('mc-primary') !== -1);
-                if (primaryBtn) {
-                    primaryBtn.focus();
-                } else {
-                    buttons[0].focus();
-                }
-            }
-        } else {
-            this.getElement().getElementsByTagName('button')[0]?.focus();
-        }
+
     }
 
     ngOnDestroy() {
@@ -289,7 +277,7 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
         return this.elementRef && this.elementRef.nativeElement;
     }
 
-    getMcFooter(): HTMLElement | null {
+    getMcFooter(): HTMLElement {
         return this.getElement().getElementsByClassName('mc-modal-footer').item(0) as HTMLElement;
     }
 
@@ -319,37 +307,19 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
         }
         // tslint:disable-next-line:deprecation .key isn't supported in Edge
         if (event.ctrlKey && event.keyCode === ENTER) {
-            if (this.mcFooter) {
-                if (this.isModalButtons(this.mcFooter)) {
-                    const mcFooter = this.mcFooter as IModalButtonOptions<T>[];
-                    if (mcFooter.length === 1) {
-                        this.onButtonClick(mcFooter[0]);
-                    } else {
-                        const btnPrimary = mcFooter.find((item) => item.type === 'primary');
-                        if (btnPrimary) {
-                            this.onButtonClick(btnPrimary);
-                        }
-                    }
-                }
-                if (this.isTemplateRef(this.mcFooter) || this.isNonEmptyString(this.mcFooter)) {
-                    const footer = this.getMcFooter();
-                    if (footer) {
-                        const buttons = Array.from(footer.getElementsByTagName('button'));
-                        if (buttons.length === 1) {
-                            buttons[0].click();
-                        } else {
-                            const button = buttons.find(
-                                (item) => item.className.indexOf('mc-primary') !== -1
-                            );
-                            if (button) {
-                                button.click();
-                            }
-                        }
-                    }
-                }
+            if (this.mcModalType === 'confirm') {
                 this.triggerOk();
+            }
+            if (this.isModalButtons(this.mcFooter)) {
+                const mcFooter = this.mcFooter as IModalButtonOptions<T>[];
+                const modalMainAction = mcFooter.find(
+                    (item) => item.mcModalMainAction
+                );
+                if (modalMainAction) {
+                    this.onButtonClick(modalMainAction);
+                }
             } else {
-                this.close();
+                (this.getElement().querySelector('[mc-modal-main-action]') as HTMLElement)?.click();
             }
             event.preventDefault();
         }

--- a/packages/mosaic/modal/modal.component.ts
+++ b/packages/mosaic/modal/modal.component.ts
@@ -227,11 +227,11 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
             }
         }
         const footer = this.getMcFooter();
-        if (footer){
+        if (footer) {
             const buttons = Array.from(footer.getElementsByTagName('button'));
             if (buttons) {
                 const primaryBtn = buttons.find((item) => item.className.indexOf('mc-primary') !== -1);
-                if (primaryBtn){
+                if (primaryBtn) {
                     primaryBtn.focus();
                 } else {
                     buttons[0].focus();
@@ -317,11 +317,12 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
             this.close();
             event.preventDefault();
         }
+        // tslint:disable-next-line:deprecation .key isn't supported in Edge
         if (event.ctrlKey && event.keyCode === ENTER) {
-            if (this.mcFooter){
+            if (this.mcFooter) {
                 if (this.isModalButtons(this.mcFooter)) {
                     const mcFooter = this.mcFooter as IModalButtonOptions<T>[];
-                    if (mcFooter.length === 1){
+                    if (mcFooter.length === 1) {
                         this.onButtonClick(mcFooter[0]);
                     } else {
                         const btnPrimary = mcFooter.find((item) => item.type === 'primary');
@@ -340,7 +341,7 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
                             const button = buttons.find(
                                 (item) => item.className.indexOf('mc-primary') !== -1
                             );
-                            if (button){
+                            if (button) {
                                 button.click();
                             }
                         }

--- a/packages/mosaic/modal/modal.component.ts
+++ b/packages/mosaic/modal/modal.component.ts
@@ -310,17 +310,9 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
             if (this.mcModalType === 'confirm') {
                 this.triggerOk();
             }
-            if (this.isModalButtons(this.mcFooter)) {
-                const mcFooter = this.mcFooter as IModalButtonOptions<T>[];
-                const modalMainAction = mcFooter.find(
-                    (item) => item.mcModalMainAction
-                );
-                if (modalMainAction) {
-                    this.onButtonClick(modalMainAction);
-                }
-            } else {
-                (this.getElement().querySelector('[mc-modal-main-action]') as HTMLElement)?.click();
-            }
+
+            (this.getElement().querySelector('[mc-modal-main-action]') as HTMLElement)?.click();
+
             event.preventDefault();
         }
     }

--- a/packages/mosaic/modal/modal.component.ts
+++ b/packages/mosaic/modal/modal.component.ts
@@ -23,7 +23,7 @@ import {
     ViewChildren,
     ViewContainerRef, ViewEncapsulation
 } from '@angular/core';
-import { ESCAPE } from '@ptsecurity/cdk/keycodes';
+import { ESCAPE, ENTER } from '@ptsecurity/cdk/keycodes';
 import { Observable } from 'rxjs';
 
 import { McModalControlService } from './modal-control.service';
@@ -226,6 +226,20 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
                 break;
             }
         }
+        const footer = this.getMcFooter();
+        if (footer){
+            const buttons = Array.from(footer.getElementsByTagName('button'));
+            if (buttons) {
+                const primaryBtn = buttons.find((item) => item.className.indexOf('mc-primary') !== -1);
+                if (primaryBtn){
+                    primaryBtn.focus();
+                } else {
+                    buttons[0].focus();
+                }
+            }
+        } else {
+            this.getElement().getElementsByTagName('button')[0]?.focus();
+        }
     }
 
     ngOnDestroy() {
@@ -275,6 +289,10 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
         return this.elementRef && this.elementRef.nativeElement;
     }
 
+    getMcFooter(): HTMLElement | null {
+        return this.getElement().getElementsByClassName('mc-modal-footer').item(0) as HTMLElement;
+    }
+
     onClickMask($event: MouseEvent) {
         if (
             this.mcMask &&
@@ -297,6 +315,41 @@ export class McModalComponent<T = any, R = any> extends McModalRef<T, R>
         if (event.keyCode === ESCAPE && this.container && (this.container instanceof OverlayRef)) {
 
             this.close();
+            event.preventDefault();
+        }
+        if (event.ctrlKey && event.keyCode === ENTER) {
+            if (this.mcFooter){
+                if (this.isModalButtons(this.mcFooter)) {
+                    const mcFooter = this.mcFooter as IModalButtonOptions<T>[];
+                    if (mcFooter.length === 1){
+                        this.onButtonClick(mcFooter[0]);
+                    } else {
+                        const btnPrimary = mcFooter.find((item) => item.type === 'primary');
+                        if (btnPrimary) {
+                            this.onButtonClick(btnPrimary);
+                        }
+                    }
+                }
+                if (this.isTemplateRef(this.mcFooter) || this.isNonEmptyString(this.mcFooter)) {
+                    const footer = this.getMcFooter();
+                    if (footer) {
+                        const buttons = Array.from(footer.getElementsByTagName('button'));
+                        if (buttons.length === 1) {
+                            buttons[0].click();
+                        } else {
+                            const button = buttons.find(
+                                (item) => item.className.indexOf('mc-primary') !== -1
+                            );
+                            if (button){
+                                button.click();
+                            }
+                        }
+                    }
+                }
+                this.triggerOk();
+            } else {
+                this.close();
+            }
             event.preventDefault();
         }
     }

--- a/packages/mosaic/modal/modal.directive.ts
+++ b/packages/mosaic/modal/modal.directive.ts
@@ -24,3 +24,9 @@ export class McModalBody {}
     }
 })
 export class McModalFooter {}
+
+@Directive({
+    selector: `[mc-modal-main-action], mc-modal-main-action`
+})
+export class McModalMainAction {
+}

--- a/packages/mosaic/modal/modal.directive.ts
+++ b/packages/mosaic/modal/modal.directive.ts
@@ -1,4 +1,4 @@
-import {Directive} from '@angular/core';
+import { Directive } from '@angular/core';
 
 
 @Directive({
@@ -28,5 +28,4 @@ export class McModalFooter {}
 @Directive({
     selector: `[mc-modal-main-action]`
 })
-export class McModalMainAction {
-}
+export class McModalMainAction {}

--- a/packages/mosaic/modal/modal.directive.ts
+++ b/packages/mosaic/modal/modal.directive.ts
@@ -1,4 +1,4 @@
-import { Directive } from '@angular/core';
+import {Directive} from '@angular/core';
 
 
 @Directive({
@@ -26,7 +26,7 @@ export class McModalBody {}
 export class McModalFooter {}
 
 @Directive({
-    selector: `[mc-modal-main-action], mc-modal-main-action`
+    selector: `[mc-modal-main-action]`
 })
 export class McModalMainAction {
 }

--- a/packages/mosaic/modal/modal.module.ts
+++ b/packages/mosaic/modal/modal.module.ts
@@ -8,7 +8,7 @@ import { McIconModule } from '@ptsecurity/mosaic/icon';
 import { CssUnitPipe } from './css-unit.pipe';
 import { McModalControlService } from './modal-control.service';
 import { McModalComponent } from './modal.component';
-import { McModalBody, McModalFooter, McModalTitle } from './modal.directive';
+import { McModalBody, McModalFooter, McModalTitle, McModalMainAction } from './modal.directive';
 import { McModalService } from './modal.service';
 
 
@@ -25,7 +25,8 @@ import { McModalService } from './modal.service';
         McModalTitle,
         McModalBody,
         McModalFooter,
-        CssUnitPipe
+        CssUnitPipe,
+        McModalMainAction
     ],
     entryComponents: [McModalComponent],
     providers: [McModalControlService, McModalService]

--- a/packages/mosaic/modal/modal.spec.ts
+++ b/packages/mosaic/modal/modal.spec.ts
@@ -1,14 +1,13 @@
 import { OverlayContainer } from '@angular/cdk/overlay';
 import { Component, EventEmitter, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, inject, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { ENTER } from '@ptsecurity/cdk/keycodes';
 import { McButtonModule } from '@ptsecurity/mosaic/button';
 
 import { McModalControlService } from './modal-control.service';
 import { McModalRef } from './modal-ref.class';
 import { McModalModule } from './modal.module';
 import { McModalService } from './modal.service';
-//import {createKeyboardEvent} from "@ptsecurity/cdk/testing";
-import { ENTER} from "@ptsecurity/cdk/keycodes";
 
 
 // tslint:disable:no-magic-numbers
@@ -255,12 +254,13 @@ describe('McModal', () => {
             expect(modalRef.getElement().querySelectorAll('[disabled]').length).toBe(1);
         }));
 
-        it('should called function on hotkey ctrl+enter. mcFooter is array ', () => {
+        it('should called function on hotkey ctrl+enter. mcFooter is array ', fakeAsync(() => {
             const spyOk = jasmine.createSpy('ok spy');
             const modalRef = modalService.create({
+                mcContent: TestModalContentComponent,
                 mcFooter: [
                     {
-                        label: 'button 1',
+                        label: 'Test label',
                         type: 'primary',
                         mcModalMainAction: true,
                         onClick: spyOk
@@ -268,6 +268,7 @@ describe('McModal', () => {
                 ]
             });
             fixture.detectChanges();
+            tick(600);
 
             const event = document.createEvent('KeyboardEvent') as any;
             event.initKeyboardEvent('keydown', true, true, window, 0, 0, 0, '', false);
@@ -280,8 +281,9 @@ describe('McModal', () => {
             modalRef.getElement().dispatchEvent(event);
 
             fixture.detectChanges();
+            tick(600);
             expect(spyOk).toHaveBeenCalled();
-        })
+        }));
 
         it('should called function on hotkey ctrl+enter. modal type is confirm ', () => {
             const spyOk = jasmine.createSpy('ok spy');
@@ -305,7 +307,7 @@ describe('McModal', () => {
 
             fixture.detectChanges();
             expect(spyOk).toHaveBeenCalled();
-        })
+        });
 
     });
 });

--- a/packages/mosaic/modal/modal.spec.ts
+++ b/packages/mosaic/modal/modal.spec.ts
@@ -7,6 +7,8 @@ import { McModalControlService } from './modal-control.service';
 import { McModalRef } from './modal-ref.class';
 import { McModalModule } from './modal.module';
 import { McModalService } from './modal.service';
+//import {createKeyboardEvent} from "@ptsecurity/cdk/testing";
+import { ENTER} from "@ptsecurity/cdk/keycodes";
 
 
 // tslint:disable:no-magic-numbers
@@ -252,6 +254,59 @@ describe('McModal', () => {
 
             expect(modalRef.getElement().querySelectorAll('[disabled]').length).toBe(1);
         }));
+
+        it('should called function on hotkey ctrl+enter. mcFooter is array ', () => {
+            const spyOk = jasmine.createSpy('ok spy');
+            const modalRef = modalService.create({
+                mcFooter: [
+                    {
+                        label: 'button 1',
+                        type: 'primary',
+                        mcModalMainAction: true,
+                        onClick: spyOk
+                    }
+                ]
+            });
+            fixture.detectChanges();
+
+            const event = document.createEvent('KeyboardEvent') as any;
+            event.initKeyboardEvent('keydown', true, true, window, 0, 0, 0, '', false);
+
+            Object.defineProperties(event, {
+                keyCode: { get: () => ENTER },
+                ctrlKey: { get: () => true }
+            });
+
+            modalRef.getElement().dispatchEvent(event);
+
+            fixture.detectChanges();
+            expect(spyOk).toHaveBeenCalled();
+        })
+
+        it('should called function on hotkey ctrl+enter. modal type is confirm ', () => {
+            const spyOk = jasmine.createSpy('ok spy');
+            const modalRef = modalService.success({
+                mcContent   : 'Сохранить сделанные изменения?',
+                mcOkText    : 'Сохранить',
+                mcCancelText: 'Отмена',
+                mcOnOk      : spyOk
+            });
+            fixture.detectChanges();
+
+            const event = document.createEvent('KeyboardEvent') as any;
+            event.initKeyboardEvent('keydown', true, true, window, 0, 0, 0, '', false);
+
+            Object.defineProperties(event, {
+                keyCode: { get: () => ENTER },
+                ctrlKey: { get: () => true }
+            });
+
+            modalRef.getElement().dispatchEvent(event);
+
+            fixture.detectChanges();
+            expect(spyOk).toHaveBeenCalled();
+        })
+
     });
 });
 

--- a/packages/mosaic/modal/modal.type.ts
+++ b/packages/mosaic/modal/modal.type.ts
@@ -66,6 +66,7 @@ export interface IModalButtonOptions<T = any> {
     disabled?: boolean | ((this: IModalButtonOptions<T>, contentComponentInstance?: T) => boolean);
 
     autoFocus?: boolean;
+    mcModalMainAction?: boolean;
 
     onClick?(this: IModalButtonOptions<T>, contentComponentInstance?: T): (void | {}) | Promise<(void | {})>;
 }


### PR DESCRIPTION
Добавлено выполнение основного действия модального окна по Ctrl+Enter.

Основное действие — primary- или единственная кнопка в футере. Если нет футера, то действие «Закрыть».

Также при открытии модального окна добавлен фокус на primary- или первой кнопке в футере. Если футера нет, то на первой найденной кнопке (Крестик)

Фокус на модальном окне необходим, чтобы срабатывало действие по Ctrl+Enter