### PR TITLE
fix(modal): footer of modal (#UIM-750)

### DIFF
--- a/packages/mosaic/modal/modal.component.html
+++ b/packages/mosaic/modal/modal.component.html
@@ -72,7 +72,7 @@
             </ng-container>
         </ng-container>
     </div>
-    <div *ngIf="mcFooter !== null" class="mc-modal-footer" [class.mc-modal-body_bottom-overflow]="isBottomOverflow">
+    <div *ngIf="mcFooter !== null || mcOkText !== null || mcCancelText !== null" class="mc-modal-footer" [class.mc-modal-body_bottom-overflow]="isBottomOverflow">
         <ng-container [ngSwitch]="true">
             <ng-container *ngSwitchCase="isTemplateRef(mcFooter)" [ngTemplateOutlet]="$any(mcFooter)"></ng-container>
             <ng-container *ngSwitchCase="isNonEmptyString(mcFooter)">
@@ -135,19 +135,19 @@
             </div>
         </div> <!-- /.mc-confirm-body-wrapper -->
     </div>
-    <div class="mc-confirm-btns">
+    <div class="mc-confirm-btns" *ngIf="mcOkText !== null || mcCancelText !== null">
         <button
             mc-button
             #autoFocusedButton
             [color]="mcOkType"
             [attr.autofocus]="true"
-            *ngIf="mcOkText !== ''"
+            *ngIf="mcOkText !== null"
             (click)="onClickOkCancel('ok')">
 
             {{ okText }}
         </button>
 
-        <button mc-button [color]="themePalette.Second" *ngIf="mcCancelText !== ''" (click)="onClickOkCancel('cancel')">
+        <button mc-button [color]="themePalette.Second" *ngIf="mcCancelText !== null" (click)="onClickOkCancel('cancel')">
             {{ cancelText }}
         </button>
     </div>

--- a/packages/mosaic/modal/modal.component.html
+++ b/packages/mosaic/modal/modal.component.html
@@ -72,7 +72,7 @@
             </ng-container>
         </ng-container>
     </div>
-    <div *ngIf="mcFooter !== null || mcOkText !== null || mcCancelText !== null" class="mc-modal-footer" [class.mc-modal-body_bottom-overflow]="isBottomOverflow">
+    <div *ngIf="mcFooter || mcOkText || mcCancelText" class="mc-modal-footer" [class.mc-modal-body_bottom-overflow]="isBottomOverflow">
         <ng-container [ngSwitch]="true">
             <ng-container *ngSwitchCase="isTemplateRef(mcFooter)" [ngTemplateOutlet]="$any(mcFooter)"></ng-container>
             <ng-container *ngSwitchCase="isNonEmptyString(mcFooter)">
@@ -98,14 +98,14 @@
                 <button
                     #autoFocusedButton
                     [attr.autofocus]="true"
-                    *ngIf="mcOkText !== null"
+                    *ngIf="mcOkText"
                     mc-button
                     [color]="themePalette.Primary"
                     (click)="onClickOkCancel('ok')">
 
                     {{ okText }}
                 </button>
-                <button *ngIf="mcCancelText!==null" mc-button (click)="onClickOkCancel('cancel')">
+                <button *ngIf="mcCancelText" mc-button (click)="onClickOkCancel('cancel')">
                     {{ cancelText }}
                 </button>
             </ng-container>
@@ -135,19 +135,19 @@
             </div>
         </div> <!-- /.mc-confirm-body-wrapper -->
     </div>
-    <div class="mc-confirm-btns" *ngIf="mcOkText !== null || mcCancelText !== null">
+    <div class="mc-confirm-btns" *ngIf="mcOkText || mcCancelText">
         <button
             mc-button
             #autoFocusedButton
             [color]="mcOkType"
             [attr.autofocus]="true"
-            *ngIf="mcOkText !== null"
+            *ngIf="mcOkText"
             (click)="onClickOkCancel('ok')">
 
             {{ okText }}
         </button>
 
-        <button mc-button [color]="themePalette.Second" *ngIf="mcCancelText !== null" (click)="onClickOkCancel('cancel')">
+        <button mc-button [color]="themePalette.Second" *ngIf="mcCancelText" (click)="onClickOkCancel('cancel')">
             {{ cancelText }}
         </button>
     </div>

--- a/packages/mosaic/modal/modal.service.ts
+++ b/packages/mosaic/modal/modal.service.ts
@@ -96,17 +96,14 @@ export class McModalService {
         }
         // Remove the Cancel button if the user not specify a Cancel button
         if (!('mcCancelText' in options)) {
-            // @ts-ignore
-            options.mcCancelText = null;
+            options.mcCancelText = undefined;
         }
         // Remove the Ok button if the user not specify a Ok button
         if (!('mcOkText' in options)) {
-            // @ts-ignore
-            options.mcOkText = null;
+            options.mcOkText = undefined;
         }
         if (!('mcFooter' in options)) {
-            // @ts-ignore
-            options.mcFooter = null;
+            options.mcFooter = undefined;
         }
 
         return new ModalBuilderForService(this.overlay, options).getInstance()!;

--- a/packages/mosaic/modal/modal.service.ts
+++ b/packages/mosaic/modal/modal.service.ts
@@ -94,6 +94,20 @@ export class McModalService {
         if (!('mcCloseByESC' in options)) {
             options.mcCloseByESC = true;
         }
+        // Remove the Cancel button if the user not specify a Cancel button
+        if (!('mcCancelText' in options)) {
+            // @ts-ignore
+            options.mcCancelText = null;
+        }
+        // Remove the Ok button if the user not specify a Ok button
+        if (!('mcOkText' in options)) {
+            // @ts-ignore
+            options.mcOkText = null;
+        }
+        if (!('mcFooter' in options)) {
+            // @ts-ignore
+            options.mcFooter = null;
+        }
 
         return new ModalBuilderForService(this.overlay, options).getInstance()!;
     }
@@ -133,12 +147,6 @@ export class McModalService {
     }
 
     private simpleConfirm<T>(options: IModalOptionsForService<T> = {}, confirmType: ConfirmType): McModalRef<T> {
-        // Remove the Cancel button if the user not specify a Cancel button
-        if (!('mcCancelText' in options)) {
-            // @ts-ignore
-            options.mcCancelText = null;
-        }
-
         return this.confirm(options, confirmType);
     }
 }

--- a/packages/mosaic/modal/modal.service.ts
+++ b/packages/mosaic/modal/modal.service.ts
@@ -102,6 +102,7 @@ export class McModalService {
         if (!('mcOkText' in options)) {
             options.mcOkText = undefined;
         }
+        // Remove the footer if the user not specify a footer
         if (!('mcFooter' in options)) {
             options.mcFooter = undefined;
         }

--- a/packages/mosaic/modal/modal.spec.ts
+++ b/packages/mosaic/modal/modal.spec.ts
@@ -312,6 +312,53 @@ describe('McModal', () => {
             expect(spyOk).toHaveBeenCalled();
         });
 
+        it('should show the footer, when mcFooter is specified', fakeAsync(() => {
+            const modalRef = modalService.create({
+                mcFooter: [
+                    {
+                        label: 'button 1',
+                        type: 'primary'
+                    }
+                ]
+            });
+
+            fixture.detectChanges();
+            tick(600);
+
+            expect(modalRef.getElement().querySelectorAll('.mc-modal-footer').length).toBe(1);
+        }));
+
+        it('should show the footer, when mcOkText is specified', fakeAsync(() => {
+            const modalRef = modalService.create({
+                mcOkText: 'OK'
+            });
+
+            fixture.detectChanges();
+            tick(600);
+
+            expect(modalRef.getElement().querySelectorAll('.mc-modal-footer').length).toBe(1);
+        }));
+
+        it('should show the footer, when mcCancelText is specified', fakeAsync(() => {
+            const modalRef = modalService.create({
+                mcCancelText: 'OK'
+            });
+
+            fixture.detectChanges();
+            tick(600);
+
+            expect(modalRef.getElement().querySelectorAll('.mc-modal-footer').length).toBe(1);
+        }));
+
+        it('should not show the footer, when mcOkText, mcOkCancel and mcFooter are not specified', fakeAsync(() => {
+            const modalRef = modalService.create();
+
+            fixture.detectChanges();
+            tick(600);
+
+            expect(modalRef.getElement().querySelectorAll('.mc-modal-footer').length).toBe(0);
+        }));
+
     });
 });
 


### PR DESCRIPTION
[Bug UIM-750  modalService.create без footerRef создаёт лишний футер](https://youtrack.ptsecurity.com/issue/UIM-750)

Добавлена проверка на наличие mcFooter, mcOkText, mcCancelText, если данных опций не будет - футер не будет выводиться

![image](https://user-images.githubusercontent.com/95629181/147258968-fd66194d-33c9-4175-b390-241d695f5012.png)
