### PR TITLE
fix(popover): trap focus in popover (#UIM-603)

### DIFF
--- a/packages/mosaic-dev/popover/module.ts
+++ b/packages/mosaic-dev/popover/module.ts
@@ -114,7 +114,7 @@ export class DemoComponent {
     get isFallbackActivated(): boolean {
         return this.selectedPlacement !== this.activatedPosition && this.activatedPosition !== '';
     }
-    
+
     onConfirm() {
         alert('confirmed');
     }

--- a/packages/mosaic-dev/popover/template.html
+++ b/packages/mosaic-dev/popover/template.html
@@ -13,7 +13,7 @@
 </ng-template>
 
 <ng-template #customFooter>
-    <div class="flex-100 layout-row layout-align-space-between-center" cdkTrapFocus="true" cdkTrapFocusAutoCapture="true">
+    <div class="flex-100 layout-row layout-align-space-between-center">
         <button class="step"
                 mc-button
                 [color]="themePalette.Primary"

--- a/packages/mosaic-examples/mosaic/popover/popover-overview/popover-overview-example.html
+++ b/packages/mosaic-examples/mosaic/popover/popover-overview/popover-overview-example.html
@@ -13,7 +13,7 @@
 </ng-template>
 
 <ng-template #customFooter>
-    <div class="flex-100 layout-row layout-align-space-between-center" cdkTrapFocus="true" cdkTrapFocusAutoCapture="true">
+    <div class="flex-100 layout-row layout-align-space-between-center">
         <button class="step"
                 mc-button
                 [color]="themePalette.Primary"

--- a/packages/mosaic/popover/popover-confirm.component.html
+++ b/packages/mosaic/popover/popover-confirm.component.html
@@ -1,11 +1,13 @@
 <div class="mc-popover-confirm mc-popover"
+     cdkTrapFocus="true"
+     cdkTrapFocusAutoCapture="true"
      [ngClass]="classMap"
      [@state]="visibility"
      (@state.start)="animationStart()"
      (@state.done)="animationDone($event)">
     <div class="mc-popover__content">
         <div>{{ confirmText }}</div>
-        <button mc-button [color]="themePalette.Primary" (click)="onConfirm.next()">{{confirmButtonText}}</button>    
+        <button mc-button [color]="themePalette.Primary" (click)="onConfirm.next()">{{confirmButtonText}}</button>
     </div>
 
     <div class="mc-popover__arrow"></div>

--- a/packages/mosaic/popover/popover.component.html
+++ b/packages/mosaic/popover/popover.component.html
@@ -1,4 +1,6 @@
 <div class="mc-popover"
+     [cdkTrapFocus]="isTrapFocus"
+     [cdkTrapFocusAutoCapture]="isTrapFocus"
      [ngClass]="classMap"
      [@state]="visibility"
      (@state.start)="animationStart()"

--- a/packages/mosaic/popover/popover.component.ts
+++ b/packages/mosaic/popover/popover.component.ts
@@ -56,6 +56,8 @@ export class McPopoverComponent extends McPopUp {
     header: string | TemplateRef<any>;
     footer: string | TemplateRef<any>;
 
+    isTrapFocus: boolean = false;
+
     constructor(changeDetectorRef: ChangeDetectorRef) {
         super(changeDetectorRef);
     }
@@ -66,6 +68,10 @@ export class McPopoverComponent extends McPopUp {
             customClass,
             { [`${this.prefix}_${size}`]: !!size }
         );
+    }
+
+    updateTrapFocus(isTrapFocus: boolean): void {
+        this.isTrapFocus = isTrapFocus;
     }
 }
 
@@ -274,6 +280,8 @@ export class McPopoverTrigger extends McPopUpTrigger<McPopoverComponent> {
         this.instance.header = this.header;
         this.instance.content = this.content;
         this.instance.footer = this.footer;
+
+        this.instance.updateTrapFocus(this.trigger !== PopUpTriggers.Focus);
 
         if (this.isOpen) {
             this.updatePosition(true);

--- a/packages/mosaic/popover/popover.module.ts
+++ b/packages/mosaic/popover/popover.module.ts
@@ -1,3 +1,4 @@
+import { A11yModule } from '@angular/cdk/a11y';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
@@ -10,7 +11,7 @@ import { MC_POPOVER_SCROLL_STRATEGY_FACTORY_PROVIDER, McPopoverComponent, McPopo
 @NgModule({
     declarations: [McPopoverComponent, McPopoverTrigger, McPopoverConfirmComponent, McPopoverConfirmTrigger],
     exports: [McPopoverComponent, McPopoverTrigger, McPopoverConfirmComponent, McPopoverConfirmTrigger],
-    imports: [CommonModule, OverlayModule, McButtonModule],
+    imports: [CommonModule, OverlayModule, McButtonModule, A11yModule],
     providers: [MC_POPOVER_SCROLL_STRATEGY_FACTORY_PROVIDER],
     entryComponents: [McPopoverComponent, McPopoverConfirmComponent]
 })


### PR DESCRIPTION
[[UI] It should be possible to set focus trap for popover](https://youtrack.ptsecurity.com/issue/UIM-603)

Добавлены cdkTrapFocus и cdkTrapFocusAutoCapture для mc-popover

При trigger = Focus, cdkTrapFocus и cdkTrapFocusAutoCapture надо включить

![popover](https://user-images.githubusercontent.com/95629181/148216027-3b4acff6-6918-44d7-b94e-85734f4c26c4.gif)

