### PR TITLE
fix(mosaic-luxon-adapter): absoluteLongDateTime and absoluteShortDateTime without seconds (#UIM-666)

### DIFF
--- a/packages/mosaic-luxon-adapter/adapter/date-adapter.spec.ts
+++ b/packages/mosaic-luxon-adapter/adapter/date-adapter.spec.ts
@@ -530,6 +530,7 @@ describe('LuxonDateAdapter formatter', () => {
     const SHORT_MONTH = 'MMM';
     const DAY = 'd';
     const TIME = 'HH:mm';
+    const SECONDS = 'ss';
 
     const DASH = '\u2013';
     const NBSP = '\u00A0';
@@ -689,7 +690,7 @@ describe('LuxonDateAdapter formatter', () => {
                     const date = adapter.today();
 
                     expect(adapter.absoluteShortDateTime(date, { milliseconds: true }))
-                        .toBe(adapter.format(date, `${DAY_SHORT_MONTH}, ${TIME}${MILLISECONDS}`));
+                        .toBe(adapter.format(date, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`));
                 });
             });
 
@@ -726,7 +727,7 @@ describe('LuxonDateAdapter formatter', () => {
                     const date = adapter.today();
 
                     expect(adapter.absoluteLongDateTime(date, { milliseconds: true }))
-                        .toBe(date.toFormat(`${DAY_MONTH}, ${TIME}${MILLISECONDS}`));
+                        .toBe(date.toFormat(`${DAY_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`));
                 });
             });
         });
@@ -1391,7 +1392,7 @@ describe('LuxonDateAdapter formatter', () => {
                     const date = adapter.today();
 
                     expect(adapter.absoluteShortDateTime(date, { milliseconds: true }))
-                        .toBe(adapter.format(date, `${DAY_SHORT_MONTH}, ${TIME}${MILLISECONDS}`));
+                        .toBe(adapter.format(date, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`));
                 });
             });
 
@@ -1428,7 +1429,7 @@ describe('LuxonDateAdapter formatter', () => {
                     const date = adapter.today();
 
                     expect(adapter.absoluteLongDateTime(date, { milliseconds: true }))
-                        .toBe(date.toFormat(`${DAY_MONTH}, ${TIME}${MILLISECONDS}`));
+                        .toBe(date.toFormat(`${DAY_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`));
                 });
             });
         });

--- a/packages/mosaic-luxon-adapter/adapter/locales/en-US.ts
+++ b/packages/mosaic-luxon-adapter/adapter/locales/en-US.ts
@@ -3,9 +3,9 @@ import { DateAdapterConfig } from '@ptsecurity/cdk/datetime';
 
 export const enUS: DateAdapterConfig = {
     variables: {
-        SECONDS: 's',
+        SECONDS: 'ss',
         MILLISECONDS: '.SSS',
-        MINUTES: 'm',
+        MINUTES: 'mm',
         TIME: 'HH:mm',
 
         DAY: 'd',

--- a/packages/mosaic-luxon-adapter/adapter/locales/ru-RU.ts
+++ b/packages/mosaic-luxon-adapter/adapter/locales/ru-RU.ts
@@ -3,9 +3,9 @@ import { DateAdapterConfig } from '@ptsecurity/cdk/datetime';
 
 export const ruRU: DateAdapterConfig = {
     variables: {
-        SECONDS: 's',
+        SECONDS: 'ss',
         MILLISECONDS: ',SSS',
-        MINUTES: 'm',
+        MINUTES: 'mm',
         TIME: 'HH:mm',
 
         DAY: 'd',

--- a/packages/mosaic-moment-adapter/adapter/moment-date-adapter.spec.ts
+++ b/packages/mosaic-moment-adapter/adapter/moment-date-adapter.spec.ts
@@ -599,6 +599,7 @@ describe('MomentDateAdapter formatter', () => {
         const SHORT_MONTH = 'MMM';
         const DAY = 'D';
         const TIME = 'HH:mm';
+        const SECONDS = 'ss';
         const MILLISECONDS = ',SSS';
 
         const DASH = '\u2013';
@@ -714,7 +715,7 @@ describe('MomentDateAdapter formatter', () => {
                 it('absoluteShortDateTime with milliseconds', () => {
                     const date = moment();
                     expect(adapter.absoluteShortDateTime(date, { milliseconds: true })).toBe(
-                        date.format(`${DAY_SHORT_MONTH}, ${TIME}${MILLISECONDS}`)
+                        date.format(`${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`)
                     );
                 });
             });
@@ -745,7 +746,7 @@ describe('MomentDateAdapter formatter', () => {
                 it('absoluteLongDateTime with milliseconds', () => {
                     const date = moment();
                     expect(adapter.absoluteLongDateTime(date, { milliseconds: true }))
-                        .toBe(date.format(`${DAY_MONTH}, ${TIME}${MILLISECONDS}`));
+                        .toBe(date.format(`${DAY_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`));
                 });
             });
         });
@@ -1277,6 +1278,7 @@ describe('MomentDateAdapter formatter', () => {
         const SHORT_MONTH = 'MMM';
         const DAY = 'D';
         const TIME = 'HH:mm';
+        const SECONDS = 'ss';
         const MILLISECONDS = '.SSS';
 
         const DASH = '\u2013';
@@ -1392,7 +1394,7 @@ describe('MomentDateAdapter formatter', () => {
                 it('absoluteShortDateTime with milliseconds', () => {
                     const date = moment();
                     expect(adapter.absoluteShortDateTime(date, { milliseconds: true })).toBe(
-                        date.format(`${DAY_SHORT_MONTH}, ${TIME}${MILLISECONDS}`)
+                        date.format(`${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`)
                     );
                 });
             });
@@ -1423,7 +1425,7 @@ describe('MomentDateAdapter formatter', () => {
                 it('absoluteLongDateTime with milliseconds', () => {
                     const date = moment();
                     expect(adapter.absoluteLongDateTime(date, { milliseconds: true }))
-                        .toBe(date.format(`${DAY_MONTH}, ${TIME}${MILLISECONDS}`));
+                        .toBe(date.format(`${DAY_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`));
                 });
             });
         });

--- a/packages/mosaic/core/formatters/date/templates/en-US.ts
+++ b/packages/mosaic/core/formatters/date/templates/en-US.ts
@@ -26,7 +26,7 @@ export const enUS = {
             }{
                 SHOW_MILLISECONDS,
                 select,
-                    yes{{MILLISECONDS}}
+                    yes{:{SECONDS}{MILLISECONDS}}
                     other{}
             }`
         },
@@ -40,7 +40,7 @@ export const enUS = {
             }{
                 SHOW_MILLISECONDS,
                 select,
-                    yes{{MILLISECONDS}}
+                    yes{:{SECONDS}{MILLISECONDS}}
                     other{}
             }`
         }

--- a/packages/mosaic/core/formatters/date/templates/ru-RU.ts
+++ b/packages/mosaic/core/formatters/date/templates/ru-RU.ts
@@ -26,7 +26,7 @@ export const ruRU = {
             }{
                 SHOW_MILLISECONDS,
                 select,
-                    yes{{MILLISECONDS}}
+                    yes{:{SECONDS}{MILLISECONDS}}
                     other{}
             }`
         },
@@ -40,7 +40,7 @@ export const ruRU = {
             }{
                 SHOW_MILLISECONDS,
                 select,
-                    yes{{MILLISECONDS}}
+                    yes{:{SECONDS}{MILLISECONDS}}
                     other{}
             }`
         }


### PR DESCRIPTION
Оказалось, что с опцией `milliseconds: true` не отображались секунды, в шаблоне их просто не было.