### PR TITLE
fix(select): select with search doesn't let type a space (#UIM-817)

### DIFF
--- a/packages/mosaic/select/select.component.ts
+++ b/packages/mosaic/select/select.component.ts
@@ -186,6 +186,11 @@ export class McSelectSearch implements AfterContentInit, OnDestroy {
                 event.stopPropagation();
             }
         }
+
+        // tslint:disable-next-line:deprecation
+        if ([SPACE, HOME, END].some((keyCode) => keyCode === event.keyCode)) {
+            event.stopPropagation();
+        }
     }
 }
 
@@ -750,12 +755,12 @@ export class McSelect extends McSelectMixinBase implements
     }
 
     handleKeydown(event: KeyboardEvent): void {
-        if (!this.disabled) {
-            if (this.panelOpen) {
-                this.handleOpenKeydown(event);
-            } else {
-                this.handleClosedKeydown(event);
-            }
+        if (this.disabled) { return; }
+
+        if (this.panelOpen) {
+            this.handleOpenKeydown(event);
+        } else {
+            this.handleClosedKeydown(event);
         }
     }
 
@@ -991,6 +996,10 @@ export class McSelect extends McSelectMixinBase implements
             if (this._multiple && isArrowKey && event.shiftKey && manager.activeItem &&
                 manager.activeItemIndex !== previouslyFocusedIndex) {
                 manager.activeItem.selectViaInteraction();
+            }
+
+            if (this.search) {
+                this.search.focus();
             }
         }
     }


### PR DESCRIPTION
Перенесено исправление отсюда https://github.com/positive-js/mosaic/pull/517/files