### PR TITLE
feat(autocomplete): Added ability to not show dropdown on focus (#UIM-616)

### DIFF
--- a/packages/mosaic/autocomplete/autocomplete-trigger.directive.ts
+++ b/packages/mosaic/autocomplete/autocomplete-trigger.directive.ts
@@ -379,7 +379,7 @@ export class McAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
     handleFocus(): void {
         if (!this.canOpenOnNextFocus) {
             this.canOpenOnNextFocus = true;
-        } else if (this.canOpen() && this.autocomplete.autoOpenOnFocus) {
+        } else if (this.canOpen() && this.autocomplete.openOnFocus) {
             this.previousValue = this.elementRef.nativeElement.value;
             this.attachOverlay();
         }

--- a/packages/mosaic/autocomplete/autocomplete-trigger.directive.ts
+++ b/packages/mosaic/autocomplete/autocomplete-trigger.directive.ts
@@ -379,7 +379,7 @@ export class McAutocompleteTrigger implements ControlValueAccessor, OnDestroy {
     handleFocus(): void {
         if (!this.canOpenOnNextFocus) {
             this.canOpenOnNextFocus = true;
-        } else if (this.canOpen()) {
+        } else if (this.canOpen() && this.autocomplete.autoOpenOnFocus) {
             this.previousValue = this.elementRef.nativeElement.value;
             this.attachOverlay();
         }

--- a/packages/mosaic/autocomplete/autocomplete.component.ts
+++ b/packages/mosaic/autocomplete/autocomplete.component.ts
@@ -145,6 +145,17 @@ export class McAutocomplete implements AfterContentInit {
 
     private _isOpen: boolean = false;
 
+    @Input()
+    get autoOpenOnFocus(): boolean {
+        return this._autoOpenOnFocus;
+    }
+
+    set autoOpenOnFocus(value: boolean) {
+        this._autoOpenOnFocus = value;
+    }
+
+    private _autoOpenOnFocus: boolean = true;
+
     constructor(
         private changeDetectorRef: ChangeDetectorRef,
         private elementRef: ElementRef<HTMLElement>,

--- a/packages/mosaic/autocomplete/autocomplete.component.ts
+++ b/packages/mosaic/autocomplete/autocomplete.component.ts
@@ -146,15 +146,15 @@ export class McAutocomplete implements AfterContentInit {
     private _isOpen: boolean = false;
 
     @Input()
-    get autoOpenOnFocus(): boolean {
-        return this._autoOpenOnFocus;
+    get openOnFocus(): boolean {
+        return this._openOnFocus;
     }
 
-    set autoOpenOnFocus(value: boolean) {
-        this._autoOpenOnFocus = value;
+    set openOnFocus(value: boolean) {
+        this._openOnFocus = value;
     }
 
-    private _autoOpenOnFocus: boolean = true;
+    private _openOnFocus: boolean = true;
 
     constructor(
         private changeDetectorRef: ChangeDetectorRef,

--- a/packages/mosaic/autocomplete/autocomplete.spec.ts
+++ b/packages/mosaic/autocomplete/autocomplete.spec.ts
@@ -2270,6 +2270,72 @@ describe('McAutocomplete', () => {
 
     });
 
+    describe('Manage dropdown opening with autoOpenOnFocus when focus', () => {
+        let fixture: ComponentFixture<AutocompleteWithDisabledItems>;
+        let input: HTMLInputElement;
+
+        beforeEach(() => {
+            fixture = createComponent(AutocompleteWithAutoOpenOnFocus);
+            fixture.detectChanges();
+            input = fixture.debugElement.query(By.css('input')).nativeElement;
+        });
+
+        it('should not open dropdown with disabled autoOpenOnFocus', () => {
+            fixture.componentInstance.trigger.autocomplete.autoOpenOnFocus = false;
+
+            expect(fixture.componentInstance.trigger.panelOpen)
+                .toBe(false, `Expected panel state to start out closed.`);
+
+            dispatchFakeEvent(input, 'focusin');
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.trigger.panelOpen)
+                .toBe(false, `Expected panel state to closed when input is focused.`);
+        });
+
+        it('should open dropdown with enabled autoOpenOnFocus', () => {
+            fixture.componentInstance.trigger.autocomplete.autoOpenOnFocus = true;
+
+            expect(fixture.componentInstance.trigger.panelOpen)
+                .toBe(false, `Expected panel state to start out closed.`);
+
+            dispatchFakeEvent(input, 'focusin');
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.trigger.panelOpen)
+                .toBe(true, `Expected panel state to read open when input is focused.`);
+            expect(overlayContainerElement.textContent)
+                .toContain('Alabama', `Expected panel to display when input is focused.`);
+            expect(overlayContainerElement.textContent)
+                .toContain('California', `Expected panel to display when input is focused.`);
+        });
+    });
+
+    describe('Manage dropdown opening with autoOpenOnFocus when focus in default state', () => {
+        let fixture: ComponentFixture<SimpleAutocomplete>;
+        let input: HTMLInputElement;
+
+        beforeEach(() => {
+            fixture = createComponent(SimpleAutocomplete);
+            fixture.detectChanges();
+            input = fixture.debugElement.query(By.css('input')).nativeElement;
+        });
+
+        it('should open dropdown when no autoOpenOnFocus attribute', () => {
+            expect(fixture.componentInstance.trigger.panelOpen)
+                .toBe(false, `Expected panel state to start out closed.`);
+
+            dispatchFakeEvent(input, 'focusin');
+            fixture.detectChanges();
+
+            expect(fixture.componentInstance.trigger.panelOpen)
+                .toBe(true, `Expected panel state to read open when input is focused.`);
+            expect(overlayContainerElement.textContent)
+                .toContain('Alabama', `Expected panel to display when input is focused.`);
+            expect(overlayContainerElement.textContent)
+                .toContain('California', `Expected panel to display when input is focused.`);
+        });
+    });
 });
 
 @Component({
@@ -2675,6 +2741,38 @@ class AutocompleteWithDisabledItems {
     selectedState: string;
     states = [
         { code: 'AL', name: 'Alabama', disabled: true },
+        { code: 'CA', name: 'California' },
+        { code: 'FL', name: 'Florida' },
+        { code: 'KS', name: 'Kansas' },
+        { code: 'MA', name: 'Massachusetts' },
+        { code: 'NY', name: 'New York' },
+        { code: 'OR', name: 'Oregon' },
+        { code: 'PA', name: 'Pennsylvania' },
+        { code: 'TN', name: 'Tennessee' },
+        { code: 'VA', name: 'Virginia' },
+        { code: 'WY', name: 'Wyoming' }
+    ];
+}
+
+@Component({
+    template: `
+        <mc-form-field>
+            <input mcInput placeholder="States" [mcAutocomplete]="auto" [(ngModel)]="selectedState">
+        </mc-form-field>
+
+        <mc-autocomplete #auto="mcAutocomplete" [autoOpenOnFocus]="false">
+            <mc-option *ngFor="let state of states" [value]="state.code">
+                <span>{{ state.name }}</span>
+            </mc-option>
+        </mc-autocomplete>
+    `
+})
+class AutocompleteWithAutoOpenOnFocus {
+    @ViewChild(McAutocompleteTrigger, {static: true}) trigger: McAutocompleteTrigger;
+
+    selectedState: string;
+    states = [
+        { code: 'AL', name: 'Alabama' },
         { code: 'CA', name: 'California' },
         { code: 'FL', name: 'Florida' },
         { code: 'KS', name: 'Kansas' },

--- a/packages/mosaic/autocomplete/autocomplete.spec.ts
+++ b/packages/mosaic/autocomplete/autocomplete.spec.ts
@@ -2270,18 +2270,18 @@ describe('McAutocomplete', () => {
 
     });
 
-    describe('Manage dropdown opening with autoOpenOnFocus when focus', () => {
+    describe('Manage dropdown opening with openOnFocus when focus', () => {
         let fixture: ComponentFixture<AutocompleteWithDisabledItems>;
         let input: HTMLInputElement;
 
         beforeEach(() => {
-            fixture = createComponent(AutocompleteWithAutoOpenOnFocus);
+            fixture = createComponent(AutocompleteWithOpenOnFocus);
             fixture.detectChanges();
             input = fixture.debugElement.query(By.css('input')).nativeElement;
         });
 
-        it('should not open dropdown with disabled autoOpenOnFocus', () => {
-            fixture.componentInstance.trigger.autocomplete.autoOpenOnFocus = false;
+        it('should not open dropdown with disabled openOnFocus', () => {
+            fixture.componentInstance.trigger.autocomplete.openOnFocus = false;
 
             expect(fixture.componentInstance.trigger.panelOpen)
                 .toBe(false, `Expected panel state to start out closed.`);
@@ -2293,8 +2293,8 @@ describe('McAutocomplete', () => {
                 .toBe(false, `Expected panel state to closed when input is focused.`);
         });
 
-        it('should open dropdown with enabled autoOpenOnFocus', () => {
-            fixture.componentInstance.trigger.autocomplete.autoOpenOnFocus = true;
+        it('should open dropdown with enabled openOnFocus', () => {
+            fixture.componentInstance.trigger.autocomplete.openOnFocus = true;
 
             expect(fixture.componentInstance.trigger.panelOpen)
                 .toBe(false, `Expected panel state to start out closed.`);
@@ -2304,14 +2304,10 @@ describe('McAutocomplete', () => {
 
             expect(fixture.componentInstance.trigger.panelOpen)
                 .toBe(true, `Expected panel state to read open when input is focused.`);
-            expect(overlayContainerElement.textContent)
-                .toContain('Alabama', `Expected panel to display when input is focused.`);
-            expect(overlayContainerElement.textContent)
-                .toContain('California', `Expected panel to display when input is focused.`);
         });
     });
 
-    describe('Manage dropdown opening with autoOpenOnFocus when focus in default state', () => {
+    describe('Manage dropdown opening with openOnFocus when focus in default state', () => {
         let fixture: ComponentFixture<SimpleAutocomplete>;
         let input: HTMLInputElement;
 
@@ -2321,7 +2317,7 @@ describe('McAutocomplete', () => {
             input = fixture.debugElement.query(By.css('input')).nativeElement;
         });
 
-        it('should open dropdown when no autoOpenOnFocus attribute', () => {
+        it('should open dropdown when no openOnFocus attribute', () => {
             expect(fixture.componentInstance.trigger.panelOpen)
                 .toBe(false, `Expected panel state to start out closed.`);
 
@@ -2330,10 +2326,6 @@ describe('McAutocomplete', () => {
 
             expect(fixture.componentInstance.trigger.panelOpen)
                 .toBe(true, `Expected panel state to read open when input is focused.`);
-            expect(overlayContainerElement.textContent)
-                .toContain('Alabama', `Expected panel to display when input is focused.`);
-            expect(overlayContainerElement.textContent)
-                .toContain('California', `Expected panel to display when input is focused.`);
         });
     });
 });
@@ -2760,14 +2752,14 @@ class AutocompleteWithDisabledItems {
             <input mcInput placeholder="States" [mcAutocomplete]="auto" [(ngModel)]="selectedState">
         </mc-form-field>
 
-        <mc-autocomplete #auto="mcAutocomplete" [autoOpenOnFocus]="false">
+        <mc-autocomplete #auto="mcAutocomplete" [openOnFocus]="false">
             <mc-option *ngFor="let state of states" [value]="state.code">
                 <span>{{ state.name }}</span>
             </mc-option>
         </mc-autocomplete>
     `
 })
-class AutocompleteWithAutoOpenOnFocus {
+class AutocompleteWithOpenOnFocus {
     @ViewChild(McAutocompleteTrigger, {static: true}) trigger: McAutocompleteTrigger;
 
     selectedState: string;


### PR DESCRIPTION
Добавлен атрибут `autoOpenOnFocus`, который управляет автоматическим открытием выпадающего списка автокомплита при фокусе в поле ввода. Значение по умолчанию `true`. 

Добавил два теста и новую фикстуру для проверки нового атрибута. Добавил тест для существующей фикстуры без атрибута для проверки работы по умолчанию. 
