### PR TITLE
fix(list): restrict keyDown event (#UIM-804)

### DIFF
--- a/packages/mosaic/list/list-selection.component.ts
+++ b/packages/mosaic/list/list-selection.component.ts
@@ -722,7 +722,7 @@ export class McListSelection extends McListSelectionMixinBase implements CanDisa
             this.keyManager.setNextPageItemActive();
         }
 
-        if (this.keyManager.activeItem) {
+        if (this.keyManager.activeItem && isVerticalMovement(event)) {
             this.setSelectedOptionsByKey(
                 this.keyManager.activeItem as McListOption,
                 hasModifierKey(event, 'shiftKey'),


### PR DESCRIPTION
в методе setSelectedOptionsByKey() эмитился selectionChange при любом нажатии, если список в режиме autoSelect.
сделал, чтобы эмитилось только при нажатии на кнопки для вертикального движения