### PR TITLE
fix(popover): remove popover viewport margin (#UIM-579)

### DIFF
--- a/packages/mosaic/core/pop-up/pop-up-trigger.ts
+++ b/packages/mosaic/core/pop-up/pop-up-trigger.ts
@@ -33,9 +33,6 @@ import {
 import { PopUpPlacements, PopUpTriggers } from './constants';
 
 
-const VIEWPORT_MARGIN: number = 8;
-
-
 @Directive()
 // tslint:disable-next-line:naming-convention
 export abstract class McPopUpTrigger<T> {
@@ -215,7 +212,6 @@ export abstract class McPopUpTrigger<T> {
             .flexibleConnectedTo(this.elementRef)
             .withTransformOriginOn(this.originSelector)
             .withFlexibleDimensions(false)
-            .withViewportMargin(VIEWPORT_MARGIN)
             .withPositions([...EXTENDED_OVERLAY_POSITIONS])
             .withScrollableContainers(this.scrollDispatcher.getAncestorScrollContainers(this.elementRef));
 


### PR DESCRIPTION
Задача: https://youtrack.ptsecurity.com/issue/UIM-579

Отступ работает только справа:
http://screenshots.ptsecurity.com/chrome_Spf1DEiLeK.png
http://screenshots.ptsecurity.com/chrome_VYYluqrGrk.png

Может быть его лучше оставить и сделать равным нулю, не нашла конкретно эту ошибку, но похожая - https://github.com/angular/components/issues/23127

