### PR TITLE
fix(highlight): fixed highlight.js deprecation warning (UIM-627)

### DIFF
--- a/tools/gulp/tasks/docs.ts
+++ b/tools/gulp/tasks/docs.ts
@@ -59,7 +59,7 @@ const markdownOptions = {
             // highlight.js expects "typescript" written out, while Github supports "ts".
             const lang = language.toLowerCase() === 'ts' ? 'typescript' : language;
 
-            return hljs.highlight(lang, code).value;
+            return hljs.highlight(code, {language: lang}).value;
         }
 
         return code;

--- a/tools/highlight-files/highlight-code-block.ts
+++ b/tools/highlight-files/highlight-code-block.ts
@@ -8,8 +8,9 @@ const highlightJs = require('highlight.js');
  */
 export function highlightCodeBlock(code: string, language: string) {
     if (language) {
-        return highlightJs.highlight(
-            language.toLowerCase() === 'ts' ? 'typescript' : language, code).value;
+        return highlightJs.highlight(code, {
+            language: language.toLowerCase() === 'ts' ? 'typescript' : language
+        }).value;
     }
 
     return code;


### PR DESCRIPTION
https://youtrack.ptsecurity.com/issue/UIM-627
убрал варнинги
![image](https://user-images.githubusercontent.com/25739698/144040796-75008391-8cb2-4570-a4ff-00b4d2e3dc48.png)
