### PR TITLE
fix(timepicker): fix for error when formControl has null value (#UIM-729)

### DIFF
--- a/packages/mosaic/timepicker/timepicker.directive.ts
+++ b/packages/mosaic/timepicker/timepicker.directive.ts
@@ -791,14 +791,16 @@ export class McTimepicker<D> implements McFormFieldControl<D>, ControlValueAcces
         }
         // tslint:enable
 
+        const date = this.value || this.dateAdapter.today();
+        // tslint:enable
         const resultDate = this.dateAdapter.createDateTime(
-            this.dateAdapter.getYear(this.value),
-            this.dateAdapter.getMonth(this.value),
-            this.dateAdapter.getDate(this.value),
+            this.dateAdapter.getYear(date),
+            this.dateAdapter.getMonth(date),
+            this.dateAdapter.getDate(date),
             hours,
             minutes || 0,
             seconds || 0,
-            this.dateAdapter.getMilliseconds(this.value)
+            this.dateAdapter.getMilliseconds(date)
         );
 
         return this.getValidDateOrNull(resultDate);

--- a/packages/mosaic/timepicker/timepicker.directive.ts
+++ b/packages/mosaic/timepicker/timepicker.directive.ts
@@ -790,9 +790,8 @@ export class McTimepicker<D> implements McFormFieldControl<D>, ControlValueAcces
             return null;
         }
         // tslint:enable
-
         const date = this.value || this.dateAdapter.today();
-        // tslint:enable
+
         const resultDate = this.dateAdapter.createDateTime(
             this.dateAdapter.getYear(date),
             this.dateAdapter.getMonth(date),

--- a/packages/mosaic/timepicker/timepicker.spec.ts
+++ b/packages/mosaic/timepicker/timepicker.spec.ts
@@ -6,7 +6,7 @@ import {
     TestBed,
     tick
 } from '@angular/core/testing';
-import { FormsModule, NgModel } from '@angular/forms';
+import { FormControl, FormsModule, NgModel, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { DateAdapter } from '@ptsecurity/cdk/datetime';
 import { DOWN_ARROW, ONE, SPACE, TWO, UP_ARROW } from '@ptsecurity/cdk/keycodes';
@@ -45,7 +45,6 @@ class TestApp {
         this.timeValue = adapter.createDateTime(1970, 1, 1, 12, 18, 28, 0);
     }
 }
-
 
 describe('McTimepicker', () => {
     let fixture: ComponentFixture<TestApp>;
@@ -540,4 +539,176 @@ describe('McTimepicker', () => {
             expect(inputNativeElement.value).toBe('12:00:00', 'Failed key-by-key input on 2nd key');
         });
     });
+});
+
+@Component({
+    selector: 'test-app',
+    template: `
+        <mc-form-field>
+            <i mcPrefix mc-icon="mc-clock_16"></i>
+            <input mcTimepicker
+                   [format]="timeFormat"
+                   [formControl]="formControl"
+        >
+        </mc-form-field>`
+})
+class TimePickerWithNullFormControlValue {
+    formControl: FormControl = new FormControl();
+    timeFormat: string;
+}
+
+describe('McTimepicker with null formControl value', () => {
+    let fixture: ComponentFixture<TimePickerWithNullFormControlValue>;
+    let testComponent: TimePickerWithNullFormControlValue;
+    let inputElementDebug;
+
+    beforeEach(fakeAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                McTimepickerModule,
+                FormsModule,
+                ReactiveFormsModule,
+                McFormFieldModule,
+                McTimepickerModule,
+                McIconModule,
+                McLuxonDateModule
+            ],
+            declarations: [TimePickerWithNullFormControlValue]
+        });
+        TestBed.compileComponents();
+
+        const mockedAdapter: DateAdapter<any> = TestBed.inject(DateAdapter);
+        spyOn(mockedAdapter, 'today').and.returnValue(
+            mockedAdapter.createDateTime(2020, 0, 1, 2, 3, 4, 5)
+        );
+
+        fixture = TestBed.createComponent(TimePickerWithNullFormControlValue);
+        testComponent = fixture.debugElement.componentInstance;
+        inputElementDebug = fixture.debugElement.query(By.directive(McTimepicker));
+
+        fixture.detectChanges();
+    }));
+
+    it('Paste value from clipboard when formControl value is null', () => {
+        testComponent.timeFormat = 'HH:mm:ss';
+        fixture.detectChanges();
+        /*
+                    jasmine.clock().install();
+                    jasmine.clock().mockDate(new Date('2020-02-02'));*/
+
+        expect(testComponent.formControl.value).toBeNull();
+
+        inputElementDebug.triggerEventHandler(
+            'paste',
+            {
+                preventDefault: () => null,
+                clipboardData: {
+                    getData: () => '19:01:02'
+                }
+            });
+        fixture.detectChanges();
+
+        expect(testComponent.formControl.value.toString()).toContain('2020-01-01T19:01:02');
+    });
+
+    it('Create time from input when formControl value is null', fakeAsync(() => {
+        testComponent.timeFormat = 'HH:mm';
+        fixture.detectChanges();
+
+        expect(testComponent.formControl.value).toBeNull();
+
+        inputElementDebug.nativeElement.value = '18:09';
+        dispatchFakeEvent(inputElementDebug.nativeElement, 'keydown');
+        tick(1);
+
+        fixture.detectChanges();
+
+        expect(testComponent.formControl.value.toString()).toContain('2020-01-01T18:09');
+    }));
+});
+
+@Component({
+    selector: 'test-app',
+    template: `
+        <mc-form-field>
+            <i mcPrefix mc-icon="mc-clock_16"></i>
+            <input mcTimepicker
+                   [format]="timeFormat"
+                   [(ngModel)]="model"
+        >
+        </mc-form-field>`
+})
+class TimePickerWithNullModelValue {
+    timeFormat: string;
+    model: any = null;
+}
+
+describe('McTimepicker with null model value', () => {
+    let fixture: ComponentFixture<TimePickerWithNullModelValue>;
+    let testComponent: TimePickerWithNullModelValue;
+    let inputElementDebug;
+
+    beforeEach(fakeAsync(() => {
+
+        TestBed.configureTestingModule({
+            imports: [
+                McTimepickerModule,
+                FormsModule,
+                McFormFieldModule,
+                McTimepickerModule,
+                McIconModule,
+                McLuxonDateModule
+            ],
+            declarations: [TimePickerWithNullModelValue]
+        });
+        TestBed.compileComponents();
+
+        const mockedAdapter: DateAdapter<any> = TestBed.inject(DateAdapter);
+        spyOn(mockedAdapter, 'today').and.returnValue(
+            mockedAdapter.createDateTime(2020, 0, 1, 2, 3, 4, 5)
+        );
+
+        fixture = TestBed.createComponent(TimePickerWithNullModelValue);
+        testComponent = fixture.debugElement.componentInstance;
+        inputElementDebug = fixture.debugElement.query(By.directive(McTimepicker));
+
+        fixture.detectChanges();
+    }));
+
+    it('Paste value from clipboard when model value is null', () => {
+        testComponent.timeFormat = 'HH:mm:ss';
+        fixture.detectChanges();
+        /*
+                    jasmine.clock().install();
+                    jasmine.clock().mockDate(new Date('2020-02-02'));*/
+
+        expect(testComponent.model).toBeNull();
+
+        inputElementDebug.triggerEventHandler(
+            'paste',
+            {
+                preventDefault: () => null,
+                clipboardData: {
+                    getData: () => '19:01:02'
+                }
+            });
+        fixture.detectChanges();
+
+        expect(testComponent.model.toString()).toContain('2020-01-01T19:01:02');
+    });
+
+    it('Create time from input when model value is null', fakeAsync(() => {
+        testComponent.timeFormat = 'HH:mm';
+        fixture.detectChanges();
+
+        expect(testComponent.model).toBeNull();
+
+        inputElementDebug.nativeElement.value = '18:09';
+        dispatchFakeEvent(inputElementDebug.nativeElement, 'keydown');
+        tick(1);
+
+        fixture.detectChanges();
+
+        expect(testComponent.model.toString()).toContain('2020-01-01T18:09');
+    }));
 });

--- a/packages/mosaic/timepicker/timepicker.spec.ts
+++ b/packages/mosaic/timepicker/timepicker.spec.ts
@@ -592,9 +592,6 @@ describe('McTimepicker with null formControl value', () => {
     it('Paste value from clipboard when formControl value is null', () => {
         testComponent.timeFormat = 'HH:mm:ss';
         fixture.detectChanges();
-        /*
-                    jasmine.clock().install();
-                    jasmine.clock().mockDate(new Date('2020-02-02'));*/
 
         expect(testComponent.formControl.value).toBeNull();
 
@@ -678,9 +675,6 @@ describe('McTimepicker with null model value', () => {
     it('Paste value from clipboard when model value is null', () => {
         testComponent.timeFormat = 'HH:mm:ss';
         fixture.detectChanges();
-        /*
-                    jasmine.clock().install();
-                    jasmine.clock().mockDate(new Date('2020-02-02'));*/
 
         expect(testComponent.model).toBeNull();
 


### PR DESCRIPTION
При генерации даты из введённого времени, не обрабатывался случай когда текущее значение null

