### PR TITLE
fix(modal): btn transparent bgcolor (#UIM-776)

### DIFF
--- a/packages/mosaic/button/_button-theme.scss
+++ b/packages/mosaic/button/_button-theme.scss
@@ -26,19 +26,20 @@
     background-color: transparent;
 
     &:hover:not([disabled]) {
+        background-color: map-get($background, overlay-hover);
         & .mc-button-overlay {
-            background: map-get($background, overlay-hover);
+            background-color: transparent;
         }
     }
 
     &:active:not([disabled]),
     &.mc-active:not([disabled]) {
         border-color: transparent;
-        background-color: transparent;
+        background-color: map-get($background, overlay-active);
         box-shadow: none;
 
         & .mc-button-overlay {
-            background: map-get($background, overlay-active);
+            background-color: transparent;
         }
     }
 

--- a/packages/mosaic/button/_button-theme.scss
+++ b/packages/mosaic/button/_button-theme.scss
@@ -27,6 +27,7 @@
 
     &:hover:not([disabled]) {
         background-color: map-get($background, overlay-hover);
+
         & .mc-button-overlay {
             background-color: transparent;
         }


### PR DESCRIPTION
[Прозрачная кнопка ломает иконку из пакета pt-flag-icons](https://youtrack.ptsecurity.com/issue/UIM-776)

![image](https://user-images.githubusercontent.com/95629181/147337790-346a6527-2192-44eb-aa7d-e1df10b80035.png)


