### PR TITLE
feat(formatter): add seconds and milliseconds options (#UIM-781)

### DIFF
--- a/packages/mosaic-dev/date-formatter/module.ts
+++ b/packages/mosaic-dev/date-formatter/module.ts
@@ -30,6 +30,7 @@ export class DemoComponent {
                 dateTime: {
                     currentYear: '',
                     notCurrentYear: '',
+                    seconds: '',
                     milliseconds: ''
                 }
             },
@@ -41,6 +42,7 @@ export class DemoComponent {
                 dateTime: {
                     currentYear: '',
                     notCurrentYear: '',
+                    seconds: '',
                     milliseconds: ''
                 }
             }
@@ -52,6 +54,8 @@ export class DemoComponent {
                 yesterday: '',
                 today: '',
                 tomorrow: '',
+                seconds: '',
+                milliseconds: '',
                 afterTomorrowCurrentYear: '',
                 afterTomorrowNotCurrentYear: ''
             },
@@ -61,6 +65,8 @@ export class DemoComponent {
                 yesterday: '',
                 today: '',
                 tomorrow: '',
+                seconds: '',
+                milliseconds: '',
                 afterTomorrowCurrentYear: '',
                 afterTomorrowNotCurrentYear: ''
             }
@@ -78,7 +84,8 @@ export class DemoComponent {
                     endsNotCurrentYear: '',
                     sameDateCurrentYear: '',
                     sameDateNotCurrentYear: '',
-                    notCurrentMonth: ''
+                    notCurrentMonth: '',
+                    milliseconds: ''
                 }
             },
             middle: {
@@ -88,7 +95,8 @@ export class DemoComponent {
                     sameDateNotCurrentYear: '',
                     notCurrentMonth: '',
                     startsNotCurrentYear: '',
-                    endsNotCurrentYear: ''
+                    endsNotCurrentYear: '',
+                    milliseconds: ''
                 }
             },
             short: {
@@ -103,7 +111,8 @@ export class DemoComponent {
                     sameDateNotCurrentYear: '',
                     notCurrentMonth: '',
                     startsNotCurrentYear: '',
-                    endsNotCurrentYear: ''
+                    endsNotCurrentYear: '',
+                    milliseconds: ''
                 }
             }
         }
@@ -119,6 +128,7 @@ export class DemoComponent {
                 dateTime: {
                     currentYear: '',
                     notCurrentYear: '',
+                    seconds: '',
                     milliseconds: ''
                 }
             },
@@ -130,6 +140,7 @@ export class DemoComponent {
                 dateTime: {
                     currentYear: '',
                     notCurrentYear: '',
+                    seconds: '',
                     milliseconds: ''
                 }
             }
@@ -141,6 +152,8 @@ export class DemoComponent {
                 yesterday: '',
                 today: '',
                 tomorrow: '',
+                seconds: '',
+                milliseconds: '',
                 afterTomorrowCurrentYear: '',
                 afterTomorrowNotCurrentYear: ''
             },
@@ -150,6 +163,8 @@ export class DemoComponent {
                 yesterday: '',
                 today: '',
                 tomorrow: '',
+                seconds: '',
+                milliseconds: '',
                 afterTomorrowCurrentYear: '',
                 afterTomorrowNotCurrentYear: ''
             }
@@ -167,7 +182,8 @@ export class DemoComponent {
                     endsNotCurrentYear: '',
                     sameDateCurrentYear: '',
                     sameDateNotCurrentYear: '',
-                    notCurrentMonth: ''
+                    notCurrentMonth: '',
+                    milliseconds: ''
                 }
             },
             middle: {
@@ -177,7 +193,8 @@ export class DemoComponent {
                     sameDateNotCurrentYear: '',
                     notCurrentMonth: '',
                     startsNotCurrentYear: '',
-                    endsNotCurrentYear: ''
+                    endsNotCurrentYear: '',
+                    milliseconds: ''
                 }
             },
             short: {
@@ -192,7 +209,8 @@ export class DemoComponent {
                     sameDateNotCurrentYear: '',
                     notCurrentMonth: '',
                     startsNotCurrentYear: '',
-                    endsNotCurrentYear: ''
+                    endsNotCurrentYear: '',
+                    milliseconds: ''
                 }
             }
         }
@@ -357,6 +375,8 @@ export class DemoComponent {
         relativeShort.afterTomorrowNotCurrentYear = this.dateFormatter.relativeShortDate(
             now.plus({ years: 1, days: 2 })
         );
+        relativeShort.seconds = this.dateFormatter.relativeShortDateTime(now, {seconds: true});
+        relativeShort.milliseconds = this.dateFormatter.relativeShortDateTime(now, {milliseconds: true});
     }
 
     private populateRelativeLong(locale: string) {
@@ -378,6 +398,8 @@ export class DemoComponent {
         relativeLong.afterTomorrowNotCurrentYear = this.dateFormatter.relativeLongDate(
             now.plus({ years: 1, days: 2 })
         );
+        relativeLong.seconds = this.dateFormatter.relativeLongDateTime(now, {seconds: true});
+        relativeLong.milliseconds = this.dateFormatter.relativeLongDateTime(now, {milliseconds: true});
     }
 
     private populateAbsoluteShort(locale: string) {
@@ -390,6 +412,7 @@ export class DemoComponent {
         absoluteShort.date.notCurrentYear = this.dateFormatter.absoluteShortDate(now.minus({ years: 1 }));
         absoluteShort.dateTime.currentYear = this.dateFormatter.absoluteShortDateTime(now);
         absoluteShort.dateTime.notCurrentYear = this.dateFormatter.absoluteShortDateTime(now.minus({ years: 1 }));
+        absoluteShort.dateTime.seconds = this.dateFormatter.absoluteShortDateTime(now, { seconds: true });
         absoluteShort.dateTime.milliseconds = this.dateFormatter.absoluteShortDateTime(now, { milliseconds: true });
     }
 
@@ -403,6 +426,7 @@ export class DemoComponent {
         absoluteLong.date.notCurrentYear = this.dateFormatter.absoluteLongDate(now.minus({ years: 1 }));
         absoluteLong.dateTime.currentYear = this.dateFormatter.absoluteLongDateTime(now);
         absoluteLong.dateTime.notCurrentYear = this.dateFormatter.absoluteLongDateTime(now.minus({ years: 1 }));
+        absoluteLong.dateTime.seconds = this.dateFormatter.absoluteLongDateTime(now, { seconds: true });
         absoluteLong.dateTime.milliseconds = this.dateFormatter.absoluteLongDateTime(now, { milliseconds: true });
     }
 }

--- a/packages/mosaic-dev/date-formatter/module.ts
+++ b/packages/mosaic-dev/date-formatter/module.ts
@@ -31,6 +31,7 @@ export class DemoComponent {
                     currentYear: '',
                     currentYearSeconds: '',
                     currentYearMilliseconds: '',
+
                     notCurrentYear: '',
                     notCurrentYearSeconds: '',
                     notCurrentYearMilliseconds: ''
@@ -45,6 +46,7 @@ export class DemoComponent {
                     currentYear: '',
                     currentYearSeconds: '',
                     currentYearMilliseconds: '',
+
                     notCurrentYear: '',
                     notCurrentYearSeconds: '',
                     notCurrentYearMilliseconds: ''
@@ -54,40 +56,52 @@ export class DemoComponent {
         relative: {
             long: {
                 beforeYesterdayNotCurrentYear: '',
+
                 beforeYesterdayCurrentYear: '',
                 beforeYesterdayCurrentYearSeconds: '',
                 beforeYesterdayCurrentYearMilliseconds: '',
+
                 yesterday: '',
                 yesterdaySeconds: '',
                 yesterdayMilliseconds: '',
+
                 today: '',
                 todaySeconds: '',
                 todayMilliseconds: '',
+
                 tomorrow: '',
                 tomorrowSeconds: '',
                 tomorrowMilliseconds: '',
+
                 afterTomorrowCurrentYear: '',
                 afterTomorrowCurrentYearSeconds: '',
                 afterTomorrowCurrentYearMilliseconds: '',
+
                 afterTomorrowNotCurrentYear: ''
             },
             short: {
                 beforeYesterdayNotCurrentYear: '',
+
                 beforeYesterdayCurrentYear: '',
                 beforeYesterdayCurrentYearSeconds: '',
                 beforeYesterdayCurrentYearMilliseconds: '',
+
                 yesterday: '',
                 yesterdaySeconds: '',
                 yesterdayMilliseconds: '',
+
                 today: '',
                 todaySeconds: '',
                 todayMilliseconds: '',
+
                 tomorrow: '',
                 tomorrowSeconds: '',
                 tomorrowMilliseconds: '',
+
                 afterTomorrowCurrentYear: '',
                 afterTomorrowCurrentYearSeconds: '',
                 afterTomorrowCurrentYearMilliseconds: '',
+
                 afterTomorrowNotCurrentYear: ''
             }
         },
@@ -101,22 +115,51 @@ export class DemoComponent {
                 },
                 dateTime: {
                     startsNotCurrentYear: '',
+                    startsNotCurrentYearSeconds: '',
+                    startsNotCurrentYearMilliseconds: '',
+
                     endsNotCurrentYear: '',
+                    endsNotCurrentYearSeconds: '',
+                    endsNotCurrentYearMilliseconds: '',
+
                     sameDateCurrentYear: '',
+                    sameDateCurrentYearSeconds: '',
+                    sameDateCurrentYearMilliseconds: '',
+
                     sameDateNotCurrentYear: '',
+                    sameDateNotCurrentYearSeconds: '',
+                    sameDateNotCurrentYearMilliseconds: '',
+
                     notCurrentMonth: '',
-                    milliseconds: ''
+                    notCurrentMonthSeconds: '',
+                    notCurrentMonthMilliseconds: ''
                 }
             },
             middle: {
                 dateTime: {
                     currentYear: '',
+                    currentYearSeconds: '',
+                    currentYearMilliseconds: '',
+
                     sameDateCurrentYear: '',
+                    sameDateCurrentYearSeconds: '',
+                    sameDateCurrentYearMilliseconds: '',
+
                     sameDateNotCurrentYear: '',
+                    sameDateNotCurrentYearSeconds: '',
+                    sameDateNotCurrentYearMilliseconds: '',
+
                     notCurrentMonth: '',
+                    notCurrentMonthSeconds: '',
+                    notCurrentMonthMilliseconds: '',
+
                     startsNotCurrentYear: '',
+                    startsNotCurrentYearSeconds: '',
+                    startsNotCurrentYearMilliseconds: '',
+
                     endsNotCurrentYear: '',
-                    milliseconds: ''
+                    endsNotCurrentYearSeconds: '',
+                    endsNotCurrentYearMilliseconds: ''
                 }
             },
             short: {
@@ -128,162 +171,44 @@ export class DemoComponent {
                 },
                 dateTime: {
                     sameDateCurrentYear: '',
+                    sameDateCurrentYearSeconds: '',
+                    sameDateCurrentYearMilliseconds: '',
+
                     sameDateNotCurrentYear: '',
+                    sameDateNotCurrentYearSeconds: '',
+                    sameDateNotCurrentYearMilliseconds: '',
+
                     notCurrentMonth: '',
+                    notCurrentMonthSeconds: '',
+                    notCurrentMonthMilliseconds: '',
+
                     startsNotCurrentYear: '',
+                    startsNotCurrentYearSeconds: '',
+                    startsNotCurrentYearMilliseconds: '',
+
                     endsNotCurrentYear: '',
-                    milliseconds: ''
+                    endsNotCurrentYearSeconds: '',
+                    endsNotCurrentYearMilliseconds: ''
                 }
             }
         }
     };
 
-    en = {
-        absolute: {
-            long: {
-                date: {
-                    currentYear: '',
-                    notCurrentYear: ''
-                },
-                dateTime: {
-                    currentYear: '',
-                    currentYearSeconds: '',
-                    currentYearMilliseconds: '',
-                    notCurrentYear: '',
-                    notCurrentYearSeconds: '',
-                    notCurrentYearMilliseconds: '',
-                    seconds: '',
-                    milliseconds: ''
-                }
-            },
-            short: {
-                date: {
-                    currentYear: '',
-                    notCurrentYear: ''
-                },
-                dateTime: {
-                    currentYear: '',
-                    currentYearSeconds: '',
-                    currentYearMilliseconds: '',
-                    notCurrentYear: '',
-                    notCurrentYearSeconds: '',
-                    notCurrentYearMilliseconds: '',
-                    seconds: '',
-                    milliseconds: ''
-                }
-            }
-        },
-        relative: {
-            long: {
-                beforeYesterdayNotCurrentYear: '',
-                beforeYesterdayCurrentYear: '',
-                beforeYesterdayCurrentYearSeconds: '',
-                beforeYesterdayCurrentYearMilliseconds: '',
-                yesterday: '',
-                yesterdaySeconds: '',
-                yesterdayMilliseconds: '',
-                today: '',
-                todaySeconds: '',
-                todayMilliseconds: '',
-                tomorrow: '',
-                tomorrowSeconds: '',
-                tomorrowMilliseconds: '',
-                afterTomorrowCurrentYear: '',
-                afterTomorrowCurrentYearSeconds: '',
-                afterTomorrowCurrentYearMilliseconds: '',
-                afterTomorrowNotCurrentYear: ''
-            },
-            short: {
-                beforeYesterdayNotCurrentYear: '',
-                beforeYesterdayCurrentYear: '',
-                beforeYesterdayCurrentYearSeconds: '',
-                beforeYesterdayCurrentYearMilliseconds: '',
-                yesterday: '',
-                yesterdaySeconds: '',
-                yesterdayMilliseconds: '',
-                today: '',
-                todaySeconds: '',
-                todayMilliseconds: '',
-                tomorrow: '',
-                tomorrowSeconds: '',
-                tomorrowMilliseconds: '',
-                afterTomorrowCurrentYear: '',
-                afterTomorrowCurrentYearSeconds: '',
-                afterTomorrowCurrentYearMilliseconds: '',
-                afterTomorrowNotCurrentYear: ''
-            }
-        },
-        range: {
-            long: {
-                date: {
-                    currentMonth: '',
-                    notCurrentYear: '',
-                    startsNotCurrentYear: '',
-                    endsNotCurrentYear: ''
-                },
-                dateTime: {
-                    startsNotCurrentYear: '',
-                    endsNotCurrentYear: '',
-                    sameDateCurrentYear: '',
-                    sameDateNotCurrentYear: '',
-                    notCurrentMonth: '',
-                    milliseconds: ''
-                }
-            },
-            middle: {
-                dateTime: {
-                    currentYear: '',
-                    sameDateCurrentYear: '',
-                    sameDateNotCurrentYear: '',
-                    notCurrentMonth: '',
-                    startsNotCurrentYear: '',
-                    endsNotCurrentYear: '',
-                    milliseconds: ''
-                }
-            },
-            short: {
-                date: {
-                    currentMonth: '',
-                    notCurrentYear: '',
-                    startsNotCurrentYear: '',
-                    endsNotCurrentYear: ''
-                },
-                dateTime: {
-                    sameDateCurrentYear: '',
-                    sameDateNotCurrentYear: '',
-                    notCurrentMonth: '',
-                    startsNotCurrentYear: '',
-                    endsNotCurrentYear: '',
-                    milliseconds: ''
-                }
-            }
-        }
-    };
+    en = JSON.parse(JSON.stringify(this.ru));
 
     constructor(
         private dateFormatter: DateFormatter<DateTime>,
         private dateAdapter: DateAdapter<DateTime>
     ) {
-        this.populateAbsoluteLong('ru');
-        this.populateAbsoluteLong('en');
-
-        this.populateAbsoluteShort('ru');
-        this.populateAbsoluteShort('en');
-
-        this.populateRelativeLong('ru');
-        this.populateRelativeLong('en');
-
-        this.populateRelativeShort('ru');
-        this.populateRelativeShort('en');
-
-        this.populateRangeLong('ru');
-        this.populateRangeLong('en');
-
-        this.populateRangeMiddle('ru');
-        this.populateRangeMiddle('en');
-
-        this.populateRangeShort('ru');
-        this.populateRangeShort('en');
+        ['ru', 'en'].forEach((language) => {
+            this.populateAbsoluteLong(language);
+            this.populateAbsoluteShort(language);
+            this.populateRelativeLong(language);
+            this.populateRelativeShort(language);
+            this.populateRangeLong(language);
+            this.populateRangeMiddle(language);
+            this.populateRangeShort(language);
+        });
     }
 
     private populateRangeShort(locale: string) {
@@ -305,25 +230,80 @@ export class DemoComponent {
             now.set({ day: 1, month: 1 }),
             now.set({ day: 10, month: 2 }).plus({ years: 1 })
         );
+
         shortRange.dateTime.sameDateCurrentYear = this.dateFormatter.rangeShortDateTime(
             now.set({ day: 10, hour: 10, minute: 14 }),
             now.set({ day: 10, hour: 11, minute: 28 })
         );
+        shortRange.dateTime.sameDateCurrentYearSeconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ day: 10, hour: 10, minute: 14 }),
+            now.set({ day: 10, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        shortRange.dateTime.sameDateCurrentYearMilliseconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ day: 10, hour: 10, minute: 14 }),
+            now.set({ day: 10, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         shortRange.dateTime.sameDateNotCurrentYear = this.dateFormatter.rangeShortDateTime(
             now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
             now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 })
         );
+        shortRange.dateTime.sameDateNotCurrentYearSeconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        shortRange.dateTime.sameDateNotCurrentYearMilliseconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         shortRange.dateTime.notCurrentMonth = this.dateFormatter.rangeShortDateTime(
             now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
             now.set({ month: 2, day: 1, hour: 11, minute: 28 })
         );
+        shortRange.dateTime.notCurrentMonthSeconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        shortRange.dateTime.notCurrentMonthMilliseconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         shortRange.dateTime.startsNotCurrentYear = this.dateFormatter.rangeShortDateTime(
             now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
             now.set({ month: 2, day: 1, hour: 11, minute: 28 })
         );
+        shortRange.dateTime.startsNotCurrentYearSeconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        shortRange.dateTime.startsNotCurrentYearMilliseconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         shortRange.dateTime.endsNotCurrentYear = this.dateFormatter.rangeShortDateTime(
             now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
             now.set({ day: 1, month: 2 }).plus({ years: 1 }).set({ hour: 11, minute: 28 })
+        );
+        shortRange.dateTime.endsNotCurrentYearSeconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ day: 1, month: 2 }).plus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        shortRange.dateTime.endsNotCurrentYearMilliseconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ day: 1, month: 2 }).plus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {milliseconds: true}
         );
     }
 
@@ -337,26 +317,94 @@ export class DemoComponent {
             now.set({ day: 1 }),
             now.set({ day: 10 })
         );
+
+        middleRange.dateTime.currentYearSeconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ day: 1 }),
+            now.set({ day: 10 }),
+            {seconds: true}
+        );
+
+        middleRange.dateTime.currentYearMilliseconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ day: 1 }),
+            now.set({ day: 10 }),
+            {milliseconds: true}
+        );
+
         middleRange.dateTime.sameDateCurrentYear = this.dateFormatter.rangeMiddleDateTime(
             now.set({ day: 10, hour: 10, minute: 14 }),
             now.set({ day: 10, hour: 10, minute: 28 })
         );
+        middleRange.dateTime.sameDateCurrentYearSeconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ day: 10, hour: 10, minute: 14 }),
+            now.set({ day: 10, hour: 10, minute: 28 }),
+            {seconds: true}
+        );
+        middleRange.dateTime.sameDateCurrentYearMilliseconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ day: 10, hour: 10, minute: 14 }),
+            now.set({ day: 10, hour: 10, minute: 28 }),
+            {milliseconds: true}
+        );
+
         middleRange.dateTime.sameDateNotCurrentYear = this.dateFormatter.rangeMiddleDateTime(
             now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
             now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 })
         );
+        middleRange.dateTime.sameDateNotCurrentYearSeconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        middleRange.dateTime.sameDateNotCurrentYearMilliseconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         middleRange.dateTime.notCurrentMonth = this.dateFormatter.rangeMiddleDateTime(
             now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
             now.set({ month: 2, day: 1, hour: 11, minute: 28 })
         );
+        middleRange.dateTime.notCurrentMonthSeconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        middleRange.dateTime.notCurrentMonthMilliseconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         middleRange.dateTime.startsNotCurrentYear = this.dateFormatter.rangeMiddleDateTime(
             now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
             now.set({ month: 1, day: 1, hour: 11, minute: 28 })
         );
+        middleRange.dateTime.startsNotCurrentYearSeconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 1, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        middleRange.dateTime.startsNotCurrentYearMilliseconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 1, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         middleRange.dateTime.endsNotCurrentYear = this.dateFormatter.rangeMiddleDateTime(
             now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
             now.set({ month: 1, day: 1 }).plus({ years: 1 }).set({ hour: 11, minute: 28 })
         );
+        middleRange.dateTime.endsNotCurrentYearSeconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 1 }).plus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        middleRange.dateTime.endsNotCurrentYearMilliseconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 1 }).plus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
     }
 
     private populateRangeLong(locale: string) {
@@ -382,22 +430,77 @@ export class DemoComponent {
             now.set({ day: 10, hour: 10, minute: 14 }),
             now.set({ day: 10, hour: 11, minute: 28 })
         );
+        longRange.dateTime.sameDateCurrentYearSeconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ day: 10, hour: 10, minute: 14 }),
+            now.set({ day: 10, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        longRange.dateTime.sameDateCurrentYearMilliseconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ day: 10, hour: 10, minute: 14 }),
+            now.set({ day: 10, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         longRange.dateTime.sameDateNotCurrentYear = this.dateFormatter.rangeLongDateTime(
             now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
             now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 })
         );
+        longRange.dateTime.sameDateNotCurrentYearSeconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        longRange.dateTime.sameDateNotCurrentYearMilliseconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         longRange.dateTime.notCurrentMonth = this.dateFormatter.rangeLongDateTime(
             now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
             now.set({ month: 2, day: 1, hour: 11, minute: 28 })
         );
+        longRange.dateTime.notCurrentMonthSeconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        longRange.dateTime.notCurrentMonthMilliseconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         longRange.dateTime.startsNotCurrentYear = this.dateFormatter.rangeLongDateTime(
             now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
             now.set({ month: 2, day: 1, hour: 11, minute: 28 })
         );
+        longRange.dateTime.startsNotCurrentYearSeconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        longRange.dateTime.startsNotCurrentYearMilliseconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         longRange.dateTime.endsNotCurrentYear = this.dateFormatter.rangeLongDateTime(
             now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
             now.set({ month: 2, day: 1 }).minus({ years: 1 }).set({ hour: 11, minute: 28 })
         );
+        longRange.dateTime.endsNotCurrentYearSeconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        longRange.dateTime.endsNotCurrentYearMilliseconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
     }
 
     private populateRelativeShort(locale: string) {

--- a/packages/mosaic-dev/date-formatter/module.ts
+++ b/packages/mosaic-dev/date-formatter/module.ts
@@ -29,9 +29,11 @@ export class DemoComponent {
                 },
                 dateTime: {
                     currentYear: '',
+                    currentYearSeconds: '',
+                    currentYearMilliseconds: '',
                     notCurrentYear: '',
-                    seconds: '',
-                    milliseconds: ''
+                    notCurrentYearSeconds: '',
+                    notCurrentYearMilliseconds: ''
                 }
             },
             short: {
@@ -41,9 +43,11 @@ export class DemoComponent {
                 },
                 dateTime: {
                     currentYear: '',
+                    currentYearSeconds: '',
+                    currentYearMilliseconds: '',
                     notCurrentYear: '',
-                    seconds: '',
-                    milliseconds: ''
+                    notCurrentYearSeconds: '',
+                    notCurrentYearMilliseconds: ''
                 }
             }
         },
@@ -51,23 +55,39 @@ export class DemoComponent {
             long: {
                 beforeYesterdayNotCurrentYear: '',
                 beforeYesterdayCurrentYear: '',
+                beforeYesterdayCurrentYearSeconds: '',
+                beforeYesterdayCurrentYearMilliseconds: '',
                 yesterday: '',
+                yesterdaySeconds: '',
+                yesterdayMilliseconds: '',
                 today: '',
+                todaySeconds: '',
+                todayMilliseconds: '',
                 tomorrow: '',
-                seconds: '',
-                milliseconds: '',
+                tomorrowSeconds: '',
+                tomorrowMilliseconds: '',
                 afterTomorrowCurrentYear: '',
+                afterTomorrowCurrentYearSeconds: '',
+                afterTomorrowCurrentYearMilliseconds: '',
                 afterTomorrowNotCurrentYear: ''
             },
             short: {
                 beforeYesterdayNotCurrentYear: '',
                 beforeYesterdayCurrentYear: '',
+                beforeYesterdayCurrentYearSeconds: '',
+                beforeYesterdayCurrentYearMilliseconds: '',
                 yesterday: '',
+                yesterdaySeconds: '',
+                yesterdayMilliseconds: '',
                 today: '',
+                todaySeconds: '',
+                todayMilliseconds: '',
                 tomorrow: '',
-                seconds: '',
-                milliseconds: '',
+                tomorrowSeconds: '',
+                tomorrowMilliseconds: '',
                 afterTomorrowCurrentYear: '',
+                afterTomorrowCurrentYearSeconds: '',
+                afterTomorrowCurrentYearMilliseconds: '',
                 afterTomorrowNotCurrentYear: ''
             }
         },
@@ -127,7 +147,11 @@ export class DemoComponent {
                 },
                 dateTime: {
                     currentYear: '',
+                    currentYearSeconds: '',
+                    currentYearMilliseconds: '',
                     notCurrentYear: '',
+                    notCurrentYearSeconds: '',
+                    notCurrentYearMilliseconds: '',
                     seconds: '',
                     milliseconds: ''
                 }
@@ -139,7 +163,11 @@ export class DemoComponent {
                 },
                 dateTime: {
                     currentYear: '',
+                    currentYearSeconds: '',
+                    currentYearMilliseconds: '',
                     notCurrentYear: '',
+                    notCurrentYearSeconds: '',
+                    notCurrentYearMilliseconds: '',
                     seconds: '',
                     milliseconds: ''
                 }
@@ -149,23 +177,39 @@ export class DemoComponent {
             long: {
                 beforeYesterdayNotCurrentYear: '',
                 beforeYesterdayCurrentYear: '',
+                beforeYesterdayCurrentYearSeconds: '',
+                beforeYesterdayCurrentYearMilliseconds: '',
                 yesterday: '',
+                yesterdaySeconds: '',
+                yesterdayMilliseconds: '',
                 today: '',
+                todaySeconds: '',
+                todayMilliseconds: '',
                 tomorrow: '',
-                seconds: '',
-                milliseconds: '',
+                tomorrowSeconds: '',
+                tomorrowMilliseconds: '',
                 afterTomorrowCurrentYear: '',
+                afterTomorrowCurrentYearSeconds: '',
+                afterTomorrowCurrentYearMilliseconds: '',
                 afterTomorrowNotCurrentYear: ''
             },
             short: {
                 beforeYesterdayNotCurrentYear: '',
                 beforeYesterdayCurrentYear: '',
+                beforeYesterdayCurrentYearSeconds: '',
+                beforeYesterdayCurrentYearMilliseconds: '',
                 yesterday: '',
+                yesterdaySeconds: '',
+                yesterdayMilliseconds: '',
                 today: '',
+                todaySeconds: '',
+                todayMilliseconds: '',
                 tomorrow: '',
-                seconds: '',
-                milliseconds: '',
+                tomorrowSeconds: '',
+                tomorrowMilliseconds: '',
                 afterTomorrowCurrentYear: '',
+                afterTomorrowCurrentYearSeconds: '',
+                afterTomorrowCurrentYearMilliseconds: '',
                 afterTomorrowNotCurrentYear: ''
             }
         },
@@ -366,17 +410,48 @@ export class DemoComponent {
             now.minus({ years: 1, days: 2 })
         );
         relativeShort.beforeYesterdayCurrentYear = this.dateFormatter.relativeShortDate(now.minus({ days: 2 }));
+        relativeShort.beforeYesterdayCurrentYearSeconds = this.dateFormatter.relativeShortDateTime(
+            now.minus({ days: 2 }), {seconds: true}
+        );
+        relativeShort.beforeYesterdayCurrentYearMilliseconds = this.dateFormatter.relativeShortDateTime(
+            now.minus({ days: 2 }), {milliseconds: true}
+        );
+
         relativeShort.yesterday = this.dateFormatter.relativeShortDate(now.minus({ days: 1 }));
+        relativeShort.yesterdaySeconds = this.dateFormatter.relativeShortDateTime(
+            now.minus({ days: 1 }), {seconds: true}
+        );
+        relativeShort.yesterdayMilliseconds = this.dateFormatter.relativeShortDateTime(
+            now.minus({ days: 1 }), {milliseconds: true}
+        );
 
         relativeShort.today = this.dateFormatter.relativeShortDate(now.minus({ hours: 1 }));
+        relativeShort.todaySeconds = this.dateFormatter.relativeShortDateTime(
+            now.minus({ hours: 1 }), {seconds: true}
+        );
+        relativeShort.todayMilliseconds = this.dateFormatter.relativeShortDateTime(
+            now.minus({ hours: 1 }), {milliseconds: true}
+        );
 
         relativeShort.tomorrow = this.dateFormatter.relativeShortDate(now.plus({ days: 1, hours: 1 }));
+        relativeShort.tomorrowSeconds = this.dateFormatter.relativeShortDateTime(
+            now.plus({ days: 1, hours: 1 }), {seconds: true}
+        );
+        relativeShort.tomorrowMilliseconds = this.dateFormatter.relativeShortDateTime(
+            now.plus({ days: 1, hours: 1 }), {milliseconds: true}
+        );
+
         relativeShort.afterTomorrowCurrentYear = this.dateFormatter.relativeShortDate(now.plus({ days: 2 }));
+        relativeShort.afterTomorrowCurrentYearSeconds = this.dateFormatter.relativeShortDateTime(
+            now.plus({ days: 2 }), {seconds: true}
+        );
+        relativeShort.afterTomorrowCurrentYearMilliseconds = this.dateFormatter.relativeShortDateTime(
+            now.plus({ days: 2 }), {milliseconds: true}
+        );
+
         relativeShort.afterTomorrowNotCurrentYear = this.dateFormatter.relativeShortDate(
             now.plus({ years: 1, days: 2 })
         );
-        relativeShort.seconds = this.dateFormatter.relativeShortDateTime(now, {seconds: true});
-        relativeShort.milliseconds = this.dateFormatter.relativeShortDateTime(now, {milliseconds: true});
     }
 
     private populateRelativeLong(locale: string) {
@@ -389,17 +464,32 @@ export class DemoComponent {
             now.minus({ years: 1, days: 2 })
         );
         relativeLong.beforeYesterdayCurrentYear = this.dateFormatter.relativeLongDate(now.minus({ days: 2 }));
+        relativeLong.beforeYesterdayCurrentYearSeconds = this.dateFormatter.relativeLongDateTime(now.minus({ days: 2 }), {seconds: true});
+        relativeLong.beforeYesterdayCurrentYearMilliseconds = this.dateFormatter.relativeLongDateTime(
+            now.minus({ days: 2 }), {milliseconds: true}
+        );
+
         relativeLong.yesterday = this.dateFormatter.relativeLongDate(now.minus({ days: 1 }));
+        relativeLong.yesterdaySeconds = this.dateFormatter.relativeLongDateTime(now.minus({ days: 1 }), {seconds: true});
+        relativeLong.yesterdayMilliseconds = this.dateFormatter.relativeLongDateTime(now.minus({ days: 1 }), {milliseconds: true});
 
         relativeLong.today = this.dateFormatter.relativeLongDate(now.minus({ hours: 1 }));
+        relativeLong.todaySeconds = this.dateFormatter.relativeLongDateTime(now.minus({ hours: 1 }), {seconds: true});
+        relativeLong.todayMilliseconds = this.dateFormatter.relativeLongDateTime(now.minus({ hours: 1 }), {milliseconds: true});
 
         relativeLong.tomorrow = this.dateFormatter.relativeLongDate(now.plus({ days: 1, hours: 1 }));
+        relativeLong.tomorrowSeconds = this.dateFormatter.relativeLongDateTime(now.plus({ days: 1, hours: 1 }), {seconds: true});
+        relativeLong.tomorrowMilliseconds = this.dateFormatter.relativeLongDateTime(now.plus({ days: 1, hours: 1 }), {milliseconds: true});
+
         relativeLong.afterTomorrowCurrentYear = this.dateFormatter.relativeLongDate(now.plus({ days: 2 }));
+        relativeLong.afterTomorrowCurrentYearSeconds = this.dateFormatter.relativeLongDateTime(now.plus({ days: 2 }), {seconds: true});
+        relativeLong.afterTomorrowCurrentYearMilliseconds = this.dateFormatter.relativeLongDateTime(
+            now.plus({ days: 2 }), {milliseconds: true}
+        );
+
         relativeLong.afterTomorrowNotCurrentYear = this.dateFormatter.relativeLongDate(
             now.plus({ years: 1, days: 2 })
         );
-        relativeLong.seconds = this.dateFormatter.relativeLongDateTime(now, {seconds: true});
-        relativeLong.milliseconds = this.dateFormatter.relativeLongDateTime(now, {milliseconds: true});
     }
 
     private populateAbsoluteShort(locale: string) {
@@ -410,10 +500,16 @@ export class DemoComponent {
 
         absoluteShort.date.currentYear = this.dateFormatter.absoluteShortDate(now);
         absoluteShort.date.notCurrentYear = this.dateFormatter.absoluteShortDate(now.minus({ years: 1 }));
+
         absoluteShort.dateTime.currentYear = this.dateFormatter.absoluteShortDateTime(now);
+        absoluteShort.dateTime.currentYearSeconds = this.dateFormatter.absoluteShortDateTime(now, {seconds: true});
+        absoluteShort.dateTime.currentYearMilliseconds = this.dateFormatter.absoluteShortDateTime(now, {milliseconds: true});
+
         absoluteShort.dateTime.notCurrentYear = this.dateFormatter.absoluteShortDateTime(now.minus({ years: 1 }));
-        absoluteShort.dateTime.seconds = this.dateFormatter.absoluteShortDateTime(now, { seconds: true });
-        absoluteShort.dateTime.milliseconds = this.dateFormatter.absoluteShortDateTime(now, { milliseconds: true });
+        absoluteShort.dateTime.notCurrentYearSeconds = this.dateFormatter.absoluteShortDateTime(now.minus({ years: 1 }), {seconds: true});
+        absoluteShort.dateTime.notCurrentYearMilliseconds = this.dateFormatter.absoluteShortDateTime(
+            now.minus({ years: 1 }), {milliseconds: true}
+        );
     }
 
     private populateAbsoluteLong(locale: string) {
@@ -424,10 +520,16 @@ export class DemoComponent {
 
         absoluteLong.date.currentYear = this.dateFormatter.absoluteLongDate(now);
         absoluteLong.date.notCurrentYear = this.dateFormatter.absoluteLongDate(now.minus({ years: 1 }));
+
         absoluteLong.dateTime.currentYear = this.dateFormatter.absoluteLongDateTime(now);
+        absoluteLong.dateTime.currentYearSeconds = this.dateFormatter.absoluteLongDateTime(now, {seconds: true});
+        absoluteLong.dateTime.currentYearMilliseconds = this.dateFormatter.absoluteLongDateTime(now, {milliseconds: true});
+
         absoluteLong.dateTime.notCurrentYear = this.dateFormatter.absoluteLongDateTime(now.minus({ years: 1 }));
-        absoluteLong.dateTime.seconds = this.dateFormatter.absoluteLongDateTime(now, { seconds: true });
-        absoluteLong.dateTime.milliseconds = this.dateFormatter.absoluteLongDateTime(now, { milliseconds: true });
+        absoluteLong.dateTime.notCurrentYearSeconds = this.dateFormatter.absoluteLongDateTime(now.minus({ years: 1 }), {seconds: true});
+        absoluteLong.dateTime.notCurrentYearMilliseconds = this.dateFormatter.absoluteLongDateTime(
+            now.minus({ years: 1 }), {milliseconds: true}
+        );
     }
 }
 

--- a/packages/mosaic-dev/date-formatter/module.ts
+++ b/packages/mosaic-dev/date-formatter/module.ts
@@ -404,7 +404,6 @@ export class DemoComponent {
             now.set({ month: 1, day: 1 }).plus({ years: 1 }).set({ hour: 11, minute: 28 }),
             {milliseconds: true}
         );
-
     }
 
     private populateRangeLong(locale: string) {
@@ -500,7 +499,6 @@ export class DemoComponent {
             now.set({ month: 2, day: 1 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
             {milliseconds: true}
         );
-
     }
 
     private populateRelativeShort(locale: string) {

--- a/packages/mosaic-dev/date-formatter/template.html
+++ b/packages/mosaic-dev/date-formatter/template.html
@@ -569,7 +569,6 @@
                 <div class="flex">{{ ru.range.middle.dateTime.endsNotCurrentYearMilliseconds }}</div>
                 <div class="flex">{{ en.range.middle.dateTime.endsNotCurrentYearMilliseconds }}</div>
             </div>
-            <div class="row-border"></div>
         </div>
     </div>
     <div class="common-container">
@@ -587,7 +586,7 @@
             </div>
             <div class="layout-row row-border">
                 <div class="flex">rangeShortDate (not current month)</div>
-                    <div class="flex">{{ ru.range.short.date.notCurrentYear }}</div>
+                <div class="flex">{{ ru.range.short.date.notCurrentYear }}</div>
                 <div class="flex">{{ en.range.short.date.notCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">

--- a/packages/mosaic-dev/date-formatter/template.html
+++ b/packages/mosaic-dev/date-formatter/template.html
@@ -30,6 +30,11 @@
                 <div class="flex">{{ en.absolute.long.dateTime.notCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">absoluteLongDateTime (with seconds)</div>
+                <div class="flex">{{ ru.absolute.long.dateTime.seconds }}</div>
+                <div class="flex">{{ en.absolute.long.dateTime.seconds }}</div>
+            </div>
+            <div class="layout-row row-border">
                 <div class="flex">absoluteLongDateTime (with milliseconds)</div>
                 <div class="flex">{{ ru.absolute.long.dateTime.milliseconds }}</div>
                 <div class="flex">{{ en.absolute.long.dateTime.milliseconds }}</div>
@@ -63,6 +68,11 @@
                 <div class="flex">absoluteShortDateTime (not current year)</div>
                 <div class="flex">{{ ru.absolute.short.dateTime.notCurrentYear }}</div>
                 <div class="flex">{{ en.absolute.short.dateTime.notCurrentYear }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">absoluteShortDateTime (with seconds)</div>
+                <div class="flex">{{ ru.absolute.short.dateTime.seconds }}</div>
+                <div class="flex">{{ en.absolute.short.dateTime.seconds }}</div>
             </div>
             <div class="layout-row row-border">
                 <div class="flex">absoluteShortDateTime (with milliseconds)</div>
@@ -124,6 +134,18 @@
                 <div class="flex">{{ ru.relative.long.afterTomorrowNotCurrentYear }}</div>
                 <div class="flex">{{ en.relative.long.afterTomorrowNotCurrentYear }}</div>
             </div>
+            
+            <div class="layout-row row-border">
+                <div class="flex">With seconds</div>
+                <div class="flex">{{ ru.relative.long.seconds }}</div>
+                <div class="flex">{{ en.relative.long.seconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">With milliseconds</div>
+                <div class="flex">{{ ru.relative.long.milliseconds }}</div>
+                <div class="flex">{{ en.relative.long.milliseconds }}</div>
+            </div>
         </div>
     </div>
     <div class="common-container">
@@ -175,6 +197,18 @@
                 <div class="flex">After tomorrow (not current year)</div>
                 <div class="flex">{{ ru.relative.short.afterTomorrowNotCurrentYear }}</div>
                 <div class="flex">{{ en.relative.short.afterTomorrowNotCurrentYear }}</div>
+            </div>
+            
+            <div class="layout-row row-border">
+                <div class="flex">With seconds</div>
+                <div class="flex">{{ ru.relative.short.seconds }}</div>
+                <div class="flex">{{ en.relative.short.seconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">With milliseconds</div>
+                <div class="flex">{{ ru.relative.short.milliseconds }}</div>
+                <div class="flex">{{ en.relative.short.milliseconds }}</div>
             </div>
         </div>
     </div>

--- a/packages/mosaic-dev/date-formatter/template.html
+++ b/packages/mosaic-dev/date-formatter/template.html
@@ -19,6 +19,8 @@
                 <div class="flex">{{ ru.absolute.long.date.notCurrentYear }}</div>
                 <div class="flex">{{ en.absolute.long.date.notCurrentYear }}</div>
             </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">absoluteLongDateTime (current year)</div>
                 <div class="flex">{{ ru.absolute.long.dateTime.currentYear }}</div>
@@ -34,6 +36,8 @@
                 <div class="flex">{{ ru.absolute.long.dateTime.currentYearMilliseconds }}</div>
                 <div class="flex">{{ en.absolute.long.dateTime.currentYearMilliseconds }}</div>
             </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">absoluteLongDateTime (not current year)</div>
                 <div class="flex">{{ ru.absolute.long.dateTime.notCurrentYear }}</div>
@@ -69,6 +73,8 @@
                 <div class="flex">{{ ru.absolute.short.date.notCurrentYear }}</div>
                 <div class="flex">{{ en.absolute.short.date.notCurrentYear }}</div>
             </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">absoluteShortDateTime (current year)</div>
                 <div class="flex">{{ ru.absolute.short.dateTime.currentYear }}</div>
@@ -84,6 +90,8 @@
                 <div class="flex">{{ ru.absolute.short.dateTime.currentYearMilliseconds }}</div>
                 <div class="flex">{{ en.absolute.short.dateTime.currentYearMilliseconds }}</div>
             </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">absoluteShortDateTime (not current year)</div>
                 <div class="flex">{{ ru.absolute.short.dateTime.notCurrentYear }}</div>
@@ -118,6 +126,7 @@
                 <div class="flex">{{ ru.relative.long.beforeYesterdayNotCurrentYear }}</div>
                 <div class="flex">{{ en.relative.long.beforeYesterdayNotCurrentYear }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">Before yesterday (current year)</div>
@@ -136,6 +145,7 @@
                 <div class="flex">{{ ru.relative.long.beforeYesterdayCurrentYearMilliseconds }}</div>
                 <div class="flex">{{ en.relative.long.beforeYesterdayCurrentYearMilliseconds }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">Yesterday</div>
@@ -154,6 +164,7 @@
                 <div class="flex">{{ ru.relative.long.yesterdayMilliseconds }}</div>
                 <div class="flex">{{ en.relative.long.yesterdayMilliseconds }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">Today</div>
@@ -172,6 +183,7 @@
                 <div class="flex">{{ ru.relative.long.todayMilliseconds }}</div>
                 <div class="flex">{{ en.relative.long.todayMilliseconds }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">Tomorrow</div>
@@ -190,6 +202,7 @@
                 <div class="flex">{{ ru.relative.long.tomorrowMilliseconds }}</div>
                 <div class="flex">{{ en.relative.long.tomorrowMilliseconds }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">After tomorrow (current year)</div>
@@ -208,6 +221,7 @@
                 <div class="flex">{{ ru.relative.long.afterTomorrowCurrentYearMilliseconds }}</div>
                 <div class="flex">{{ en.relative.long.afterTomorrowCurrentYearMilliseconds }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">After tomorrow (not current year)</div>
@@ -230,6 +244,7 @@
                 <div class="flex">{{ ru.relative.short.beforeYesterdayNotCurrentYear }}</div>
                 <div class="flex">{{ en.relative.short.beforeYesterdayNotCurrentYear }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">Before yesterday (current year)</div>
@@ -248,6 +263,7 @@
                 <div class="flex">{{ ru.relative.short.beforeYesterdayCurrentYearMilliseconds }}</div>
                 <div class="flex">{{ en.relative.short.beforeYesterdayCurrentYearMilliseconds }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">Yesterday</div>
@@ -266,6 +282,7 @@
                 <div class="flex">{{ ru.relative.short.yesterdayMilliseconds }}</div>
                 <div class="flex">{{ en.relative.short.yesterdayMilliseconds }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">Today</div>
@@ -284,6 +301,7 @@
                 <div class="flex">{{ ru.relative.short.todayMilliseconds }}</div>
                 <div class="flex">{{ en.relative.short.todayMilliseconds }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">Tomorrow</div>
@@ -302,6 +320,7 @@
                 <div class="flex">{{ ru.relative.short.tomorrowMilliseconds }}</div>
                 <div class="flex">{{ en.relative.short.tomorrowMilliseconds }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">After tomorrow (current year)</div>
@@ -320,6 +339,7 @@
                 <div class="flex">{{ ru.relative.short.afterTomorrowCurrentYearMilliseconds }}</div>
                 <div class="flex">{{ en.relative.short.afterTomorrowCurrentYearMilliseconds }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">After tomorrow (not current year)</div>
@@ -359,30 +379,90 @@
                 <div class="flex">{{ ru.range.long.date.endsNotCurrentYear }}</div>
                 <div class="flex">{{ en.range.long.date.endsNotCurrentYear }}</div>
             </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">rangeLongDateTime (the same day, current year)</div>
                 <div class="flex">{{ ru.range.long.dateTime.sameDateCurrentYear }}</div>
                 <div class="flex">{{ en.range.long.dateTime.sameDateCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (the same day, current year) (with seconds)</div>
+                <div class="flex">{{ ru.range.long.dateTime.sameDateCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.range.long.dateTime.sameDateCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (the same day, current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.long.dateTime.sameDateCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.range.long.dateTime.sameDateCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">rangeLongDateTime (the same day, not current year)</div>
                 <div class="flex">{{ ru.range.long.dateTime.sameDateNotCurrentYear }}</div>
                 <div class="flex">{{ en.range.long.dateTime.sameDateNotCurrentYear }}</div>
             </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (the same day, not current year) (with seconds)</div>
+                <div class="flex">{{ ru.range.long.dateTime.sameDateNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.range.long.dateTime.sameDateNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (the same day, not current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.long.dateTime.sameDateNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.range.long.dateTime.sameDateNotCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">rangeLongDateTime (not current month)</div>
                 <div class="flex">{{ ru.range.long.dateTime.notCurrentMonth }}</div>
                 <div class="flex">{{ en.range.long.dateTime.notCurrentMonth }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (not current month) (with seconds)</div>
+                <div class="flex">{{ ru.range.long.dateTime.notCurrentMonthSeconds }}</div>
+                <div class="flex">{{ en.range.long.dateTime.notCurrentMonthSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (not current month) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.long.dateTime.notCurrentMonthMilliseconds }}</div>
+                <div class="flex">{{ en.range.long.dateTime.notCurrentMonthMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">rangeLongDateTime (start date is not in current year)</div>
                 <div class="flex">{{ ru.range.long.dateTime.startsNotCurrentYear }}</div>
                 <div class="flex">{{ en.range.long.dateTime.startsNotCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (start date is not in current year) (with seconds)</div>
+                <div class="flex">{{ ru.range.long.dateTime.startsNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.range.long.dateTime.startsNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (start date is not in current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.long.dateTime.startsNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.range.long.dateTime.startsNotCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">rangeLongDateTime (end date is not in current year)</div>
                 <div class="flex">{{ ru.range.long.dateTime.endsNotCurrentYear }}</div>
                 <div class="flex">{{ en.range.long.dateTime.endsNotCurrentYear }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (end date is not in current year) (with seconds)</div>
+                <div class="flex">{{ ru.range.long.dateTime.endsNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.range.long.dateTime.endsNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (end date is not in current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.long.dateTime.endsNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.range.long.dateTime.endsNotCurrentYearMilliseconds }}</div>
             </div>
         </div>
     </div>
@@ -400,30 +480,96 @@
                 <div class="flex">{{ en.range.middle.dateTime.currentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (with seconds)</div>
+                <div class="flex">{{ ru.range.middle.dateTime.currentYearSeconds }}</div>
+                <div class="flex">{{ en.range.middle.dateTime.currentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (with milliseconds)</div>
+                <div class="flex">{{ ru.range.middle.dateTime.currentYearMilliseconds }}</div>
+                <div class="flex">{{ en.range.middle.dateTime.currentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+            <div class="layout-row row-border">
                 <div class="flex">rangeMiddleDateTime (the same day)</div>
                 <div class="flex">{{ ru.range.middle.dateTime.sameDateCurrentYear }}</div>
                 <div class="flex">{{ en.range.middle.dateTime.sameDateCurrentYear }}</div>
             </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (the same day) (with seconds)</div>
+                <div class="flex">{{ ru.range.middle.dateTime.sameDateCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.range.middle.dateTime.sameDateCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (the same day) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.middle.dateTime.sameDateCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.range.middle.dateTime.sameDateCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
             <div class="layout-row row-border">
                 <div class="flex">rangeMiddleDateTime (the same day, not current year)</div>
                 <div class="flex">{{ ru.range.middle.dateTime.sameDateNotCurrentYear }}</div>
                 <div class="flex">{{ en.range.middle.dateTime.sameDateNotCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (the same day, not current year) (with seconds)</div>
+                <div class="flex">{{ ru.range.middle.dateTime.sameDateNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.range.middle.dateTime.sameDateNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (the same day, not current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.middle.dateTime.sameDateNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.range.middle.dateTime.sameDateNotCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+            <div class="layout-row row-border">
                 <div class="flex">rangeMiddleDateTime (not current month)</div>
                 <div class="flex">{{ ru.range.middle.dateTime.notCurrentMonth }}</div>
                 <div class="flex">{{ en.range.middle.dateTime.notCurrentMonth }}</div>
             </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (not current month) (with seconds)</div>
+                <div class="flex">{{ ru.range.middle.dateTime.notCurrentMonthSeconds }}</div>
+                <div class="flex">{{ en.range.middle.dateTime.notCurrentMonthSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (not current month) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.middle.dateTime.notCurrentMonthMilliseconds }}</div>
+                <div class="flex">{{ en.range.middle.dateTime.notCurrentMonthMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
             <div class="layout-row row-border">
                 <div class="flex">rangeMiddleDateTime (start date is not in current year)</div>
                 <div class="flex">{{ ru.range.middle.dateTime.startsNotCurrentYear }}</div>
                 <div class="flex">{{ en.range.middle.dateTime.startsNotCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (start date is not in current year) (with seconds)</div>
+                <div class="flex">{{ ru.range.middle.dateTime.startsNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.range.middle.dateTime.startsNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (start date is not in current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.middle.dateTime.startsNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.range.middle.dateTime.startsNotCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+            <div class="layout-row row-border">
                 <div class="flex">rangeMiddleDateTime (end date is not in current year)</div>
                 <div class="flex">{{ ru.range.middle.dateTime.endsNotCurrentYear }}</div>
                 <div class="flex">{{ en.range.middle.dateTime.endsNotCurrentYear }}</div>
             </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (end date is not in current year) (with seconds)</div>
+                <div class="flex">{{ ru.range.middle.dateTime.endsNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.range.middle.dateTime.endsNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (end date is not in current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.middle.dateTime.endsNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.range.middle.dateTime.endsNotCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
         </div>
     </div>
     <div class="common-container">
@@ -454,30 +600,90 @@
                 <div class="flex">{{ ru.range.short.date.endsNotCurrentYear }}</div>
                 <div class="flex">{{ en.range.short.date.endsNotCurrentYear }}</div>
             </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">rangeShortDateTime (the same day, current year)</div>
                 <div class="flex">{{ ru.range.short.dateTime.sameDateCurrentYear }}</div>
                 <div class="flex">{{ en.range.short.dateTime.sameDateCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (the same day, current year) (with seconds)</div>
+                <div class="flex">{{ ru.range.short.dateTime.sameDateCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.range.short.dateTime.sameDateCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (the same day, current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.short.dateTime.sameDateCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.range.short.dateTime.sameDateCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">rangeShortDateTime (the same day, not current year)</div>
                 <div class="flex">{{ ru.range.short.dateTime.sameDateNotCurrentYear }}</div>
                 <div class="flex">{{ en.range.short.dateTime.sameDateNotCurrentYear }}</div>
             </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (the same day, not current year) (with seconds)</div>
+                <div class="flex">{{ ru.range.short.dateTime.sameDateNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.range.short.dateTime.sameDateNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (the same day, not current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.short.dateTime.sameDateNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.range.short.dateTime.sameDateNotCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">rangeShortDateTime (not current month)</div>
                 <div class="flex">{{ ru.range.short.dateTime.notCurrentMonth }}</div>
                 <div class="flex">{{ en.range.short.dateTime.notCurrentMonth }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (not current month) (with seconds)</div>
+                <div class="flex">{{ ru.range.short.dateTime.notCurrentMonthSeconds }}</div>
+                <div class="flex">{{ en.range.short.dateTime.notCurrentMonthSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (not current month) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.short.dateTime.notCurrentMonthMilliseconds }}</div>
+                <div class="flex">{{ en.range.short.dateTime.notCurrentMonthMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">rangeShortDateTime (start date is not in current year)</div>
                 <div class="flex">{{ ru.range.short.dateTime.startsNotCurrentYear }}</div>
                 <div class="flex">{{ en.range.short.dateTime.startsNotCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (start date is not in current year) (with seconds)</div>
+                <div class="flex">{{ ru.range.short.dateTime.startsNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.range.short.dateTime.startsNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (start date is not in current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.short.dateTime.startsNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.range.short.dateTime.startsNotCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">rangeShortDateTime (end date is not in current year)</div>
                 <div class="flex">{{ ru.range.short.dateTime.endsNotCurrentYear }}</div>
                 <div class="flex">{{ en.range.short.dateTime.endsNotCurrentYear }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (end date is not in current year) (with seconds)</div>
+                <div class="flex">{{ ru.range.short.dateTime.endsNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.range.short.dateTime.endsNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (end date is not in current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.range.short.dateTime.endsNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.range.short.dateTime.endsNotCurrentYearMilliseconds }}</div>
             </div>
         </div>
     </div>

--- a/packages/mosaic-dev/date-formatter/template.html
+++ b/packages/mosaic-dev/date-formatter/template.html
@@ -25,19 +25,29 @@
                 <div class="flex">{{ en.absolute.long.dateTime.currentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">absoluteLongDateTime (current year) (with seconds)</div>
+                <div class="flex">{{ ru.absolute.long.dateTime.currentYearSeconds }}</div>
+                <div class="flex">{{ en.absolute.long.dateTime.currentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">absoluteLongDateTime (current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.absolute.long.dateTime.currentYearMilliseconds }}</div>
+                <div class="flex">{{ en.absolute.long.dateTime.currentYearMilliseconds }}</div>
+            </div>
+            <div class="layout-row row-border">
                 <div class="flex">absoluteLongDateTime (not current year)</div>
                 <div class="flex">{{ ru.absolute.long.dateTime.notCurrentYear }}</div>
                 <div class="flex">{{ en.absolute.long.dateTime.notCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
-                <div class="flex">absoluteLongDateTime (with seconds)</div>
-                <div class="flex">{{ ru.absolute.long.dateTime.seconds }}</div>
-                <div class="flex">{{ en.absolute.long.dateTime.seconds }}</div>
+                <div class="flex">absoluteLongDateTime (not current year) (with seconds)</div>
+                <div class="flex">{{ ru.absolute.long.dateTime.notCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.absolute.long.dateTime.notCurrentYearSeconds }}</div>
             </div>
             <div class="layout-row row-border">
-                <div class="flex">absoluteLongDateTime (with milliseconds)</div>
-                <div class="flex">{{ ru.absolute.long.dateTime.milliseconds }}</div>
-                <div class="flex">{{ en.absolute.long.dateTime.milliseconds }}</div>
+                <div class="flex">absoluteLongDateTime (not current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.absolute.long.dateTime.notCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.absolute.long.dateTime.notCurrentYearMilliseconds }}</div>
             </div>
         </div>
     </div>
@@ -65,19 +75,29 @@
                 <div class="flex">{{ en.absolute.short.dateTime.currentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">absoluteShortDateTime (current year) (with seconds)</div>
+                <div class="flex">{{ ru.absolute.short.dateTime.currentYearSeconds }}</div>
+                <div class="flex">{{ en.absolute.short.dateTime.currentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">absoluteShortDateTime (current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.absolute.short.dateTime.currentYearMilliseconds }}</div>
+                <div class="flex">{{ en.absolute.short.dateTime.currentYearMilliseconds }}</div>
+            </div>
+            <div class="layout-row row-border">
                 <div class="flex">absoluteShortDateTime (not current year)</div>
                 <div class="flex">{{ ru.absolute.short.dateTime.notCurrentYear }}</div>
                 <div class="flex">{{ en.absolute.short.dateTime.notCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
-                <div class="flex">absoluteShortDateTime (with seconds)</div>
-                <div class="flex">{{ ru.absolute.short.dateTime.seconds }}</div>
-                <div class="flex">{{ en.absolute.short.dateTime.seconds }}</div>
+                <div class="flex">absoluteShortDateTime (not current year) (with seconds)</div>
+                <div class="flex">{{ ru.absolute.short.dateTime.notCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.absolute.short.dateTime.notCurrentYearSeconds }}</div>
             </div>
             <div class="layout-row row-border">
-                <div class="flex">absoluteShortDateTime (with milliseconds)</div>
-                <div class="flex">{{ ru.absolute.short.dateTime.milliseconds }}</div>
-                <div class="flex">{{ en.absolute.short.dateTime.milliseconds }}</div>
+                <div class="flex">absoluteShortDateTime (not current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.absolute.short.dateTime.notCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.absolute.short.dateTime.notCurrentYearMilliseconds }}</div>
             </div>
         </div>
     </div>
@@ -106,9 +126,33 @@
             </div>
 
             <div class="layout-row row-border">
+                <div class="flex">Before yesterday (current year) (with seconds)</div>
+                <div class="flex">{{ ru.relative.long.beforeYesterdayCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.relative.long.beforeYesterdayCurrentYearSeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Before yesterday (current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.relative.long.beforeYesterdayCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.relative.long.beforeYesterdayCurrentYearMilliseconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
                 <div class="flex">Yesterday</div>
                 <div class="flex">{{ ru.relative.long.yesterday }}</div>
                 <div class="flex">{{ en.relative.long.yesterday }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Yesterday (with seconds)</div>
+                <div class="flex">{{ ru.relative.long.yesterdaySeconds }}</div>
+                <div class="flex">{{ en.relative.long.yesterdaySeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Yesterday (with milliseconds)</div>
+                <div class="flex">{{ ru.relative.long.yesterdayMilliseconds }}</div>
+                <div class="flex">{{ en.relative.long.yesterdayMilliseconds }}</div>
             </div>
 
             <div class="layout-row row-border">
@@ -118,9 +162,33 @@
             </div>
 
             <div class="layout-row row-border">
+                <div class="flex">Today (with seconds)</div>
+                <div class="flex">{{ ru.relative.long.todaySeconds }}</div>
+                <div class="flex">{{ en.relative.long.todaySeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Today (with milliseconds)</div>
+                <div class="flex">{{ ru.relative.long.todayMilliseconds }}</div>
+                <div class="flex">{{ en.relative.long.todayMilliseconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
                 <div class="flex">Tomorrow</div>
                 <div class="flex">{{ ru.relative.long.tomorrow }}</div>
                 <div class="flex">{{ en.relative.long.tomorrow }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Tomorrow (with seconds)</div>
+                <div class="flex">{{ ru.relative.long.tomorrowSeconds }}</div>
+                <div class="flex">{{ en.relative.long.tomorrowSeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Tomorrow (with milliseconds)</div>
+                <div class="flex">{{ ru.relative.long.tomorrowMilliseconds }}</div>
+                <div class="flex">{{ en.relative.long.tomorrowMilliseconds }}</div>
             </div>
 
             <div class="layout-row row-border">
@@ -130,21 +198,21 @@
             </div>
 
             <div class="layout-row row-border">
-                <div class="flex">After tomorrow (not current year)</div>
-                <div class="flex">{{ ru.relative.long.afterTomorrowNotCurrentYear }}</div>
-                <div class="flex">{{ en.relative.long.afterTomorrowNotCurrentYear }}</div>
-            </div>
-            
-            <div class="layout-row row-border">
-                <div class="flex">With seconds</div>
-                <div class="flex">{{ ru.relative.long.seconds }}</div>
-                <div class="flex">{{ en.relative.long.seconds }}</div>
+                <div class="flex">After tomorrow (current year) (with seconds)</div>
+                <div class="flex">{{ ru.relative.long.afterTomorrowCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.relative.long.afterTomorrowCurrentYearSeconds }}</div>
             </div>
 
             <div class="layout-row row-border">
-                <div class="flex">With milliseconds</div>
-                <div class="flex">{{ ru.relative.long.milliseconds }}</div>
-                <div class="flex">{{ en.relative.long.milliseconds }}</div>
+                <div class="flex">After tomorrow (current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.relative.long.afterTomorrowCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.relative.long.afterTomorrowCurrentYearMilliseconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">After tomorrow (not current year)</div>
+                <div class="flex">{{ ru.relative.long.afterTomorrowNotCurrentYear }}</div>
+                <div class="flex">{{ en.relative.long.afterTomorrowNotCurrentYear }}</div>
             </div>
         </div>
     </div>
@@ -170,9 +238,33 @@
             </div>
 
             <div class="layout-row row-border">
+                <div class="flex">Before yesterday (current year) (with seconds)</div>
+                <div class="flex">{{ ru.relative.short.beforeYesterdayCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.relative.short.beforeYesterdayCurrentYearSeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Before yesterday (current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.relative.short.beforeYesterdayCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.relative.short.beforeYesterdayCurrentYearMilliseconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
                 <div class="flex">Yesterday</div>
                 <div class="flex">{{ ru.relative.short.yesterday }}</div>
                 <div class="flex">{{ en.relative.short.yesterday }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Yesterday (with seconds)</div>
+                <div class="flex">{{ ru.relative.short.yesterdaySeconds }}</div>
+                <div class="flex">{{ en.relative.short.yesterdaySeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Yesterday (with milliseconds)</div>
+                <div class="flex">{{ ru.relative.short.yesterdayMilliseconds }}</div>
+                <div class="flex">{{ en.relative.short.yesterdayMilliseconds }}</div>
             </div>
 
             <div class="layout-row row-border">
@@ -182,9 +274,33 @@
             </div>
 
             <div class="layout-row row-border">
+                <div class="flex">Today (with seconds)</div>
+                <div class="flex">{{ ru.relative.short.todaySeconds }}</div>
+                <div class="flex">{{ en.relative.short.todaySeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Today (with milliseconds)</div>
+                <div class="flex">{{ ru.relative.short.todayMilliseconds }}</div>
+                <div class="flex">{{ en.relative.short.todayMilliseconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
                 <div class="flex">Tomorrow</div>
                 <div class="flex">{{ ru.relative.short.tomorrow }}</div>
                 <div class="flex">{{ en.relative.short.tomorrow }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Tomorrow (with seconds)</div>
+                <div class="flex">{{ ru.relative.short.tomorrowSeconds }}</div>
+                <div class="flex">{{ en.relative.short.tomorrowSeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Tomorrow (with milliseconds)</div>
+                <div class="flex">{{ ru.relative.short.tomorrowMilliseconds }}</div>
+                <div class="flex">{{ en.relative.short.tomorrowMilliseconds }}</div>
             </div>
 
             <div class="layout-row row-border">
@@ -194,21 +310,21 @@
             </div>
 
             <div class="layout-row row-border">
-                <div class="flex">After tomorrow (not current year)</div>
-                <div class="flex">{{ ru.relative.short.afterTomorrowNotCurrentYear }}</div>
-                <div class="flex">{{ en.relative.short.afterTomorrowNotCurrentYear }}</div>
-            </div>
-            
-            <div class="layout-row row-border">
-                <div class="flex">With seconds</div>
-                <div class="flex">{{ ru.relative.short.seconds }}</div>
-                <div class="flex">{{ en.relative.short.seconds }}</div>
+                <div class="flex">After tomorrow (current year) (with seconds)</div>
+                <div class="flex">{{ ru.relative.short.afterTomorrowCurrentYearSeconds }}</div>
+                <div class="flex">{{ en.relative.short.afterTomorrowCurrentYearSeconds }}</div>
             </div>
 
             <div class="layout-row row-border">
-                <div class="flex">With milliseconds</div>
-                <div class="flex">{{ ru.relative.short.milliseconds }}</div>
-                <div class="flex">{{ en.relative.short.milliseconds }}</div>
+                <div class="flex">After tomorrow (current year) (with milliseconds)</div>
+                <div class="flex">{{ ru.relative.short.afterTomorrowCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ en.relative.short.afterTomorrowCurrentYearMilliseconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">After tomorrow (not current year)</div>
+                <div class="flex">{{ ru.relative.short.afterTomorrowNotCurrentYear }}</div>
+                <div class="flex">{{ en.relative.short.afterTomorrowNotCurrentYear }}</div>
             </div>
         </div>
     </div>

--- a/packages/mosaic-examples/mosaic/date-formatter/absolute-date-formatter/absolute-date-formatter-example.html
+++ b/packages/mosaic-examples/mosaic/date-formatter/absolute-date-formatter/absolute-date-formatter-example.html
@@ -17,20 +17,39 @@
                 <div class="flex">{{ formats.ru.absolute.long.date.notCurrentYear }}</div>
                 <div class="flex">{{ formats.en.absolute.long.date.notCurrentYear }}</div>
             </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">absoluteLongDateTime (current year)</div>
                 <div class="flex">{{ formats.ru.absolute.long.dateTime.currentYear }}</div>
                 <div class="flex">{{ formats.en.absolute.long.dateTime.currentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">absoluteLongDateTime (current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.absolute.long.dateTime.currentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.absolute.long.dateTime.currentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">absoluteLongDateTime (current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.absolute.long.dateTime.currentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.absolute.long.dateTime.currentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">absoluteLongDateTime (not current year)</div>
                 <div class="flex">{{ formats.ru.absolute.long.dateTime.notCurrentYear }}</div>
                 <div class="flex">{{ formats.en.absolute.long.dateTime.notCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
-                <div class="flex">absoluteLongDateTime (with milliseconds)</div>
-                <div class="flex">{{ formats.ru.absolute.long.dateTime.milliseconds }}</div>
-                <div class="flex">{{ formats.en.absolute.long.dateTime.milliseconds }}</div>
+                <div class="flex">absoluteLongDateTime (not current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.absolute.long.dateTime.notCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.absolute.long.dateTime.notCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">absoluteLongDateTime (not current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.absolute.long.dateTime.notCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.absolute.long.dateTime.notCurrentYearMilliseconds }}</div>
             </div>
         </div>
     </div>
@@ -52,20 +71,39 @@
                 <div class="flex">{{ formats.ru.absolute.short.date.notCurrentYear }}</div>
                 <div class="flex">{{ formats.en.absolute.short.date.notCurrentYear }}</div>
             </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">absoluteShortDateTime (current year)</div>
                 <div class="flex">{{ formats.ru.absolute.short.dateTime.currentYear }}</div>
                 <div class="flex">{{ formats.en.absolute.short.dateTime.currentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">absoluteShortDateTime (current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.absolute.short.dateTime.currentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.absolute.short.dateTime.currentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">absoluteShortDateTime (current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.absolute.short.dateTime.currentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.absolute.short.dateTime.currentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">absoluteShortDateTime (not current year)</div>
                 <div class="flex">{{ formats.ru.absolute.short.dateTime.notCurrentYear }}</div>
                 <div class="flex">{{ formats.en.absolute.short.dateTime.notCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
-                <div class="flex">absoluteShortDateTime (with milliseconds)</div>
-                <div class="flex">{{ formats.ru.absolute.short.dateTime.milliseconds }}</div>
-                <div class="flex">{{ formats.en.absolute.short.dateTime.milliseconds }}</div>
+                <div class="flex">absoluteShortDateTime (not current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.absolute.short.dateTime.notCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.absolute.short.dateTime.notCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">absoluteShortDateTime (not current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.absolute.short.dateTime.notCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.absolute.short.dateTime.notCurrentYearMilliseconds }}</div>
             </div>
         </div>
     </div>

--- a/packages/mosaic-examples/mosaic/date-formatter/absolute-date-formatter/absolute-date-formatter-example.ts
+++ b/packages/mosaic-examples/mosaic/date-formatter/absolute-date-formatter/absolute-date-formatter-example.ts
@@ -29,8 +29,12 @@ export class AbsoluteDateFormatterExample {
                     },
                     dateTime: {
                         currentYear: '',
+                        currentYearSeconds: '',
+                        currentYearMilliseconds: '',
+
                         notCurrentYear: '',
-                        milliseconds: ''
+                        notCurrentYearSeconds: '',
+                        notCurrentYearMilliseconds: ''
                     }
                 },
                 short: {
@@ -40,8 +44,12 @@ export class AbsoluteDateFormatterExample {
                     },
                     dateTime: {
                         currentYear: '',
+                        currentYearSeconds: '',
+                        currentYearMilliseconds: '',
+
                         notCurrentYear: '',
-                        milliseconds: ''
+                        notCurrentYearSeconds: '',
+                        notCurrentYearMilliseconds: ''
                     }
                 }
             }
@@ -55,8 +63,12 @@ export class AbsoluteDateFormatterExample {
                     },
                     dateTime: {
                         currentYear: '',
+                        currentYearSeconds: '',
+                        currentYearMilliseconds: '',
+
                         notCurrentYear: '',
-                        milliseconds: ''
+                        notCurrentYearSeconds: '',
+                        notCurrentYearMilliseconds: ''
                     }
                 },
                 short: {
@@ -66,8 +78,12 @@ export class AbsoluteDateFormatterExample {
                     },
                     dateTime: {
                         currentYear: '',
+                        currentYearSeconds: '',
+                        currentYearMilliseconds: '',
+
                         notCurrentYear: '',
-                        milliseconds: ''
+                        notCurrentYearSeconds: '',
+                        notCurrentYearMilliseconds: ''
                     }
                 }
             }
@@ -92,9 +108,16 @@ export class AbsoluteDateFormatterExample {
 
         absoluteShort.date.currentYear = this.dateFormatter.absoluteShortDate(now);
         absoluteShort.date.notCurrentYear = this.dateFormatter.absoluteShortDate(now.minus({ years: 1 }));
+
         absoluteShort.dateTime.currentYear = this.dateFormatter.absoluteShortDateTime(now);
+        absoluteShort.dateTime.currentYearSeconds = this.dateFormatter.absoluteShortDateTime(now, {seconds: true});
+        absoluteShort.dateTime.currentYearMilliseconds = this.dateFormatter.absoluteShortDateTime(now, {milliseconds: true});
+
         absoluteShort.dateTime.notCurrentYear = this.dateFormatter.absoluteShortDateTime(now.minus({ years: 1 }));
-        absoluteShort.dateTime.milliseconds = this.dateFormatter.absoluteShortDateTime(now, { milliseconds: true });
+        absoluteShort.dateTime.notCurrentYearSeconds = this.dateFormatter.absoluteShortDateTime(now.minus({ years: 1 }), {seconds: true});
+        absoluteShort.dateTime.notCurrentYearMilliseconds = this.dateFormatter.absoluteShortDateTime(
+            now.minus({ years: 1 }), {milliseconds: true}
+        );
     }
 
     private populateAbsoluteLong(locale: string) {
@@ -107,8 +130,15 @@ export class AbsoluteDateFormatterExample {
 
         absoluteLong.date.currentYear = this.dateFormatter.absoluteLongDate(now);
         absoluteLong.date.notCurrentYear = this.dateFormatter.absoluteLongDate(now.minus({ years: 1 }));
+
         absoluteLong.dateTime.currentYear = this.dateFormatter.absoluteLongDateTime(now);
+        absoluteLong.dateTime.currentYearSeconds = this.dateFormatter.absoluteLongDateTime(now, {seconds: true});
+        absoluteLong.dateTime.currentYearMilliseconds = this.dateFormatter.absoluteLongDateTime(now, {milliseconds: true});
+
         absoluteLong.dateTime.notCurrentYear = this.dateFormatter.absoluteLongDateTime(now.minus({ years: 1 }));
-        absoluteLong.dateTime.milliseconds = this.dateFormatter.absoluteLongDateTime(now, { milliseconds: true });
+        absoluteLong.dateTime.notCurrentYearSeconds = this.dateFormatter.absoluteLongDateTime(now.minus({ years: 1 }), {seconds: true});
+        absoluteLong.dateTime.notCurrentYearMilliseconds = this.dateFormatter.absoluteLongDateTime(
+            now.minus({ years: 1 }), {milliseconds: true}
+        );
     }
 }

--- a/packages/mosaic-examples/mosaic/date-formatter/range-date-formatter/range-date-formatter-example.html
+++ b/packages/mosaic-examples/mosaic/date-formatter/range-date-formatter/range-date-formatter-example.html
@@ -27,30 +27,90 @@
                 <div class="flex">{{ formats.ru.range.long.date.endsNotCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.long.date.endsNotCurrentYear }}</div>
             </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">rangeLongDateTime (the same day, current year)</div>
                 <div class="flex">{{ formats.ru.range.long.dateTime.sameDateCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.long.dateTime.sameDateCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (the same day, current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.long.dateTime.sameDateCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.range.long.dateTime.sameDateCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (the same day, current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.long.dateTime.sameDateCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.long.dateTime.sameDateCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">rangeLongDateTime (the same day, not current year)</div>
                 <div class="flex">{{ formats.ru.range.long.dateTime.sameDateNotCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.long.dateTime.sameDateNotCurrentYear }}</div>
             </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (the same day, not current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.long.dateTime.sameDateNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.range.long.dateTime.sameDateNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (the same day, not current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.long.dateTime.sameDateNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.long.dateTime.sameDateNotCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">rangeLongDateTime (not current month)</div>
                 <div class="flex">{{ formats.ru.range.long.dateTime.notCurrentMonth }}</div>
                 <div class="flex">{{ formats.en.range.long.dateTime.notCurrentMonth }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (not current month) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.long.dateTime.notCurrentMonthSeconds }}</div>
+                <div class="flex">{{ formats.en.range.long.dateTime.notCurrentMonthSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (not current month) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.long.dateTime.notCurrentMonthMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.long.dateTime.notCurrentMonthMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">rangeLongDateTime (start date is not in current year)</div>
                 <div class="flex">{{ formats.ru.range.long.dateTime.startsNotCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.long.dateTime.startsNotCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (start date is not in current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.long.dateTime.startsNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.range.long.dateTime.startsNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (start date is not in current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.long.dateTime.startsNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.long.dateTime.startsNotCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">rangeLongDateTime (end date is not in current year)</div>
                 <div class="flex">{{ formats.ru.range.long.dateTime.endsNotCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.long.dateTime.endsNotCurrentYear }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (end date is not in current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.long.dateTime.endsNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.range.long.dateTime.endsNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeLongDateTime (end date is not in current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.long.dateTime.endsNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.long.dateTime.endsNotCurrentYearMilliseconds }}</div>
             </div>
         </div>
     </div>
@@ -68,29 +128,94 @@
                 <div class="flex">{{ formats.en.range.middle.dateTime.currentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.middle.dateTime.currentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.range.middle.dateTime.currentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.middle.dateTime.currentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.middle.dateTime.currentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+            <div class="layout-row row-border">
                 <div class="flex">rangeMiddleDateTime (the same day)</div>
                 <div class="flex">{{ formats.ru.range.middle.dateTime.sameDateCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.middle.dateTime.sameDateCurrentYear }}</div>
             </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (the same day) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.middle.dateTime.sameDateCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.range.middle.dateTime.sameDateCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (the same day) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.middle.dateTime.sameDateCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.middle.dateTime.sameDateCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
             <div class="layout-row row-border">
                 <div class="flex">rangeMiddleDateTime (the same day, not current year)</div>
                 <div class="flex">{{ formats.ru.range.middle.dateTime.sameDateNotCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.middle.dateTime.sameDateNotCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (the same day, not current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.middle.dateTime.sameDateNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.range.middle.dateTime.sameDateNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (the same day, not current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.middle.dateTime.sameDateNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.middle.dateTime.sameDateNotCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+            <div class="layout-row row-border">
                 <div class="flex">rangeMiddleDateTime (not current month)</div>
                 <div class="flex">{{ formats.ru.range.middle.dateTime.notCurrentMonth }}</div>
                 <div class="flex">{{ formats.en.range.middle.dateTime.notCurrentMonth }}</div>
             </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (not current month) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.middle.dateTime.notCurrentMonthSeconds }}</div>
+                <div class="flex">{{ formats.en.range.middle.dateTime.notCurrentMonthSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (not current month) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.middle.dateTime.notCurrentMonthMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.middle.dateTime.notCurrentMonthMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
             <div class="layout-row row-border">
                 <div class="flex">rangeMiddleDateTime (start date is not in current year)</div>
                 <div class="flex">{{ formats.ru.range.middle.dateTime.startsNotCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.middle.dateTime.startsNotCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (start date is not in current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.middle.dateTime.startsNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.range.middle.dateTime.startsNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (start date is not in current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.middle.dateTime.startsNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.middle.dateTime.startsNotCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+            <div class="layout-row row-border">
                 <div class="flex">rangeMiddleDateTime (end date is not in current year)</div>
                 <div class="flex">{{ formats.ru.range.middle.dateTime.endsNotCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.middle.dateTime.endsNotCurrentYear }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (end date is not in current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.middle.dateTime.endsNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.range.middle.dateTime.endsNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeMiddleDateTime (end date is not in current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.middle.dateTime.endsNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.middle.dateTime.endsNotCurrentYearMilliseconds }}</div>
             </div>
         </div>
     </div>
@@ -122,30 +247,90 @@
                 <div class="flex">{{ formats.ru.range.short.date.endsNotCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.short.date.endsNotCurrentYear }}</div>
             </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">rangeShortDateTime (the same day, current year)</div>
                 <div class="flex">{{ formats.ru.range.short.dateTime.sameDateCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.short.dateTime.sameDateCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (the same day, current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.short.dateTime.sameDateCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.range.short.dateTime.sameDateCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (the same day, current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.short.dateTime.sameDateCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.short.dateTime.sameDateCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">rangeShortDateTime (the same day, not current year)</div>
                 <div class="flex">{{ formats.ru.range.short.dateTime.sameDateNotCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.short.dateTime.sameDateNotCurrentYear }}</div>
             </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (the same day, not current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.short.dateTime.sameDateNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.range.short.dateTime.sameDateNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (the same day, not current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.short.dateTime.sameDateNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.short.dateTime.sameDateNotCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
             <div class="layout-row row-border">
                 <div class="flex">rangeShortDateTime (not current month)</div>
                 <div class="flex">{{ formats.ru.range.short.dateTime.notCurrentMonth }}</div>
                 <div class="flex">{{ formats.en.range.short.dateTime.notCurrentMonth }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (not current month) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.short.dateTime.notCurrentMonthSeconds }}</div>
+                <div class="flex">{{ formats.en.range.short.dateTime.notCurrentMonthSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (not current month) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.short.dateTime.notCurrentMonthMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.short.dateTime.notCurrentMonthMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">rangeShortDateTime (start date is not in current year)</div>
                 <div class="flex">{{ formats.ru.range.short.dateTime.startsNotCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.short.dateTime.startsNotCurrentYear }}</div>
             </div>
             <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (start date is not in current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.short.dateTime.startsNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.range.short.dateTime.startsNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (start date is not in current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.short.dateTime.startsNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.short.dateTime.startsNotCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">rangeShortDateTime (end date is not in current year)</div>
                 <div class="flex">{{ formats.ru.range.short.dateTime.endsNotCurrentYear }}</div>
                 <div class="flex">{{ formats.en.range.short.dateTime.endsNotCurrentYear }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (end date is not in current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.range.short.dateTime.endsNotCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.range.short.dateTime.endsNotCurrentYearSeconds }}</div>
+            </div>
+            <div class="layout-row row-border">
+                <div class="flex">rangeShortDateTime (end date is not in current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.range.short.dateTime.endsNotCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.range.short.dateTime.endsNotCurrentYearMilliseconds }}</div>
             </div>
         </div>
     </div>

--- a/packages/mosaic-examples/mosaic/date-formatter/range-date-formatter/range-date-formatter-example.ts
+++ b/packages/mosaic-examples/mosaic/date-formatter/range-date-formatter/range-date-formatter-example.ts
@@ -31,20 +31,51 @@ export class RangeDateFormatterExample {
                     },
                     dateTime: {
                         startsNotCurrentYear: '',
+                        startsNotCurrentYearSeconds: '',
+                        startsNotCurrentYearMilliseconds: '',
+
                         endsNotCurrentYear: '',
+                        endsNotCurrentYearSeconds: '',
+                        endsNotCurrentYearMilliseconds: '',
+
                         sameDateCurrentYear: '',
+                        sameDateCurrentYearSeconds: '',
+                        sameDateCurrentYearMilliseconds: '',
+
                         sameDateNotCurrentYear: '',
-                        notCurrentMonth: ''
+                        sameDateNotCurrentYearSeconds: '',
+                        sameDateNotCurrentYearMilliseconds: '',
+
+                        notCurrentMonth: '',
+                        notCurrentMonthSeconds: '',
+                        notCurrentMonthMilliseconds: ''
                     }
                 },
                 middle: {
                     dateTime: {
                         currentYear: '',
+                        currentYearSeconds: '',
+                        currentYearMilliseconds: '',
+
                         sameDateCurrentYear: '',
+                        sameDateCurrentYearSeconds: '',
+                        sameDateCurrentYearMilliseconds: '',
+
                         sameDateNotCurrentYear: '',
+                        sameDateNotCurrentYearSeconds: '',
+                        sameDateNotCurrentYearMilliseconds: '',
+
                         notCurrentMonth: '',
+                        notCurrentMonthSeconds: '',
+                        notCurrentMonthMilliseconds: '',
+
                         startsNotCurrentYear: '',
-                        endsNotCurrentYear: ''
+                        startsNotCurrentYearSeconds: '',
+                        startsNotCurrentYearMilliseconds: '',
+
+                        endsNotCurrentYear: '',
+                        endsNotCurrentYearSeconds: '',
+                        endsNotCurrentYearMilliseconds: ''
                     }
                 },
                 short: {
@@ -56,10 +87,24 @@ export class RangeDateFormatterExample {
                     },
                     dateTime: {
                         sameDateCurrentYear: '',
+                        sameDateCurrentYearSeconds: '',
+                        sameDateCurrentYearMilliseconds: '',
+
                         sameDateNotCurrentYear: '',
+                        sameDateNotCurrentYearSeconds: '',
+                        sameDateNotCurrentYearMilliseconds: '',
+
                         notCurrentMonth: '',
+                        notCurrentMonthSeconds: '',
+                        notCurrentMonthMilliseconds: '',
+
                         startsNotCurrentYear: '',
-                        endsNotCurrentYear: ''
+                        startsNotCurrentYearSeconds: '',
+                        startsNotCurrentYearMilliseconds: '',
+
+                        endsNotCurrentYear: '',
+                        endsNotCurrentYearSeconds: '',
+                        endsNotCurrentYearMilliseconds: ''
                     }
                 }
             }
@@ -75,20 +120,51 @@ export class RangeDateFormatterExample {
                     },
                     dateTime: {
                         startsNotCurrentYear: '',
+                        startsNotCurrentYearSeconds: '',
+                        startsNotCurrentYearMilliseconds: '',
+
                         endsNotCurrentYear: '',
+                        endsNotCurrentYearSeconds: '',
+                        endsNotCurrentYearMilliseconds: '',
+
                         sameDateCurrentYear: '',
+                        sameDateCurrentYearSeconds: '',
+                        sameDateCurrentYearMilliseconds: '',
+
                         sameDateNotCurrentYear: '',
-                        notCurrentMonth: ''
+                        sameDateNotCurrentYearSeconds: '',
+                        sameDateNotCurrentYearMilliseconds: '',
+
+                        notCurrentMonth: '',
+                        notCurrentMonthSeconds: '',
+                        notCurrentMonthMilliseconds: ''
                     }
                 },
                 middle: {
                     dateTime: {
                         currentYear: '',
+                        currentYearSeconds: '',
+                        currentYearMilliseconds: '',
+
                         sameDateCurrentYear: '',
+                        sameDateCurrentYearSeconds: '',
+                        sameDateCurrentYearMilliseconds: '',
+
                         sameDateNotCurrentYear: '',
+                        sameDateNotCurrentYearSeconds: '',
+                        sameDateNotCurrentYearMilliseconds: '',
+
                         notCurrentMonth: '',
+                        notCurrentMonthSeconds: '',
+                        notCurrentMonthMilliseconds: '',
+
                         startsNotCurrentYear: '',
-                        endsNotCurrentYear: ''
+                        startsNotCurrentYearSeconds: '',
+                        startsNotCurrentYearMilliseconds: '',
+
+                        endsNotCurrentYear: '',
+                        endsNotCurrentYearSeconds: '',
+                        endsNotCurrentYearMilliseconds: ''
                     }
                 },
                 short: {
@@ -100,10 +176,24 @@ export class RangeDateFormatterExample {
                     },
                     dateTime: {
                         sameDateCurrentYear: '',
+                        sameDateCurrentYearSeconds: '',
+                        sameDateCurrentYearMilliseconds: '',
+
                         sameDateNotCurrentYear: '',
+                        sameDateNotCurrentYearSeconds: '',
+                        sameDateNotCurrentYearMilliseconds: '',
+
                         notCurrentMonth: '',
+                        notCurrentMonthSeconds: '',
+                        notCurrentMonthMilliseconds: '',
+
                         startsNotCurrentYear: '',
-                        endsNotCurrentYear: ''
+                        startsNotCurrentYearSeconds: '',
+                        startsNotCurrentYearMilliseconds: '',
+
+                        endsNotCurrentYear: '',
+                        endsNotCurrentYearSeconds: '',
+                        endsNotCurrentYearMilliseconds: ''
                     }
                 }
             }
@@ -141,25 +231,80 @@ export class RangeDateFormatterExample {
             now.set({ day: 1, month: 1 }),
             now.set({ day: 10, month: 2 }).plus({ years: 1 })
         );
+
         shortRange.dateTime.sameDateCurrentYear = this.dateFormatter.rangeShortDateTime(
             now.set({ day: 10, hour: 10, minute: 14 }),
             now.set({ day: 10, hour: 11, minute: 28 })
         );
+        shortRange.dateTime.sameDateCurrentYearSeconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ day: 10, hour: 10, minute: 14 }),
+            now.set({ day: 10, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        shortRange.dateTime.sameDateCurrentYearMilliseconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ day: 10, hour: 10, minute: 14 }),
+            now.set({ day: 10, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         shortRange.dateTime.sameDateNotCurrentYear = this.dateFormatter.rangeShortDateTime(
             now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
             now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 })
         );
+        shortRange.dateTime.sameDateNotCurrentYearSeconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        shortRange.dateTime.sameDateNotCurrentYearMilliseconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         shortRange.dateTime.notCurrentMonth = this.dateFormatter.rangeShortDateTime(
             now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
             now.set({ month: 2, day: 1, hour: 11, minute: 28 })
         );
+        shortRange.dateTime.notCurrentMonthSeconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        shortRange.dateTime.notCurrentMonthMilliseconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         shortRange.dateTime.startsNotCurrentYear = this.dateFormatter.rangeShortDateTime(
             now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
             now.set({ month: 2, day: 1, hour: 11, minute: 28 })
         );
+        shortRange.dateTime.startsNotCurrentYearSeconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        shortRange.dateTime.startsNotCurrentYearMilliseconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         shortRange.dateTime.endsNotCurrentYear = this.dateFormatter.rangeShortDateTime(
             now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
             now.set({ day: 1, month: 2 }).plus({ years: 1 }).set({ hour: 11, minute: 28 })
+        );
+        shortRange.dateTime.endsNotCurrentYearSeconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ day: 1, month: 2 }).plus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        shortRange.dateTime.endsNotCurrentYearMilliseconds = this.dateFormatter.rangeShortDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ day: 1, month: 2 }).plus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {milliseconds: true}
         );
     }
 
@@ -174,25 +319,92 @@ export class RangeDateFormatterExample {
             now.set({ day: 1 }),
             now.set({ day: 10 })
         );
+
+        middleRange.dateTime.currentYearSeconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ day: 1 }),
+            now.set({ day: 10 }),
+            {seconds: true}
+        );
+
+        middleRange.dateTime.currentYearMilliseconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ day: 1 }),
+            now.set({ day: 10 }),
+            {milliseconds: true}
+        );
+
         middleRange.dateTime.sameDateCurrentYear = this.dateFormatter.rangeMiddleDateTime(
             now.set({ day: 10, hour: 10, minute: 14 }),
             now.set({ day: 10, hour: 10, minute: 28 })
         );
+        middleRange.dateTime.sameDateCurrentYearSeconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ day: 10, hour: 10, minute: 14 }),
+            now.set({ day: 10, hour: 10, minute: 28 }),
+            {seconds: true}
+        );
+        middleRange.dateTime.sameDateCurrentYearMilliseconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ day: 10, hour: 10, minute: 14 }),
+            now.set({ day: 10, hour: 10, minute: 28 }),
+            {milliseconds: true}
+        );
+
         middleRange.dateTime.sameDateNotCurrentYear = this.dateFormatter.rangeMiddleDateTime(
             now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
             now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 })
         );
+        middleRange.dateTime.sameDateNotCurrentYearSeconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        middleRange.dateTime.sameDateNotCurrentYearMilliseconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         middleRange.dateTime.notCurrentMonth = this.dateFormatter.rangeMiddleDateTime(
             now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
             now.set({ month: 2, day: 1, hour: 11, minute: 28 })
         );
+        middleRange.dateTime.notCurrentMonthSeconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        middleRange.dateTime.notCurrentMonthMilliseconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         middleRange.dateTime.startsNotCurrentYear = this.dateFormatter.rangeMiddleDateTime(
             now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
             now.set({ month: 1, day: 1, hour: 11, minute: 28 })
         );
+        middleRange.dateTime.startsNotCurrentYearSeconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 1, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        middleRange.dateTime.startsNotCurrentYearMilliseconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 1, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         middleRange.dateTime.endsNotCurrentYear = this.dateFormatter.rangeMiddleDateTime(
             now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
             now.set({ month: 1, day: 1 }).plus({ years: 1 }).set({ hour: 11, minute: 28 })
+        );
+        middleRange.dateTime.endsNotCurrentYearSeconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 1 }).plus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        middleRange.dateTime.endsNotCurrentYearMilliseconds = this.dateFormatter.rangeMiddleDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 1 }).plus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {milliseconds: true}
         );
     }
 
@@ -220,21 +432,75 @@ export class RangeDateFormatterExample {
             now.set({ day: 10, hour: 10, minute: 14 }),
             now.set({ day: 10, hour: 11, minute: 28 })
         );
+        longRange.dateTime.sameDateCurrentYearSeconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ day: 10, hour: 10, minute: 14 }),
+            now.set({ day: 10, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        longRange.dateTime.sameDateCurrentYearMilliseconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ day: 10, hour: 10, minute: 14 }),
+            now.set({ day: 10, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         longRange.dateTime.sameDateNotCurrentYear = this.dateFormatter.rangeLongDateTime(
             now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
             now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 })
         );
+        longRange.dateTime.sameDateNotCurrentYearSeconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        longRange.dateTime.sameDateNotCurrentYearMilliseconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 1, day: 11 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         longRange.dateTime.notCurrentMonth = this.dateFormatter.rangeLongDateTime(
             now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
             now.set({ month: 2, day: 1, hour: 11, minute: 28 })
         );
+        longRange.dateTime.notCurrentMonthSeconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        longRange.dateTime.notCurrentMonthMilliseconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         longRange.dateTime.startsNotCurrentYear = this.dateFormatter.rangeLongDateTime(
             now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
             now.set({ month: 2, day: 1, hour: 11, minute: 28 })
         );
+        longRange.dateTime.startsNotCurrentYearSeconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        longRange.dateTime.startsNotCurrentYearMilliseconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 1 }).minus({ years: 1 }).set({ hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1, hour: 11, minute: 28 }),
+            {milliseconds: true}
+        );
+
         longRange.dateTime.endsNotCurrentYear = this.dateFormatter.rangeLongDateTime(
             now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
             now.set({ month: 2, day: 1 }).minus({ years: 1 }).set({ hour: 11, minute: 28 })
+        );
+        longRange.dateTime.endsNotCurrentYearSeconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {seconds: true}
+        );
+        longRange.dateTime.endsNotCurrentYearMilliseconds = this.dateFormatter.rangeLongDateTime(
+            now.set({ month: 1, day: 1, hour: 10, minute: 14 }),
+            now.set({ month: 2, day: 1 }).minus({ years: 1 }).set({ hour: 11, minute: 28 }),
+            {milliseconds: true}
         );
     }
 }

--- a/packages/mosaic-examples/mosaic/date-formatter/relative-date-formatter/relative-date-formatter-example.html
+++ b/packages/mosaic-examples/mosaic/date-formatter/relative-date-formatter/relative-date-formatter-example.html
@@ -13,6 +13,7 @@
                 <div class="flex">{{ formats.ru.relative.long.beforeYesterdayNotCurrentYear }}</div>
                 <div class="flex">{{ formats.en.relative.long.beforeYesterdayNotCurrentYear }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">Before yesterday (current year)</div>
@@ -21,10 +22,36 @@
             </div>
 
             <div class="layout-row row-border">
+                <div class="flex">Before yesterday (current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.relative.long.beforeYesterdayCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.relative.long.beforeYesterdayCurrentYearSeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Before yesterday (current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.relative.long.beforeYesterdayCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.relative.long.beforeYesterdayCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">Yesterday</div>
                 <div class="flex">{{ formats.ru.relative.long.yesterday }}</div>
                 <div class="flex">{{ formats.en.relative.long.yesterday }}</div>
             </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Yesterday (with seconds)</div>
+                <div class="flex">{{ formats.ru.relative.long.yesterdaySeconds }}</div>
+                <div class="flex">{{ formats.en.relative.long.yesterdaySeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Yesterday (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.relative.long.yesterdayMilliseconds }}</div>
+                <div class="flex">{{ formats.en.relative.long.yesterdayMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">Today</div>
@@ -33,16 +60,55 @@
             </div>
 
             <div class="layout-row row-border">
+                <div class="flex">Today (with seconds)</div>
+                <div class="flex">{{ formats.ru.relative.long.todaySeconds }}</div>
+                <div class="flex">{{ formats.en.relative.long.todaySeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Today (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.relative.long.todayMilliseconds }}</div>
+                <div class="flex">{{ formats.en.relative.long.todayMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">Tomorrow</div>
                 <div class="flex">{{ formats.ru.relative.long.tomorrow }}</div>
                 <div class="flex">{{ formats.en.relative.long.tomorrow }}</div>
             </div>
 
             <div class="layout-row row-border">
+                <div class="flex">Tomorrow (with seconds)</div>
+                <div class="flex">{{ formats.ru.relative.long.tomorrowSeconds }}</div>
+                <div class="flex">{{ formats.en.relative.long.tomorrowSeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Tomorrow (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.relative.long.tomorrowMilliseconds }}</div>
+                <div class="flex">{{ formats.en.relative.long.tomorrowMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">After tomorrow (current year)</div>
                 <div class="flex">{{ formats.ru.relative.long.afterTomorrowCurrentYear }}</div>
                 <div class="flex">{{ formats.en.relative.long.afterTomorrowCurrentYear }}</div>
             </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">After tomorrow (current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.relative.long.afterTomorrowCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.relative.long.afterTomorrowCurrentYearSeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">After tomorrow (current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.relative.long.afterTomorrowCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.relative.long.afterTomorrowCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">After tomorrow (not current year)</div>
@@ -65,6 +131,7 @@
                 <div class="flex">{{ formats.ru.relative.short.beforeYesterdayNotCurrentYear }}</div>
                 <div class="flex">{{ formats.en.relative.short.beforeYesterdayNotCurrentYear }}</div>
             </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">Before yesterday (current year)</div>
@@ -73,10 +140,36 @@
             </div>
 
             <div class="layout-row row-border">
+                <div class="flex">Before yesterday (current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.relative.short.beforeYesterdayCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.relative.short.beforeYesterdayCurrentYearSeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Before yesterday (current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.relative.short.beforeYesterdayCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.relative.short.beforeYesterdayCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">Yesterday</div>
                 <div class="flex">{{ formats.ru.relative.short.yesterday }}</div>
                 <div class="flex">{{ formats.en.relative.short.yesterday }}</div>
             </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Yesterday (with seconds)</div>
+                <div class="flex">{{ formats.ru.relative.short.yesterdaySeconds }}</div>
+                <div class="flex">{{ formats.en.relative.short.yesterdaySeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Yesterday (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.relative.short.yesterdayMilliseconds }}</div>
+                <div class="flex">{{ formats.en.relative.short.yesterdayMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">Today</div>
@@ -85,16 +178,55 @@
             </div>
 
             <div class="layout-row row-border">
+                <div class="flex">Today (with seconds)</div>
+                <div class="flex">{{ formats.ru.relative.short.todaySeconds }}</div>
+                <div class="flex">{{ formats.en.relative.short.todaySeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Today (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.relative.short.todayMilliseconds }}</div>
+                <div class="flex">{{ formats.en.relative.short.todayMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">Tomorrow</div>
                 <div class="flex">{{ formats.ru.relative.short.tomorrow }}</div>
                 <div class="flex">{{ formats.en.relative.short.tomorrow }}</div>
             </div>
 
             <div class="layout-row row-border">
+                <div class="flex">Tomorrow (with seconds)</div>
+                <div class="flex">{{ formats.ru.relative.short.tomorrowSeconds }}</div>
+                <div class="flex">{{ formats.en.relative.short.tomorrowSeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">Tomorrow (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.relative.short.tomorrowMilliseconds }}</div>
+                <div class="flex">{{ formats.en.relative.short.tomorrowMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
+
+            <div class="layout-row row-border">
                 <div class="flex">After tomorrow (current year)</div>
                 <div class="flex">{{ formats.ru.relative.short.afterTomorrowCurrentYear }}</div>
                 <div class="flex">{{ formats.en.relative.short.afterTomorrowCurrentYear }}</div>
             </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">After tomorrow (current year) (with seconds)</div>
+                <div class="flex">{{ formats.ru.relative.short.afterTomorrowCurrentYearSeconds }}</div>
+                <div class="flex">{{ formats.en.relative.short.afterTomorrowCurrentYearSeconds }}</div>
+            </div>
+
+            <div class="layout-row row-border">
+                <div class="flex">After tomorrow (current year) (with milliseconds)</div>
+                <div class="flex">{{ formats.ru.relative.short.afterTomorrowCurrentYearMilliseconds }}</div>
+                <div class="flex">{{ formats.en.relative.short.afterTomorrowCurrentYearMilliseconds }}</div>
+            </div>
+            <div class="row-border"></div>
 
             <div class="layout-row row-border">
                 <div class="flex">After tomorrow (not current year)</div>

--- a/packages/mosaic-examples/mosaic/date-formatter/relative-date-formatter/relative-date-formatter-example.ts
+++ b/packages/mosaic-examples/mosaic/date-formatter/relative-date-formatter/relative-date-formatter-example.ts
@@ -23,44 +23,108 @@ export class RelativeDateFormatterExample {
         ru: {
             relative: {
                 long: {
-                    beforeYesterdayNotCurrentYear: '',
-                    beforeYesterdayCurrentYear: '',
-                    yesterday: '',
-                    today: '',
-                    tomorrow: '',
-                    afterTomorrowCurrentYear: '',
-                    afterTomorrowNotCurrentYear: ''
+                        beforeYesterdayNotCurrentYear: '',
+
+                        beforeYesterdayCurrentYear: '',
+                        beforeYesterdayCurrentYearSeconds: '',
+                        beforeYesterdayCurrentYearMilliseconds: '',
+
+                        yesterday: '',
+                        yesterdaySeconds: '',
+                        yesterdayMilliseconds: '',
+
+                        today: '',
+                        todaySeconds: '',
+                        todayMilliseconds: '',
+
+                        tomorrow: '',
+                        tomorrowSeconds: '',
+                        tomorrowMilliseconds: '',
+
+                        afterTomorrowCurrentYear: '',
+                        afterTomorrowCurrentYearSeconds: '',
+                        afterTomorrowCurrentYearMilliseconds: '',
+
+                        afterTomorrowNotCurrentYear: ''
                 },
                 short: {
-                    beforeYesterdayNotCurrentYear: '',
-                    beforeYesterdayCurrentYear: '',
-                    yesterday: '',
-                    today: '',
-                    tomorrow: '',
-                    afterTomorrowCurrentYear: '',
-                    afterTomorrowNotCurrentYear: ''
+                        beforeYesterdayNotCurrentYear: '',
+
+                        beforeYesterdayCurrentYear: '',
+                        beforeYesterdayCurrentYearSeconds: '',
+                        beforeYesterdayCurrentYearMilliseconds: '',
+
+                        yesterday: '',
+                        yesterdaySeconds: '',
+                        yesterdayMilliseconds: '',
+
+                        today: '',
+                        todaySeconds: '',
+                        todayMilliseconds: '',
+
+                        tomorrow: '',
+                        tomorrowSeconds: '',
+                        tomorrowMilliseconds: '',
+
+                        afterTomorrowCurrentYear: '',
+                        afterTomorrowCurrentYearSeconds: '',
+                        afterTomorrowCurrentYearMilliseconds: '',
+
+                        afterTomorrowNotCurrentYear: ''
                 }
             }
         },
         en: {
             relative: {
                 long: {
-                    beforeYesterdayNotCurrentYear: '',
-                    beforeYesterdayCurrentYear: '',
-                    yesterday: '',
-                    today: '',
-                    tomorrow: '',
-                    afterTomorrowCurrentYear: '',
-                    afterTomorrowNotCurrentYear: ''
+                        beforeYesterdayNotCurrentYear: '',
+
+                        beforeYesterdayCurrentYear: '',
+                        beforeYesterdayCurrentYearSeconds: '',
+                        beforeYesterdayCurrentYearMilliseconds: '',
+
+                        yesterday: '',
+                        yesterdaySeconds: '',
+                        yesterdayMilliseconds: '',
+
+                        today: '',
+                        todaySeconds: '',
+                        todayMilliseconds: '',
+
+                        tomorrow: '',
+                        tomorrowSeconds: '',
+                        tomorrowMilliseconds: '',
+
+                        afterTomorrowCurrentYear: '',
+                        afterTomorrowCurrentYearSeconds: '',
+                        afterTomorrowCurrentYearMilliseconds: '',
+
+                        afterTomorrowNotCurrentYear: ''
                 },
                 short: {
-                    beforeYesterdayNotCurrentYear: '',
-                    beforeYesterdayCurrentYear: '',
-                    yesterday: '',
-                    today: '',
-                    tomorrow: '',
-                    afterTomorrowCurrentYear: '',
-                    afterTomorrowNotCurrentYear: ''
+                        beforeYesterdayNotCurrentYear: '',
+
+                        beforeYesterdayCurrentYear: '',
+                        beforeYesterdayCurrentYearSeconds: '',
+                        beforeYesterdayCurrentYearMilliseconds: '',
+
+                        yesterday: '',
+                        yesterdaySeconds: '',
+                        yesterdayMilliseconds: '',
+
+                        today: '',
+                        todaySeconds: '',
+                        todayMilliseconds: '',
+
+                        tomorrow: '',
+                        tomorrowSeconds: '',
+                        tomorrowMilliseconds: '',
+
+                        afterTomorrowCurrentYear: '',
+                        afterTomorrowCurrentYearSeconds: '',
+                        afterTomorrowCurrentYearMilliseconds: '',
+
+                        afterTomorrowNotCurrentYear: ''
                 }
             }
         }
@@ -82,17 +146,50 @@ export class RelativeDateFormatterExample {
         const now = this.adapter.today();
 
         relativeShort.beforeYesterdayNotCurrentYear = this.dateFormatter.relativeShortDate(
-            now.minus({ years: 1 })
+            now.minus({ years: 1, days: 2 })
         );
         relativeShort.beforeYesterdayCurrentYear = this.dateFormatter.relativeShortDate(now.minus({ days: 2 }));
+        relativeShort.beforeYesterdayCurrentYearSeconds = this.dateFormatter.relativeShortDateTime(
+            now.minus({ days: 2 }), {seconds: true}
+        );
+        relativeShort.beforeYesterdayCurrentYearMilliseconds = this.dateFormatter.relativeShortDateTime(
+            now.minus({ days: 2 }), {milliseconds: true}
+        );
+
         relativeShort.yesterday = this.dateFormatter.relativeShortDate(now.minus({ days: 1 }));
+        relativeShort.yesterdaySeconds = this.dateFormatter.relativeShortDateTime(
+            now.minus({ days: 1 }), {seconds: true}
+        );
+        relativeShort.yesterdayMilliseconds = this.dateFormatter.relativeShortDateTime(
+            now.minus({ days: 1 }), {milliseconds: true}
+        );
 
         relativeShort.today = this.dateFormatter.relativeShortDate(now.minus({ hours: 1 }));
+        relativeShort.todaySeconds = this.dateFormatter.relativeShortDateTime(
+            now.minus({ hours: 1 }), {seconds: true}
+        );
+        relativeShort.todayMilliseconds = this.dateFormatter.relativeShortDateTime(
+            now.minus({ hours: 1 }), {milliseconds: true}
+        );
 
-        relativeShort.tomorrow = this.dateFormatter.relativeShortDate(now.plus({ days: 1 }));
+        relativeShort.tomorrow = this.dateFormatter.relativeShortDate(now.plus({ days: 1, hours: 1 }));
+        relativeShort.tomorrowSeconds = this.dateFormatter.relativeShortDateTime(
+            now.plus({ days: 1, hours: 1 }), {seconds: true}
+        );
+        relativeShort.tomorrowMilliseconds = this.dateFormatter.relativeShortDateTime(
+            now.plus({ days: 1, hours: 1 }), {milliseconds: true}
+        );
+
         relativeShort.afterTomorrowCurrentYear = this.dateFormatter.relativeShortDate(now.plus({ days: 2 }));
+        relativeShort.afterTomorrowCurrentYearSeconds = this.dateFormatter.relativeShortDateTime(
+            now.plus({ days: 2 }), {seconds: true}
+        );
+        relativeShort.afterTomorrowCurrentYearMilliseconds = this.dateFormatter.relativeShortDateTime(
+            now.plus({ days: 2 }), {milliseconds: true}
+        );
+
         relativeShort.afterTomorrowNotCurrentYear = this.dateFormatter.relativeShortDate(
-            now.plus({ years: 1 })
+            now.plus({ years: 1, days: 2 })
         );
     }
 
@@ -104,17 +201,34 @@ export class RelativeDateFormatterExample {
         const now = this.adapter.today();
 
         relativeLong.beforeYesterdayNotCurrentYear = this.dateFormatter.relativeLongDate(
-            now.minus({ years: 1 })
+            now.minus({ years: 1, days: 2 })
         );
         relativeLong.beforeYesterdayCurrentYear = this.dateFormatter.relativeLongDate(now.minus({ days: 2 }));
+        relativeLong.beforeYesterdayCurrentYearSeconds = this.dateFormatter.relativeLongDateTime(now.minus({ days: 2 }), {seconds: true});
+        relativeLong.beforeYesterdayCurrentYearMilliseconds = this.dateFormatter.relativeLongDateTime(
+            now.minus({ days: 2 }), {milliseconds: true}
+        );
+
         relativeLong.yesterday = this.dateFormatter.relativeLongDate(now.minus({ days: 1 }));
+        relativeLong.yesterdaySeconds = this.dateFormatter.relativeLongDateTime(now.minus({ days: 1 }), {seconds: true});
+        relativeLong.yesterdayMilliseconds = this.dateFormatter.relativeLongDateTime(now.minus({ days: 1 }), {milliseconds: true});
 
         relativeLong.today = this.dateFormatter.relativeLongDate(now.minus({ hours: 1 }));
+        relativeLong.todaySeconds = this.dateFormatter.relativeLongDateTime(now.minus({ hours: 1 }), {seconds: true});
+        relativeLong.todayMilliseconds = this.dateFormatter.relativeLongDateTime(now.minus({ hours: 1 }), {milliseconds: true});
 
-        relativeLong.tomorrow = this.dateFormatter.relativeLongDate(now.plus({ days: 1 }));
+        relativeLong.tomorrow = this.dateFormatter.relativeLongDate(now.plus({ days: 1, hours: 1 }));
+        relativeLong.tomorrowSeconds = this.dateFormatter.relativeLongDateTime(now.plus({ days: 1, hours: 1 }), {seconds: true});
+        relativeLong.tomorrowMilliseconds = this.dateFormatter.relativeLongDateTime(now.plus({ days: 1, hours: 1 }), {milliseconds: true});
+
         relativeLong.afterTomorrowCurrentYear = this.dateFormatter.relativeLongDate(now.plus({ days: 2 }));
+        relativeLong.afterTomorrowCurrentYearSeconds = this.dateFormatter.relativeLongDateTime(now.plus({ days: 2 }), {seconds: true});
+        relativeLong.afterTomorrowCurrentYearMilliseconds = this.dateFormatter.relativeLongDateTime(
+            now.plus({ days: 2 }), {milliseconds: true}
+        );
+
         relativeLong.afterTomorrowNotCurrentYear = this.dateFormatter.relativeLongDate(
-            now.plus({ years: 1 })
+            now.plus({ years: 1, days: 2 })
         );
     }
 }

--- a/packages/mosaic/core/formatters/date/formatter.spec.ts
+++ b/packages/mosaic/core/formatters/date/formatter.spec.ts
@@ -136,6 +136,20 @@ describe('Date formatter', () => {
                     expect(formatter.relativeShortDate(date))
                         .toBe(adapter.format(date, `${DAY}${NBSP}${SHORT_MONTH} ${YEAR}`));
                 });
+
+                it('with milliseconds', () => {
+                    const date = adapter.today();
+
+                    expect(formatter.relativeShortDateTime(date, { milliseconds: true }))
+                        .toBe(date.toFormat(`Сегодня, ${TIME}:${SECONDS}${MILLISECONDS}`));
+                });
+
+                it('with seconds', () => {
+                    const date = adapter.today();
+
+                    expect(formatter.relativeShortDateTime(date, { seconds: true }))
+                        .toBe(adapter.format(date, `Сегодня, ${TIME}:${SECONDS}`));
+                });
             });
 
             describe('Relative long (relativeLongDate method)', () => {
@@ -203,6 +217,20 @@ describe('Date formatter', () => {
                     expect(formatter.relativeLongDate(date))
                         .toBe(adapter.format(date, `${DAY_MONTH} ${YEAR}`));
                 });
+
+                it('with milliseconds', () => {
+                    const date = adapter.today();
+
+                    expect(formatter.relativeShortDateTime(date, { milliseconds: true }))
+                        .toBe(date.toFormat(`Сегодня, ${TIME}:${SECONDS}${MILLISECONDS}`));
+                });
+
+                it('with seconds', () => {
+                    const date = adapter.today();
+
+                    expect(formatter.relativeShortDateTime(date, { seconds: true }))
+                        .toBe(adapter.format(date, `Сегодня, ${TIME}:${SECONDS}`));
+                });
             });
         });
 
@@ -242,6 +270,13 @@ describe('Date formatter', () => {
                     expect(formatter.absoluteShortDateTime(date, { milliseconds: true }))
                         .toBe(adapter.format(date, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`));
                 });
+
+                it('absoluteShortDateTime with seconds', () => {
+                    const date = adapter.today();
+
+                    expect(formatter.absoluteShortDateTime(date, { seconds: true }))
+                        .toBe(adapter.format(date, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}`));
+                });
             });
 
             describe('Absolute long (absoluteLongDate/Time method)', () => {
@@ -278,6 +313,13 @@ describe('Date formatter', () => {
 
                     expect(formatter.absoluteLongDateTime(date, { milliseconds: true }))
                         .toBe(date.toFormat(`${DAY_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`));
+                });
+
+                it('absoluteLongDateTime with seconds', () => {
+                    const date = adapter.today();
+
+                    expect(formatter.absoluteLongDateTime(date, { seconds: true }))
+                        .toBe(adapter.format(date, `${DAY_MONTH}, ${TIME}:${SECONDS}`));
                 });
             });
         });
@@ -407,6 +449,28 @@ describe('Date formatter', () => {
                         const endString = adapter.format(endDate, `${DAY_SHORT_MONTH} ${YEAR}, ${TIME}`);
 
                         expect(formatter.rangeShortDateTime(startDate, endDate))
+                            .toBe(`${startString}${LONG_DASH}${endString}`);
+                    });
+
+                    it('rangeShortDateTime (with seconds)', () => {
+                        const startDate = adapter.today().set({ day: 1 });
+                        const endDate = startDate.plus({ days: 10 });
+
+                        const startString = adapter.format(startDate, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}`);
+                        const endString = adapter.format(endDate, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}`);
+
+                        expect(formatter.rangeShortDateTime(startDate, endDate, {seconds: true}))
+                            .toBe(`${startString}${LONG_DASH}${endString}`);
+                    });
+
+                    it('rangeShortDateTime (with milliseconds)', () => {
+                        const startDate = adapter.today().set({ day: 1 });
+                        const endDate = startDate.plus({ days: 10 });
+
+                        const startString = adapter.format(startDate, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`);
+                        const endString = adapter.format(endDate, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`);
+
+                        expect(formatter.rangeShortDateTime(startDate, endDate, {milliseconds: true}))
                             .toBe(`${startString}${LONG_DASH}${endString}`);
                     });
                 });
@@ -700,6 +764,24 @@ describe('Date formatter', () => {
                         expect(formatter.rangeShortDateTime(null, endDate))
                             .toBe(`${UNTIL}${NBSP}${endString}`);
                     });
+
+                    it('rangeShortDateTime (with seconds)', () => {
+
+                        const startDate = adapter.today();
+                        const startString = adapter.format(startDate, `${startDateFormat}:${SECONDS}`);
+
+                        expect(formatter.rangeShortDateTime(startDate, null, {seconds: true}))
+                            .toBe(`${FROM}${NBSP}${startString}`);
+                    });
+
+                    it('rangeShortDateTime (with milliseconds)', () => {
+
+                        const startDate = adapter.today();
+                        const startString = adapter.format(startDate, `${startDateFormat}:${SECONDS}${MILLISECONDS}`);
+
+                        expect(formatter.rangeShortDateTime(startDate, null, {milliseconds: true}))
+                            .toBe(`${FROM}${NBSP}${startString}`);
+                    });
                 });
 
                 describe('Range long (rangeLongDate method)', () => {
@@ -876,6 +958,19 @@ describe('Date formatter', () => {
                         .toBe(adapter.format(date, `${SHORT_MONTH}${NBSP}${DAY}, ${YEAR}`));
                 });
 
+                it('with milliseconds', () => {
+                    const date = adapter.today();
+
+                    expect(formatter.relativeShortDateTime(date, { milliseconds: true }))
+                        .toBe(`Today, ${date.toFormat(`${TIME}:${SECONDS}${MILLISECONDS}`)}`);
+                });
+
+                it('with seconds', () => {
+                    const date = adapter.today();
+
+                    expect(formatter.relativeShortDateTime(date, { seconds: true }))
+                        .toBe(`Today, ${date.toFormat(`${TIME}:${SECONDS}`)}`);
+                });
             });
 
             describe('Relative long (relativeLongDate method)', () => {
@@ -943,6 +1038,20 @@ describe('Date formatter', () => {
                     expect(formatter.relativeLongDate(date))
                         .toBe(adapter.format(date, `${DAY_MONTH}, ${YEAR}`));
                 });
+
+                it('with milliseconds', () => {
+                    const date = adapter.today();
+
+                    expect(formatter.relativeLongDateTime(date, { milliseconds: true }))
+                        .toBe(`Today, ${date.toFormat(`${TIME}:${SECONDS}${MILLISECONDS}`)}`);
+                });
+
+                it('with seconds', () => {
+                    const date = adapter.today();
+
+                    expect(formatter.relativeLongDateTime(date, { seconds: true }))
+                        .toBe(`Today, ${date.toFormat(`${TIME}:${SECONDS}`)}`);
+                });
             });
         });
 
@@ -982,6 +1091,13 @@ describe('Date formatter', () => {
                     expect(formatter.absoluteShortDateTime(date, { milliseconds: true }))
                         .toBe(adapter.format(date, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`));
                 });
+
+                it('absoluteShortDateTime with seconds', () => {
+                    const date = adapter.today();
+
+                    expect(formatter.absoluteShortDateTime(date, { seconds: true }))
+                        .toBe(adapter.format(date, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}`));
+                });
             });
 
             describe('Absolute long (absoluteLongDate/Time method)', () => {
@@ -1018,6 +1134,13 @@ describe('Date formatter', () => {
 
                     expect(formatter.absoluteLongDateTime(date, { milliseconds: true }))
                         .toBe(date.toFormat(`${DAY_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`));
+                });
+
+                it('absoluteLongDateTime with seconds', () => {
+                    const date = adapter.today();
+
+                    expect(formatter.absoluteLongDateTime(date, { seconds: true }))
+                        .toBe(adapter.format(date, `${DAY_MONTH}, ${TIME}:${SECONDS}`));
                 });
             });
         });
@@ -1147,6 +1270,28 @@ describe('Date formatter', () => {
                         const endString = adapter.format(endDate, `${DAY_SHORT_MONTH}, ${YEAR}, ${TIME}`);
 
                         expect(formatter.rangeShortDateTime(startDate, endDate))
+                            .toBe(`${startString}${LONG_DASH}${endString}`);
+                    });
+
+                    it('rangeShortDateTime (with seconds)', () => {
+                        const startDate = adapter.today().set({ day: 1 });
+                        const endDate = startDate.plus({ days: 10 });
+
+                        const startString = adapter.format(startDate, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}`);
+                        const endString = adapter.format(endDate, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}`);
+
+                        expect(formatter.rangeShortDateTime(startDate, endDate, {seconds: true}))
+                            .toBe(`${startString}${LONG_DASH}${endString}`);
+                    });
+
+                    it('rangeShortDateTime (with milliseconds)', () => {
+                        const startDate = adapter.today().set({ day: 1 });
+                        const endDate = startDate.plus({ days: 10 });
+
+                        const startString = adapter.format(startDate, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`);
+                        const endString = adapter.format(endDate, `${DAY_SHORT_MONTH}, ${TIME}:${SECONDS}${MILLISECONDS}`);
+
+                        expect(formatter.rangeShortDateTime(startDate, endDate, {milliseconds: true}))
                             .toBe(`${startString}${LONG_DASH}${endString}`);
                     });
                 });
@@ -1435,6 +1580,24 @@ describe('Date formatter', () => {
 
                         expect(formatter.rangeShortDateTime(null, endDate))
                             .toBe(`${UNTIL}${NBSP}${endString}`);
+                    });
+
+                    it('rangeShortDateTime (with seconds)', () => {
+
+                        const startDate = adapter.today();
+                        const startString = adapter.format(startDate, `${startDateFormat}:${SECONDS}`);
+
+                        expect(formatter.rangeShortDateTime(startDate, null, {seconds: true}))
+                            .toBe(`${FROM}${NBSP}${startString}`);
+                    });
+
+                    it('rangeShortDateTime (with milliseconds)', () => {
+
+                        const startDate = adapter.today();
+                        const startString = adapter.format(startDate, `${startDateFormat}:${SECONDS}${MILLISECONDS}`);
+
+                        expect(formatter.rangeShortDateTime(startDate, null, {milliseconds: true}))
+                            .toBe(`${FROM}${NBSP}${startString}`);
                     });
                 });
 

--- a/packages/mosaic/core/formatters/date/formatter.ts
+++ b/packages/mosaic/core/formatters/date/formatter.ts
@@ -269,9 +269,17 @@ export class DateFormatter<D> {
      * @param startDate - start date
      * @param endDate - end date
      * @param template - template
+     * @param seconds - should time with seconds be shown as well
+     * @param milliseconds - should time with milliseconds be shown as well
      * @returns opened date
      */
-    openedRangeDateTime(startDate: D | null, endDate: D | null, template: FormatterRangeTemplate) {
+    openedRangeDateTime(
+        startDate: D | null,
+        endDate: D | null,
+        template: FormatterRangeTemplate,
+        seconds = false,
+        milliseconds = false
+    ) {
         if (!this.adapter.isDateInstance(startDate) && !this.adapter.isDateInstance(endDate)) {
             throw new Error(this.invalidDateErrorText);
         }
@@ -281,6 +289,8 @@ export class DateFormatter<D> {
 
         if (startDate) {
             const startDateVariables = this.compileVariables(startDate, variables);
+            startDateVariables.SHOW_SECONDS = seconds ? 'yes' : 'no';
+            startDateVariables.SHOW_MILLISECONDS = milliseconds ? 'yes' : 'no';
 
             params = {
                 ...variables,
@@ -289,6 +299,8 @@ export class DateFormatter<D> {
             };
         } else if (endDate) {
             const endDateVariables = this.compileVariables(endDate, variables);
+            endDateVariables.SHOW_SECONDS = seconds ? 'yes' : 'no';
+            endDateVariables.SHOW_MILLISECONDS = milliseconds ? 'yes' : 'no';
 
             params = {
                 ...variables,
@@ -398,14 +410,20 @@ export class DateFormatter<D> {
      * @param options - DateTimeOptions
      * @returns range date in short format with time
      */
-    rangeShortDateTime(startDate: D | null, endDate?: D, options?: DateTimeOptions): string {
+    rangeShortDateTime(startDate: D | null, endDate?: D | null, options?: DateTimeOptions): string {
         const rangeTemplates = this.config.rangeTemplates;
 
         if (startDate && endDate) {
             return this.rangeDateTime(startDate, endDate, rangeTemplates.closedRange.short, options?.seconds, options?.milliseconds);
         }
 
-        return this.openedRangeDateTime(startDate, endDate || null, rangeTemplates.openedRange.short);
+        return this.openedRangeDateTime(
+            startDate,
+            endDate || null,
+            rangeTemplates.openedRange.short,
+            options?.seconds,
+            options?.milliseconds
+        );
     }
 
     /**
@@ -413,7 +431,7 @@ export class DateFormatter<D> {
      * @param endDate - end date
      * @returns range date in long format
      */
-    rangeLongDate(startDate: D | null, endDate?: D): string {
+    rangeLongDate(startDate: D | null, endDate?: D | null): string {
         const rangeTemplates = this.config.rangeTemplates;
 
         if (startDate && endDate) {

--- a/packages/mosaic/core/formatters/date/formatter.ts
+++ b/packages/mosaic/core/formatters/date/formatter.ts
@@ -347,19 +347,20 @@ export class DateFormatter<D> {
 
         const variables = {...this.adapter.config.variables, ...template.variables};
 
-        variables.SHOW_SECONDS = seconds ? 'yes' : 'no';
-        variables.SHOW_MILLISECONDS = milliseconds ? 'yes' : 'no';
-
         const sameMonth = this.hasSame(startDate, endDate, 'month');
         const sameDay = this.hasSame(startDate, endDate, 'day');
 
         const startDateVariables = this.compileVariables(startDate, variables);
         startDateVariables.SAME_MONTH = sameMonth;
         startDateVariables.SAME_DAY = sameDay;
+        startDateVariables.SHOW_SECONDS = seconds ? 'yes' : 'no';
+        startDateVariables.SHOW_MILLISECONDS = milliseconds ? 'yes' : 'no';
 
         const endDateVariables = this.compileVariables(endDate, variables);
         endDateVariables.SAME_MONTH = sameMonth;
         endDateVariables.SAME_DAY = sameDay;
+        endDateVariables.SHOW_SECONDS = seconds ? 'yes' : 'no';
+        endDateVariables.SHOW_MILLISECONDS = milliseconds ? 'yes' : 'no';
 
         const bothCurrentYear = startDateVariables.CURRENT_YEAR === 'yes' && endDateVariables.CURRENT_YEAR === 'yes';
         startDateVariables.CURRENT_YEAR = bothCurrentYear ? 'yes' : 'no';
@@ -449,7 +450,8 @@ export class DateFormatter<D> {
             startDate,
             endDate,
             this.config.rangeTemplates.closedRange.middle,
-            options?.seconds, options?.milliseconds
+            options?.seconds,
+            options?.milliseconds
         );
     }
 

--- a/packages/mosaic/core/formatters/date/formatter.ts
+++ b/packages/mosaic/core/formatters/date/formatter.ts
@@ -115,12 +115,6 @@ export class DateFormatter<D> {
 
         const templateVariables = {...this.adapter.config.variables, ...template.variables};
 
-        if (milliseconds) {
-            templateVariables.TIME += ':ss,SSS';
-        } else if (seconds) {
-            templateVariables.TIME += ':ss';
-        }
-
         if (this.isBeforeYesterday(date)) {
             newTemplate = template.BEFORE_YESTERDAY;
         } else if (this.isYesterday(date)) {
@@ -134,6 +128,9 @@ export class DateFormatter<D> {
         }
 
         const variables = this.compileVariables(date, templateVariables);
+
+        variables.SHOW_SECONDS = seconds ? 'yes' : 'no';
+        variables.SHOW_MILLISECONDS = milliseconds ? 'yes' : 'no';
 
         return this.messageFormat.compile(newTemplate)(variables);
     }
@@ -189,15 +186,10 @@ export class DateFormatter<D> {
     ): string {
         if (!this.adapter.isDateInstance(date)) { throw new Error(this.invalidDateErrorText); }
 
-        const templateVariables = { ...this.adapter.config.variables, ...params.variables };
+        const variables = this.compileVariables(date, { ...this.adapter.config.variables, ...params.variables });
 
-        if (milliseconds) {
-            templateVariables.TIME += ':ss,SSS';
-        } else if (seconds) {
-            templateVariables.TIME += ':ss';
-        }
-
-        const variables = this.compileVariables(date, templateVariables);
+        variables.SHOW_SECONDS = seconds ? 'yes' : 'no';
+        variables.SHOW_MILLISECONDS = milliseconds ? 'yes' : 'no';
 
         const template = datetime ? params.DATETIME : params.DATE;
 
@@ -355,11 +347,8 @@ export class DateFormatter<D> {
 
         const variables = {...this.adapter.config.variables, ...template.variables};
 
-        if (milliseconds) {
-            variables.TIME += ':ss,SSS';
-        } else if (seconds) {
-            variables.TIME += ':ss';
-        }
+        variables.SHOW_SECONDS = seconds ? 'yes' : 'no';
+        variables.SHOW_MILLISECONDS = milliseconds ? 'yes' : 'no';
 
         const sameMonth = this.hasSame(startDate, endDate, 'month');
         const sameDay = this.hasSame(startDate, endDate, 'day');

--- a/packages/mosaic/core/formatters/date/templates/en-US.ts
+++ b/packages/mosaic/core/formatters/date/templates/en-US.ts
@@ -1,17 +1,29 @@
+const SECONDS_TEMPLATE = `{
+    SHOW_MILLISECONDS,
+    select,
+        yes{:{SECONDS}{MILLISECONDS}}
+        other{{
+            SHOW_SECONDS,
+            select,
+                yes{:{SECONDS}}
+                other{}
+        }}
+}`;
+
 export const enUS = {
     relativeTemplates: {
         short: {
-            BEFORE_YESTERDAY: '{CURRENT_YEAR, select, yes{{SHORT_DATE}, {TIME}} other{{SHORT_DATE}, {YEAR}}}',
-            YESTERDAY: 'Yesterday, {TIME}',
-            TODAY: 'Today, {TIME}',
-            TOMORROW: 'Tomorrow, {TIME}',
+            BEFORE_YESTERDAY: `{CURRENT_YEAR, select, yes{{SHORT_DATE}, {TIME}} other{{SHORT_DATE}, {YEAR}}}${SECONDS_TEMPLATE}`,
+            YESTERDAY: `Yesterday, {TIME}${SECONDS_TEMPLATE}`,
+            TODAY: `Today, {TIME}${SECONDS_TEMPLATE}`,
+            TOMORROW: `Tomorrow, {TIME}${SECONDS_TEMPLATE}`,
             AFTER_TOMORROW: '{CURRENT_YEAR, select, yes{{SHORT_DATE}, {TIME}} other{{SHORT_DATE}, {YEAR}}}'
         },
         long: {
-            BEFORE_YESTERDAY: '{CURRENT_YEAR, select, yes{{DATE}, {TIME}} other{{DATE}, {YEAR}}}',
-            YESTERDAY: 'Yesterday, {TIME}',
-            TODAY: 'Today, {TIME}',
-            TOMORROW: 'Tomorrow, {TIME}',
+            BEFORE_YESTERDAY: `{CURRENT_YEAR, select, yes{{DATE}, {TIME}} other{{DATE}, {YEAR}}}${SECONDS_TEMPLATE}`,
+            YESTERDAY: `Yesterday, {TIME}${SECONDS_TEMPLATE}`,
+            TODAY: `Today, {TIME}${SECONDS_TEMPLATE}`,
+            TOMORROW: `Tomorrow, {TIME}${SECONDS_TEMPLATE}`,
             AFTER_TOMORROW: '{CURRENT_YEAR, select, yes{{DATE}, {TIME}} other{{DATE}, {YEAR}}}'
         }
     },
@@ -23,7 +35,7 @@ export const enUS = {
                 select,
                     yes{{SHORT_DATE}, {TIME}}
                     other{{SHORT_DATE}, {YEAR}, {TIME}}
-            }`
+            }${SECONDS_TEMPLATE}`
         },
         long: {
             DATE: '{CURRENT_YEAR, select, yes{{DATE}} other{{DATE}, {YEAR}}}',
@@ -32,7 +44,7 @@ export const enUS = {
                 select,
                     yes{{DATE}, {TIME}}
                     other{{DATE}, {YEAR}, {TIME}}
-            }`
+            }${SECONDS_TEMPLATE}`
         }
     },
     rangeTemplates: {

--- a/packages/mosaic/core/formatters/date/templates/en-US.ts
+++ b/packages/mosaic/core/formatters/date/templates/en-US.ts
@@ -17,14 +17,14 @@ export const enUS = {
             YESTERDAY: `Yesterday, {TIME}${SECONDS_TEMPLATE}`,
             TODAY: `Today, {TIME}${SECONDS_TEMPLATE}`,
             TOMORROW: `Tomorrow, {TIME}${SECONDS_TEMPLATE}`,
-            AFTER_TOMORROW: '{CURRENT_YEAR, select, yes{{SHORT_DATE}, {TIME}} other{{SHORT_DATE}, {YEAR}}}'
+            AFTER_TOMORROW: `{CURRENT_YEAR, select, yes{{SHORT_DATE}, {TIME}} other{{SHORT_DATE}, {YEAR}}}${SECONDS_TEMPLATE}`
         },
         long: {
             BEFORE_YESTERDAY: `{CURRENT_YEAR, select, yes{{DATE}, {TIME}} other{{DATE}, {YEAR}}}${SECONDS_TEMPLATE}`,
             YESTERDAY: `Yesterday, {TIME}${SECONDS_TEMPLATE}`,
             TODAY: `Today, {TIME}${SECONDS_TEMPLATE}`,
             TOMORROW: `Tomorrow, {TIME}${SECONDS_TEMPLATE}`,
-            AFTER_TOMORROW: '{CURRENT_YEAR, select, yes{{DATE}, {TIME}} other{{DATE}, {YEAR}}}'
+            AFTER_TOMORROW: `{CURRENT_YEAR, select, yes{{DATE}, {TIME}} other{{DATE}, {YEAR}}}${SECONDS_TEMPLATE}`
         }
     },
     absoluteTemplates: {
@@ -79,22 +79,22 @@ export const enUS = {
                                 yes{{SHORT_DATE}, {TIME}}
                                 other{{SHORT_DATE}, {YEAR}, {TIME}}
                         }}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 END_DATETIME: `{
                     SAME_DAY,
                     select,
                         yes{{
                             CURRENT_YEAR,
                             select,
-                                yes{{TIME}, {SHORT_DATE}}
-                                other{{TIME}, {SHORT_DATE}, {YEAR}}
+                                yes{{TIME}${SECONDS_TEMPLATE}, {SHORT_DATE}}
+                                other{{TIME}${SECONDS_TEMPLATE}, {SHORT_DATE}, {YEAR}}
                         }}
                         other{{
                             CURRENT_YEAR,
                             select,
                                 yes{{SHORT_DATE}, {TIME}}
                                 other{{SHORT_DATE}, {YEAR}, {TIME}}
-                        }}
+                        }${SECONDS_TEMPLATE}}
                 }`,
                 DATETIME: `{
                     SAME_DAY,
@@ -133,22 +133,22 @@ export const enUS = {
                                 yes{{DATE}, {TIME}}
                                 other{{DATE}, {YEAR}, {TIME}}
                         }}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 END_DATETIME: `{
                     SAME_DAY,
                     select,
                         yes{{
                             CURRENT_YEAR,
                             select,
-                                yes{{TIME}, {DATE}}
-                                other{{TIME}, {DATE}, {YEAR}}
+                                yes{{TIME}${SECONDS_TEMPLATE}, {DATE}}
+                                other{{TIME}${SECONDS_TEMPLATE}, {DATE}, {YEAR}}
                         }}
                         other{{
                             CURRENT_YEAR,
                             select,
                                 yes{{DATE}, {TIME}}
                                 other{{DATE}, {YEAR}, {TIME}}
-                        }}
+                        }${SECONDS_TEMPLATE}}
                 }`,
                 DATETIME: `{
                     SAME_DAY,
@@ -192,7 +192,7 @@ export const enUS = {
                                 yes{{DATE}, {TIME}}
                                 other{{DATE}, {YEAR}, {TIME}}
                         }}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 END_DATETIME: `{
                     SAME_DAY,
                     select,
@@ -203,7 +203,7 @@ export const enUS = {
                                 yes{{DATE}, {TIME}}
                                 other{{DATE}, {YEAR}, {TIME}}
                         }}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 DATETIME: `{
                     SAME_DAY,
                     select,
@@ -233,13 +233,13 @@ export const enUS = {
                     select,
                         yes{{SHORT_DATE}, {TIME}}
                         other{{SHORT_DATE} {YEAR}, {TIME}}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 END_DATETIME: `{
                     CURRENT_YEAR,
                     select,
                         yes{{SHORT_DATE}, {TIME}}
                         other{{SHORT_DATE} {YEAR}, {TIME}}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 DATETIME: `{
                     RANGE_TYPE,
                     select,
@@ -267,13 +267,13 @@ export const enUS = {
                     select,
                         yes{{DATE}, {TIME}}
                         other{{DATE} {YEAR}, {TIME}}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 END_DATETIME: `{
                     CURRENT_YEAR,
                     select,
                         yes{{DATE}, {TIME}}
                         other{{DATE} {YEAR}, {TIME}}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 DATETIME: `{
                     RANGE_TYPE,
                     select,

--- a/packages/mosaic/core/formatters/date/templates/en-US.ts
+++ b/packages/mosaic/core/formatters/date/templates/en-US.ts
@@ -23,11 +23,6 @@ export const enUS = {
                 select,
                     yes{{SHORT_DATE}, {TIME}}
                     other{{SHORT_DATE}, {YEAR}, {TIME}}
-            }{
-                SHOW_MILLISECONDS,
-                select,
-                    yes{:{SECONDS}{MILLISECONDS}}
-                    other{}
             }`
         },
         long: {
@@ -37,11 +32,6 @@ export const enUS = {
                 select,
                     yes{{DATE}, {TIME}}
                     other{{DATE}, {YEAR}, {TIME}}
-            }{
-                SHOW_MILLISECONDS,
-                select,
-                    yes{:{SECONDS}{MILLISECONDS}}
-                    other{}
             }`
         }
     },

--- a/packages/mosaic/core/formatters/date/templates/ru-RU.ts
+++ b/packages/mosaic/core/formatters/date/templates/ru-RU.ts
@@ -23,11 +23,6 @@ export const ruRU = {
                 select,
                     yes{{SHORT_DATE}, {TIME}}
                     other{{SHORT_DATE} {YEAR}, {TIME}}
-            }{
-                SHOW_MILLISECONDS,
-                select,
-                    yes{:{SECONDS}{MILLISECONDS}}
-                    other{}
             }`
         },
         long: {
@@ -37,11 +32,6 @@ export const ruRU = {
                 select,
                     yes{{DATE}, {TIME}}
                     other{{DATE} {YEAR}, {TIME}}
-            }{
-                SHOW_MILLISECONDS,
-                select,
-                    yes{:{SECONDS}{MILLISECONDS}}
-                    other{}
             }`
         }
     },

--- a/packages/mosaic/core/formatters/date/templates/ru-RU.ts
+++ b/packages/mosaic/core/formatters/date/templates/ru-RU.ts
@@ -1,17 +1,29 @@
+const SECONDS_TEMPLATE = `{
+    SHOW_MILLISECONDS,
+    select,
+        yes{:{SECONDS}{MILLISECONDS}}
+        other{{
+            SHOW_SECONDS,
+            select,
+                yes{:{SECONDS}}
+                other{}
+        }}
+}`;
+
 export const ruRU = {
     relativeTemplates: {
         short: {
-            BEFORE_YESTERDAY: '{CURRENT_YEAR, select, yes{{SHORT_DATE}, {TIME}} other{{SHORT_DATE} {YEAR}}}',
-            YESTERDAY: 'Вчера, {TIME}',
-            TODAY: 'Сегодня, {TIME}',
-            TOMORROW: 'Завтра, {TIME}',
+            BEFORE_YESTERDAY: `{CURRENT_YEAR, select, yes{{SHORT_DATE}, {TIME}} other{{SHORT_DATE} {YEAR}}}${SECONDS_TEMPLATE}`,
+            YESTERDAY: `Вчера, {TIME}${SECONDS_TEMPLATE}`,
+            TODAY: `Сегодня, {TIME}${SECONDS_TEMPLATE}`,
+            TOMORROW: `Завтра, {TIME}${SECONDS_TEMPLATE}`,
             AFTER_TOMORROW: '{CURRENT_YEAR, select, yes{{SHORT_DATE}, {TIME}} other{{SHORT_DATE} {YEAR}}}'
         },
         long: {
-            BEFORE_YESTERDAY: '{CURRENT_YEAR, select, yes{{DATE}, {TIME}} other{{DATE} {YEAR}}}',
-            YESTERDAY: 'Вчера, {TIME}',
-            TODAY: 'Сегодня, {TIME}',
-            TOMORROW: 'Завтра, {TIME}',
+            BEFORE_YESTERDAY: `{CURRENT_YEAR, select, yes{{DATE}, {TIME}} other{{DATE} {YEAR}}}${SECONDS_TEMPLATE}`,
+            YESTERDAY: `Вчера, {TIME}${SECONDS_TEMPLATE}`,
+            TODAY: `Сегодня, {TIME}${SECONDS_TEMPLATE}`,
+            TOMORROW: `Завтра, {TIME}${SECONDS_TEMPLATE}`,
             AFTER_TOMORROW: '{CURRENT_YEAR, select, yes{{DATE}, {TIME}} other{{DATE} {YEAR}}}'
         }
     },
@@ -23,7 +35,7 @@ export const ruRU = {
                 select,
                     yes{{SHORT_DATE}, {TIME}}
                     other{{SHORT_DATE} {YEAR}, {TIME}}
-            }`
+            }${SECONDS_TEMPLATE}`
         },
         long: {
             DATE: '{CURRENT_YEAR, select, yes{{DATE}} other{{DATE} {YEAR}}}',
@@ -32,7 +44,7 @@ export const ruRU = {
                 select,
                     yes{{DATE}, {TIME}}
                     other{{DATE} {YEAR}, {TIME}}
-            }`
+            }${SECONDS_TEMPLATE}`
         }
     },
     rangeTemplates: {

--- a/packages/mosaic/core/formatters/date/templates/ru-RU.ts
+++ b/packages/mosaic/core/formatters/date/templates/ru-RU.ts
@@ -17,14 +17,14 @@ export const ruRU = {
             YESTERDAY: `Вчера, {TIME}${SECONDS_TEMPLATE}`,
             TODAY: `Сегодня, {TIME}${SECONDS_TEMPLATE}`,
             TOMORROW: `Завтра, {TIME}${SECONDS_TEMPLATE}`,
-            AFTER_TOMORROW: '{CURRENT_YEAR, select, yes{{SHORT_DATE}, {TIME}} other{{SHORT_DATE} {YEAR}}}'
+            AFTER_TOMORROW: `{CURRENT_YEAR, select, yes{{SHORT_DATE}, {TIME}} other{{SHORT_DATE} {YEAR}}}${SECONDS_TEMPLATE}`
         },
         long: {
             BEFORE_YESTERDAY: `{CURRENT_YEAR, select, yes{{DATE}, {TIME}} other{{DATE} {YEAR}}}${SECONDS_TEMPLATE}`,
             YESTERDAY: `Вчера, {TIME}${SECONDS_TEMPLATE}`,
             TODAY: `Сегодня, {TIME}${SECONDS_TEMPLATE}`,
             TOMORROW: `Завтра, {TIME}${SECONDS_TEMPLATE}`,
-            AFTER_TOMORROW: '{CURRENT_YEAR, select, yes{{DATE}, {TIME}} other{{DATE} {YEAR}}}'
+            AFTER_TOMORROW: `{CURRENT_YEAR, select, yes{{DATE}, {TIME}} other{{DATE} {YEAR}}}${SECONDS_TEMPLATE}`
         }
     },
     absoluteTemplates: {
@@ -79,22 +79,22 @@ export const ruRU = {
                                 yes{{SHORT_DATE}, {TIME}}
                                 other{{SHORT_DATE} {YEAR}, {TIME}}
                         }}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 END_DATETIME: `{
                     SAME_DAY,
                     select,
                         yes{{
                             CURRENT_YEAR,
                             select,
-                                yes{{TIME}, {SHORT_DATE}}
-                                other{{TIME}, {SHORT_DATE} {YEAR}}
+                                yes{{TIME}${SECONDS_TEMPLATE}, {SHORT_DATE}}
+                                other{{TIME}${SECONDS_TEMPLATE}, {SHORT_DATE} {YEAR}}
                         }}
                         other{{
                             CURRENT_YEAR,
                             select,
                                 yes{{SHORT_DATE}, {TIME}}
                                 other{{SHORT_DATE} {YEAR}, {TIME}}
-                        }}
+                        }${SECONDS_TEMPLATE}}
                 }`,
                 DATETIME: `{
                     SAME_DAY,
@@ -133,22 +133,22 @@ export const ruRU = {
                                 yes{{DATE}, {TIME}}
                                 other{{DATE} {YEAR}, {TIME}}
                         }}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 END_DATETIME: `{
                     SAME_DAY,
                     select,
                         yes{{
                             CURRENT_YEAR,
                             select,
-                                yes{{TIME}, {DATE}}
-                                other{{TIME}, {DATE} {YEAR}}
+                                yes{{TIME}${SECONDS_TEMPLATE}, {DATE}}
+                                other{{TIME}${SECONDS_TEMPLATE}, {DATE} {YEAR}}
                         }}
                         other{{
                             CURRENT_YEAR,
                             select,
                                 yes{{DATE}, {TIME}}
                                 other{{DATE} {YEAR}, {TIME}}
-                        }}
+                        }${SECONDS_TEMPLATE}}
                 }`,
                 DATETIME: `{
                     SAME_DAY,
@@ -192,7 +192,7 @@ export const ruRU = {
                                 yes{{DATE}, {TIME}}
                                 other{{DATE} {YEAR}, {TIME}}
                         }}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 END_DATETIME: `{
                     SAME_DAY,
                     select,
@@ -203,7 +203,7 @@ export const ruRU = {
                                 yes{{DATE}, {TIME}}
                                 other{{DATE} {YEAR}, {TIME}}
                         }}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 DATETIME: `{
                     SAME_DAY,
                     select,
@@ -233,13 +233,13 @@ export const ruRU = {
                     select,
                         yes{{SHORT_DATE}, {TIME}}
                         other{{SHORT_DATE} {YEAR}, {TIME}}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 END_DATETIME: `{
                     CURRENT_YEAR,
                     select,
                         yes{{SHORT_DATE}, {TIME}}
                         other{{SHORT_DATE} {YEAR}, {TIME}}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 DATETIME: `{
                     RANGE_TYPE,
                     select,
@@ -267,13 +267,13 @@ export const ruRU = {
                     select,
                         yes{{DATE}, {TIME}}
                         other{{DATE} {YEAR}, {TIME}}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 END_DATETIME: `{
                     CURRENT_YEAR,
                     select,
                         yes{{DATE}, {TIME}}
                         other{{DATE} {YEAR}, {TIME}}
-                }`,
+                }${SECONDS_TEMPLATE}`,
                 DATETIME: `{
                     RANGE_TYPE,
                     select,

--- a/tools/public_api_guard/mosaic/core.api.md
+++ b/tools/public_api_guard/mosaic/core.api.md
@@ -122,13 +122,13 @@ export class DateFormatter<D> {
     // (undocumented)
     openedRangeDate(startDate: D | null, endDate: D | null, template: FormatterRangeTemplate): string;
     // (undocumented)
-    openedRangeDateTime(startDate: D | null, endDate: D | null, template: FormatterRangeTemplate): string;
+    openedRangeDateTime(startDate: D | null, endDate: D | null, template: FormatterRangeTemplate, seconds?: boolean, milliseconds?: boolean): string;
     // (undocumented)
     rangeDate(startDate: D, endDate: D, template: FormatterRangeTemplate): string;
     // (undocumented)
     rangeDateTime(startDate: D, endDate: D, template: FormatterRangeTemplate, seconds?: boolean, milliseconds?: boolean): string;
     // (undocumented)
-    rangeLongDate(startDate: D | null, endDate?: D): string;
+    rangeLongDate(startDate: D | null, endDate?: D | null): string;
     // (undocumented)
     rangeLongDateTime(startDate: D | null, endDate?: D, options?: DateTimeOptions): string;
     // (undocumented)
@@ -136,7 +136,7 @@ export class DateFormatter<D> {
     // (undocumented)
     rangeShortDate(startDate: D | null, endDate?: D): string;
     // (undocumented)
-    rangeShortDateTime(startDate: D | null, endDate?: D, options?: DateTimeOptions): string;
+    rangeShortDateTime(startDate: D | null, endDate?: D | null, options?: DateTimeOptions): string;
     // (undocumented)
     relativeDate(date: D, template: FormatterRelativeTemplate, seconds?: boolean, milliseconds?: boolean): string;
     // (undocumented)

--- a/tools/public_api_guard/mosaic/core.api.md
+++ b/tools/public_api_guard/mosaic/core.api.md
@@ -45,12 +45,6 @@ import { Validator } from '@angular/forms';
 import { ViewContainerRef } from '@angular/core';
 
 // @public (undocumented)
-export interface AbsoluteDateTimeOptions {
-    // (undocumented)
-    milliseconds?: boolean;
-}
-
-// @public (undocumented)
 export enum AnimationCurves {
     // (undocumented)
     AccelerationCurve = "cubic-bezier(0.4,0.0,1,1)",
@@ -114,15 +108,15 @@ export function countGroupLabelsBeforeOption(optionIndex: number, options: Query
 export class DateFormatter<D> {
     constructor(adapter: DateAdapter<D>, locale: string);
     // (undocumented)
-    absoluteDate(date: D, params: FormatterAbsoluteTemplate, datetime?: boolean, milliseconds?: boolean): string;
+    absoluteDate(date: D, params: FormatterAbsoluteTemplate, datetime?: boolean, seconds?: boolean, milliseconds?: boolean): string;
     // (undocumented)
     absoluteLongDate(date: D): string;
     // (undocumented)
-    absoluteLongDateTime(date: D, options?: AbsoluteDateTimeOptions): string;
+    absoluteLongDateTime(date: D, options?: DateTimeOptions): string;
     // (undocumented)
     absoluteShortDate(date: D): string;
     // (undocumented)
-    absoluteShortDateTime(date: D, options?: AbsoluteDateTimeOptions): string;
+    absoluteShortDateTime(date: D, options?: DateTimeOptions): string;
     // (undocumented)
     config: FormatterConfig;
     // (undocumented)
@@ -132,29 +126,41 @@ export class DateFormatter<D> {
     // (undocumented)
     rangeDate(startDate: D, endDate: D, template: FormatterRangeTemplate): string;
     // (undocumented)
-    rangeDateTime(startDate: D, endDate: D, template: FormatterRangeTemplate): string;
+    rangeDateTime(startDate: D, endDate: D, template: FormatterRangeTemplate, seconds?: boolean, milliseconds?: boolean): string;
     // (undocumented)
     rangeLongDate(startDate: D | null, endDate?: D): string;
     // (undocumented)
-    rangeLongDateTime(startDate: D | null, endDate?: D): string;
+    rangeLongDateTime(startDate: D | null, endDate?: D, options?: DateTimeOptions): string;
     // (undocumented)
-    rangeMiddleDateTime(startDate: D, endDate: D): string;
+    rangeMiddleDateTime(startDate: D, endDate: D, options?: DateTimeOptions): string;
     // (undocumented)
     rangeShortDate(startDate: D | null, endDate?: D): string;
     // (undocumented)
-    rangeShortDateTime(startDate: D | null, endDate?: D): string;
+    rangeShortDateTime(startDate: D | null, endDate?: D, options?: DateTimeOptions): string;
     // (undocumented)
-    relativeDate(date: D, template: FormatterRelativeTemplate): string;
+    relativeDate(date: D, template: FormatterRelativeTemplate, seconds?: boolean, milliseconds?: boolean): string;
     // (undocumented)
     relativeLongDate(date: D): string;
     // (undocumented)
+    relativeLongDateTime(date: D, options?: DateTimeOptions): string;
+    // (undocumented)
     relativeShortDate(date: D): string;
+    // (undocumented)
+    relativeShortDateTime(date: D, options?: DateTimeOptions): string;
     // (undocumented)
     setLocale(locale: string): void;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<DateFormatter<any>, never>;
     // (undocumented)
     static ɵprov: i0.ɵɵInjectableDeclaration<DateFormatter<any>>;
+}
+
+// @public (undocumented)
+export interface DateTimeOptions {
+    // (undocumented)
+    milliseconds?: boolean;
+    // (undocumented)
+    seconds?: boolean;
 }
 
 // @public (undocumented)


### PR DESCRIPTION
@lskramarov Добавил объект options с seconds и milliseconds в аргументы всех методов, оканчивающихся на DateTime.

Я думаю, что в доках нет смысла добавлять секунды и миллисекунды во все форматы, получится слишком громоздко.

Лучше сделать снизу отдельный раздел, и в нём написать, что все DateTime методы принимают [DateTimeOptions](https://github.com/positive-js/mosaic/compare/master...oburdasov:feature/UIM-781?expand=1#diff-a9fb7c6ecfea87eedb969444d15d2e96b951828b4ab4bc5228e36658f784eb62R49)