### PR TITLE
fix(docs): add example lazy loading options (#UIM-802)

### DIFF
--- a/packages/mosaic-examples/mosaic/tree-select/index.ts
+++ b/packages/mosaic-examples/mosaic/tree-select/index.ts
@@ -4,21 +4,25 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { McFormFieldModule } from '@ptsecurity/mosaic/form-field';
 import { McIconModule } from '@ptsecurity/mosaic/icon';
 import { McInputModule } from '@ptsecurity/mosaic/input';
+import { McProgressSpinnerModule } from '@ptsecurity/mosaic/progress-spinner';
 import { McTreeModule } from '@ptsecurity/mosaic/tree';
 import { McTreeSelectModule } from '@ptsecurity/mosaic/tree-select';
 
+import { TreeSelectLazyloadExample } from './tree-select-lazyload/tree-select-lazyload-example';
 import { TreeSelectMultipleOverviewExample } from './tree-select-multiple-overview/tree-select-multiple-overview-example';
 import { TreeSelectOverviewExample } from './tree-select-overview/tree-select-overview-example';
 
 
 export {
     TreeSelectOverviewExample,
-    TreeSelectMultipleOverviewExample
+    TreeSelectMultipleOverviewExample,
+    TreeSelectLazyloadExample
 };
 
 const EXAMPLES = [
     TreeSelectOverviewExample,
-    TreeSelectMultipleOverviewExample
+    TreeSelectMultipleOverviewExample,
+    TreeSelectLazyloadExample
 ];
 
 @NgModule({
@@ -30,7 +34,8 @@ const EXAMPLES = [
         McTreeModule,
         McTreeSelectModule,
         McInputModule,
-        McIconModule
+        McIconModule,
+        McProgressSpinnerModule
     ],
     declarations: EXAMPLES,
     exports: EXAMPLES

--- a/packages/mosaic-examples/mosaic/tree-select/tree-select-lazyload/tree-select-lazyload-example.css
+++ b/packages/mosaic-examples/mosaic/tree-select/tree-select-lazyload/tree-select-lazyload-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/packages/mosaic-examples/mosaic/tree-select/tree-select-lazyload/tree-select-lazyload-example.html
+++ b/packages/mosaic-examples/mosaic/tree-select/tree-select-lazyload/tree-select-lazyload-example.html
@@ -1,0 +1,26 @@
+<mc-form-field>
+    <mc-tree-select
+        [(ngModel)]="selected">
+        <mc-tree-selection
+            [dataSource]="dataSource"
+            [treeControl]="treeControl">
+            <mc-tree-option *mcTreeNodeDef="let node" mcTreeNodePadding>
+                {{ treeControl.getViewValue(node) }}
+            </mc-tree-option>
+
+            <mc-tree-option *mcTreeNodeDef="let node; when: hasChild" mcTreeNodePadding>
+                <i mc-icon="mc-angle-down-S_16"
+                   [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
+                   mcTreeNodeToggle
+                   (click)="clickNode(node)">
+                </i>
+                <mc-progress-spinner *ngIf="node.loading"
+                                     mode="indeterminate">
+                </mc-progress-spinner>
+                {{ treeControl.getViewValue(node) }}
+            </mc-tree-option>
+        </mc-tree-selection>
+
+        <mc-cleaner #mcSelectCleaner></mc-cleaner>
+    </mc-tree-select>
+</mc-form-field>

--- a/packages/mosaic-examples/mosaic/tree-select/tree-select-lazyload/tree-select-lazyload-example.html
+++ b/packages/mosaic-examples/mosaic/tree-select/tree-select-lazyload/tree-select-lazyload-example.html
@@ -11,8 +11,7 @@
             <mc-tree-option *mcTreeNodeDef="let node; when: hasChild" mcTreeNodePadding>
                 <i mc-icon="mc-angle-down-S_16"
                    [style.transform]="treeControl.isExpanded(node) ? '' : 'rotate(-90deg)'"
-                   mcTreeNodeToggle
-                   (click)="clickNode(node)">
+                   mcTreeNodeToggle>
                 </i>
                 <mc-progress-spinner *ngIf="node.loading"
                                      mode="indeterminate">

--- a/packages/mosaic-examples/mosaic/tree-select/tree-select-lazyload/tree-select-lazyload-example.ts
+++ b/packages/mosaic-examples/mosaic/tree-select/tree-select-lazyload/tree-select-lazyload-example.ts
@@ -11,12 +11,12 @@ interface INodeResponse {
     hasChildren: boolean;
 }
 
-class LazyLoadFlatNode {
+class FlatNode {
     id: string;
     name: string;
     expandable: boolean;
     level: number;
-    parent: LazyLoadFlatNode;
+    parent: FlatNode;
     loading: boolean;
 }
 
@@ -57,7 +57,7 @@ export class LazyLoadDataService {
         });*/
 
         this.dataChange.next(
-            Array(5).fill({}).map((value, index) => {
+            Array(10).fill({}).map((value, index) => {
                 const id = index.toString();
 
                 return {
@@ -136,30 +136,29 @@ export class LazyLoadDataService {
 }
 
 /**
- * @title Basic tree
+ * @title Basic Select
  */
 @Component({
-    selector: 'tree-lazyload-example',
-    templateUrl: 'tree-lazyload-example.html',
-    styleUrls: ['tree-lazyload-example.css'],
+    selector: 'tree-select-lazyload-example',
+    templateUrl: 'tree-select-lazyload-example.html',
+    styleUrls: ['tree-select-lazyload-example.css'],
     providers: [LazyLoadDataService]
 })
-export class TreeLazyloadExample {
-    treeControl: FlatTreeControl<LazyLoadFlatNode>;
-    treeFlattener: McTreeFlattener<LazyLoadNode, LazyLoadFlatNode>;
+export class TreeSelectLazyloadExample {
+    selected = '';
+    treeControl: FlatTreeControl<FlatNode>;
+    treeFlattener: McTreeFlattener<LazyLoadNode, FlatNode>;
 
-    dataSource: McTreeFlatDataSource<LazyLoadNode, LazyLoadFlatNode>;
+    dataSource: McTreeFlatDataSource<LazyLoadNode, FlatNode>;
 
-    modelValue: any = '';
-
-    nodeMap = new Map<string, LazyLoadFlatNode>();
+    nodeMap = new Map<string, FlatNode>();
 
     constructor(private dataService: LazyLoadDataService) {
         this.treeFlattener = new McTreeFlattener(
             this.transformer, this.getLevel, this.isExpandable, this.getChildren
         );
 
-        this.treeControl = new FlatTreeControl<LazyLoadFlatNode>(
+        this.treeControl = new FlatTreeControl<FlatNode>(
             this.getLevel, this.isExpandable, this.getValue, this.getViewValue
         );
         this.dataSource = new McTreeFlatDataSource(this.treeControl, this.treeFlattener);
@@ -174,18 +173,18 @@ export class TreeLazyloadExample {
 
     }
 
-    hasChild(_: number, nodeData: LazyLoadFlatNode): boolean {
+    hasChild(_: number, nodeData: FlatNode): boolean {
         return nodeData.expandable;
     }
 
-    clickNode(node: LazyLoadFlatNode): void {
+    clickNode(node: FlatNode): void {
         this.dataService.loadChildren(node.id);
     }
 
-    private transformer = (node: LazyLoadNode, level: number, parent: any): LazyLoadFlatNode => {
+    private transformer = (node: LazyLoadNode, level: number, parent: any): FlatNode => {
         const existingNode = this.nodeMap.get(node.id);
 
-        const flatNode = new LazyLoadFlatNode();
+        const flatNode = new FlatNode();
         flatNode.id = node.id;
         flatNode.name = node.name;
         flatNode.parent = parent;
@@ -207,11 +206,11 @@ export class TreeLazyloadExample {
         return flatNode;
     }
 
-    private getLevel = (node: LazyLoadFlatNode) => {
+    private getLevel = (node: FlatNode) => {
         return node.level;
     }
 
-    private isExpandable = (node: LazyLoadFlatNode) => {
+    private isExpandable = (node: FlatNode) => {
         return node.expandable;
     }
 
@@ -219,11 +218,11 @@ export class TreeLazyloadExample {
         return node.childrenChange;
     }
 
-    private getValue = (node: LazyLoadFlatNode): string => {
+    private getValue = (node: FlatNode): string => {
         return node.name;
     }
 
-    private getViewValue = (node: LazyLoadFlatNode): string => {
+    private getViewValue = (node: FlatNode): string => {
         return node.name;
     }
 }

--- a/packages/mosaic-examples/mosaic/tree/index.ts
+++ b/packages/mosaic-examples/mosaic/tree/index.ts
@@ -1,4 +1,5 @@
 import { ClipboardModule } from '@angular/cdk/clipboard';
+import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { McCheckboxModule } from '@ptsecurity/mosaic/checkbox';
@@ -7,18 +8,19 @@ import { McDropdownModule } from '@ptsecurity/mosaic/dropdown';
 import { McFormFieldModule } from '@ptsecurity/mosaic/form-field';
 import { McIconModule } from '@ptsecurity/mosaic/icon';
 import { McInputModule } from '@ptsecurity/mosaic/input';
+import { McProgressSpinnerModule } from '@ptsecurity/mosaic/progress-spinner';
 import { McToolTipModule } from '@ptsecurity/mosaic/tooltip';
 import { McTreeModule } from '@ptsecurity/mosaic/tree';
 
 import { TreeActionButtonExample } from './tree-action-button/tree-action-button-example';
 import { TreeFilteringExample } from './tree-filtering/tree-filtering-example';
+import { TreeLazyloadExample } from './tree-lazyload/tree-lazyload-example';
 import { TreeMultipleCheckboxExample } from './tree-multiple-checkbox/tree-multiple-checkbox-example';
 import {
     TreeMultipleChecklistExample
 } from './tree-multiple-checklist/tree-multiple-checklist-example';
 import { TreeMultipleKeyboardExample } from './tree-multiple-keyboard/tree-multiple-keyboard-example';
 import { TreeOverviewExample } from './tree-overview/tree-overview-example';
-import { TreeLazyloadExample } from './tree-lazyload/tree-lazyload-example';
 
 
 export {
@@ -43,6 +45,7 @@ const EXAMPLES = [
 
 @NgModule({
     imports: [
+        CommonModule,
         FormsModule,
         McFormFieldModule,
         McInputModule,
@@ -53,6 +56,7 @@ const EXAMPLES = [
         McDropdownModule,
         McToolTipModule,
         McOptionModule,
+        McProgressSpinnerModule,
         ClipboardModule
     ],
     declarations: EXAMPLES,

--- a/packages/mosaic-examples/mosaic/tree/index.ts
+++ b/packages/mosaic-examples/mosaic/tree/index.ts
@@ -18,6 +18,7 @@ import {
 } from './tree-multiple-checklist/tree-multiple-checklist-example';
 import { TreeMultipleKeyboardExample } from './tree-multiple-keyboard/tree-multiple-keyboard-example';
 import { TreeOverviewExample } from './tree-overview/tree-overview-example';
+import { TreeLazyloadExample } from './tree-lazyload/tree-lazyload-example';
 
 
 export {
@@ -26,7 +27,8 @@ export {
     TreeMultipleCheckboxExample,
     TreeMultipleChecklistExample,
     TreeMultipleKeyboardExample,
-    TreeFilteringExample
+    TreeFilteringExample,
+    TreeLazyloadExample
 };
 
 const EXAMPLES = [
@@ -35,7 +37,8 @@ const EXAMPLES = [
     TreeMultipleCheckboxExample,
     TreeMultipleChecklistExample,
     TreeMultipleKeyboardExample,
-    TreeFilteringExample
+    TreeFilteringExample,
+    TreeLazyloadExample
 ];
 
 @NgModule({

--- a/packages/mosaic-examples/mosaic/tree/tree-lazyload/tree-lazyload-example.css
+++ b/packages/mosaic-examples/mosaic/tree/tree-lazyload/tree-lazyload-example.css
@@ -1,0 +1,1 @@
+/** No CSS for this example */

--- a/packages/mosaic-examples/mosaic/tree/tree-lazyload/tree-lazyload-example.html
+++ b/packages/mosaic-examples/mosaic/tree/tree-lazyload/tree-lazyload-example.html
@@ -11,7 +11,7 @@
     <mc-tree-option
         *mcTreeNodeDef="let node; when: hasChild"
         mcTreeNodePadding>
-        <mc-tree-node-toggle [node]="node" (click)="clickNode(node)"></mc-tree-node-toggle>
+        <mc-tree-node-toggle [node]="node"></mc-tree-node-toggle>
         <mc-progress-spinner *ngIf="node.loading"
                              mode="indeterminate">
         </mc-progress-spinner>

--- a/packages/mosaic-examples/mosaic/tree/tree-lazyload/tree-lazyload-example.html
+++ b/packages/mosaic-examples/mosaic/tree/tree-lazyload/tree-lazyload-example.html
@@ -2,13 +2,19 @@
     [(ngModel)]="modelValue"
     [dataSource]="dataSource"
     [treeControl]="treeControl">
-
-    <mc-tree-option *mcTreeNodeDef="let node" mcTreeNodePadding [disabled]="node.name === 'tests'">
+    <mc-tree-option
+        *mcTreeNodeDef="let node"
+        mcTreeNodePadding>
         <span [innerHTML]="treeControl.getViewValue(node)"></span>
     </mc-tree-option>
 
-    <mc-tree-option *mcTreeNodeDef="let node; when: hasChild" mcTreeNodePadding>
-        <mc-tree-node-toggle [node]="node"></mc-tree-node-toggle>
+    <mc-tree-option
+        *mcTreeNodeDef="let node; when: hasChild"
+        mcTreeNodePadding>
+        <mc-tree-node-toggle [node]="node" (click)="clickNode(node)"></mc-tree-node-toggle>
+        <mc-progress-spinner *ngIf="node.loading"
+                             mode="indeterminate">
+        </mc-progress-spinner>
 
         <span [innerHTML]="treeControl.getViewValue(node)"></span>
     </mc-tree-option>

--- a/packages/mosaic-examples/mosaic/tree/tree-lazyload/tree-lazyload-example.html
+++ b/packages/mosaic-examples/mosaic/tree/tree-lazyload/tree-lazyload-example.html
@@ -1,0 +1,15 @@
+<mc-tree-selection
+    [(ngModel)]="modelValue"
+    [dataSource]="dataSource"
+    [treeControl]="treeControl">
+
+    <mc-tree-option *mcTreeNodeDef="let node" mcTreeNodePadding [disabled]="node.name === 'tests'">
+        <span [innerHTML]="treeControl.getViewValue(node)"></span>
+    </mc-tree-option>
+
+    <mc-tree-option *mcTreeNodeDef="let node; when: hasChild" mcTreeNodePadding>
+        <mc-tree-node-toggle [node]="node"></mc-tree-node-toggle>
+
+        <span [innerHTML]="treeControl.getViewValue(node)"></span>
+    </mc-tree-option>
+</mc-tree-selection>

--- a/packages/mosaic-examples/mosaic/tree/tree-lazyload/tree-lazyload-example.ts
+++ b/packages/mosaic-examples/mosaic/tree/tree-lazyload/tree-lazyload-example.ts
@@ -1,0 +1,163 @@
+/* tslint:disable:no-reserved-keywords object-literal-key-quotes */
+import { Component } from '@angular/core';
+import { FlatTreeControl, McTreeFlatDataSource, McTreeFlattener } from '@ptsecurity/mosaic/tree';
+
+
+export class FileNode {
+    children: FileNode[];
+    name: string;
+    type: any;
+}
+
+/** Flat node with expandable and level information */
+export class FileFlatNode {
+    name: string;
+    type: any;
+    level: number;
+    expandable: boolean;
+    parent: any;
+}
+
+/**
+ * Build the file structure tree. The `value` is the Json object, or a sub-tree of a Json object.
+ * The return value is the list of `FileNode`.
+ */
+export function buildFileTree(value: any, level: number): FileNode[] {
+    const data: any[] = [];
+
+    for (const k of Object.keys(value)) {
+        const v = value[k];
+        const node = new FileNode();
+
+        node.name = `${k}`;
+
+        if (v === null || v === undefined) {
+            // no action
+        } else if (typeof v === 'object') {
+            node.children = buildFileTree(v, level + 1);
+        } else {
+            node.type = v;
+        }
+
+        data.push(node);
+    }
+
+    return data;
+}
+
+export const DATA_OBJECT = {
+    docs: 'app',
+    src: {
+        cdk: {
+            a11ly: {
+                'aria describer': {
+                    'aria-describer': 'ts',
+                    'aria-describer.spec': 'ts',
+                    'aria-reference': 'ts',
+                    'aria-reference.spec': 'ts'
+                },
+                'focus monitor': {
+                    'focus-monitor': 'ts',
+                    'focus-monitor.spec': 'ts'
+                }
+            }
+        },
+        documentation: {
+            source: '',
+            tools: ''
+        },
+        mosaic: {
+            autocomplete: '',
+            button: '',
+            'button-toggle': '',
+            index: 'ts',
+            package: 'json',
+            version: 'ts'
+        },
+        'mosaic-dev': {
+            alert: '',
+            badge: ''
+        },
+        'mosaic-examples': '',
+        'mosaic-moment-adapter': '',
+        README: 'md',
+        'tsconfig.build': 'json',
+        wallabyTest: 'ts'
+    },
+    scripts: {
+        deploy: {
+            'cleanup-preview': 'ts',
+            'publish-artifacts': 'sh',
+            'publish-docs': 'sh',
+            'publish-docs-preview': 'ts'
+        },
+        'tsconfig.deploy': 'json'
+    },
+    tests: ''
+};
+
+/**
+ * @title Basic tree
+ */
+@Component({
+    selector: 'tree-lazyload-example',
+    templateUrl: 'tree-lazyload-example.html',
+    styleUrls: ['tree-lazyload-example.css']
+})
+export class TreeLazyloadExample {
+    treeControl: FlatTreeControl<FileFlatNode>;
+    treeFlattener: McTreeFlattener<FileNode, FileFlatNode>;
+
+    dataSource: McTreeFlatDataSource<FileNode, FileFlatNode>;
+
+    modelValue: any = '';
+
+    constructor() {
+        this.treeFlattener = new McTreeFlattener(
+            this.transformer, this.getLevel, this.isExpandable, this.getChildren
+        );
+
+        this.treeControl = new FlatTreeControl<FileFlatNode>(
+            this.getLevel, this.isExpandable, this.getValue, this.getViewValue
+        );
+        this.dataSource = new McTreeFlatDataSource(this.treeControl, this.treeFlattener);
+
+        this.dataSource.data = buildFileTree(DATA_OBJECT, 0);
+    }
+
+    hasChild(_: number, nodeData: FileFlatNode) { return nodeData.expandable; }
+
+    private transformer = (node: FileNode, level: number, parent: any) => {
+        const flatNode = new FileFlatNode();
+
+        flatNode.name = node.name;
+        flatNode.parent = parent;
+        flatNode.type = node.type;
+        flatNode.level = level;
+        flatNode.expandable = !!node.children;
+
+        return flatNode;
+    }
+
+    private getLevel = (node: FileFlatNode) => {
+        return node.level;
+    }
+
+    private isExpandable = (node: FileFlatNode) => {
+        return node.expandable;
+    }
+
+    private getChildren = (node: FileNode): FileNode[] => {
+        return node.children;
+    }
+
+    private getValue = (node: FileNode): string => {
+        return node.name;
+    }
+
+    private getViewValue = (node: FileNode): string => {
+        const nodeType = node.type ? `.${node.type}` : '';
+
+        return `${node.name}${nodeType}`;
+    }
+}

--- a/packages/mosaic/tree-select/tree-select.md
+++ b/packages/mosaic/tree-select/tree-select.md
@@ -4,3 +4,5 @@
 #### Multiple tree-select
 <!-- example(tree-select-multiple-overview) -->
 
+#### Lazy loading tree-select
+<!-- example(tree-select-lazyload) -->

--- a/packages/mosaic/tree/data-source/flat-data-source.ts
+++ b/packages/mosaic/tree/data-source/flat-data-source.ts
@@ -1,4 +1,4 @@
-import { CollectionViewer, DataSource } from '@angular/cdk/collections';
+import { CollectionViewer, DataSource, SelectionChange } from '@angular/cdk/collections';
 import { BehaviorSubject, merge, Observable } from 'rxjs';
 import { map, take } from 'rxjs/operators';
 
@@ -171,11 +171,11 @@ export class McTreeFlatDataSource<T, F> extends DataSource<F> {
                 if (changeObj.value && changeObj.value.length > 0) {
                     return this.filterHandler();
                 } else {
-                    return this.expansionHandler();
+                    return this.expansionHandler(changeObj.value);
                 }
             }
 
-            return this.expansionHandler();
+            return this.expansionHandler(changeObj.value);
         }));
     }
 
@@ -185,7 +185,7 @@ export class McTreeFlatDataSource<T, F> extends DataSource<F> {
         return this.filteredData.value;
     }
 
-    expansionHandler(): F[] {
+    expansionHandler(_change: SelectionChange<F>): F[] {
         const expandedNodes = this.treeFlattener.expandFlattenedNodes(this.flattenedData.value, this.treeControl);
         this.expandedData.next(expandedNodes);
 

--- a/packages/mosaic/tree/tree-option.component.ts
+++ b/packages/mosaic/tree/tree-option.component.ts
@@ -234,6 +234,10 @@ export class McTreeOption extends McTreeNode<McTreeOption> implements AfterConte
 
         this._selected = true;
 
+        if (!this.hasFocus) {
+            this.focus();
+        }
+
         this.changeDetectorRef.markForCheck();
         this.emitSelectionChangeEvent();
     }

--- a/packages/mosaic/tree/tree-option.html
+++ b/packages/mosaic/tree/tree-option.html
@@ -10,6 +10,8 @@
 
 <ng-content select="[mc-icon]"></ng-content>
 
+<ng-content select="mc-progress-spinner"></ng-content>
+
 <span class="mc-option-text mc-no-select"><ng-content></ng-content></span>
 
 <ng-content select="mc-option-action"></ng-content>

--- a/packages/mosaic/tree/tree-option.scss
+++ b/packages/mosaic/tree/tree-option.scss
@@ -31,6 +31,10 @@
         cursor: pointer;
     }
 
+    & > .mc-progress-spinner {
+        margin-right: 8px;
+    }
+
     &:focus {
         outline: none;
     }

--- a/packages/mosaic/tree/tree.md
+++ b/packages/mosaic/tree/tree.md
@@ -15,3 +15,6 @@
 
 ### Action button
 <!-- example(tree-action-button) -->
+
+### Lazy loading
+<!-- example(tree-lazyload) -->


### PR DESCRIPTION
[Примеры lazy loading для mc-tree-selection \ mc-tree-select](https://youtrack.ptsecurity.com/issue/UIM-802)


Добавлены пример для mc-tree-selection и для mc-tree-select

![tree](https://user-images.githubusercontent.com/95629181/148076264-a00dbb75-b92d-4ce0-bee8-95046bdff9d3.gif)

