### PR TITLE
fix(list): List option font size (#UIM-658)

### DIFF
--- a/packages/mosaic/list/_list-theme.scss
+++ b/packages/mosaic/list/_list-theme.scss
@@ -35,7 +35,8 @@
 }
 
 @mixin mc-list-typography($config) {
-    .mc-list-item {
+    .mc-list-item,
+    .mc-list-option {
         @include mc-typography-level-to-styles($config, $list-font-item);
     }
 }


### PR DESCRIPTION
Стиль для mc-list-option потерялся при переходе на [токены](https://github.com/positive-js/mosaic/commit/7438db4991124b2a869aa38bdc0f1f77e6c74d25#diff-4ea7cabd5b93cb165d032ee0f52544f929891d6b5e38052231704b3ea7460693R38).
Из-за этого размер шрифта наследовался от родительских элементов.