### PR TITLE
feat(formatter): fix relative dates (#UIM-853)

### DIFF
--- a/packages/mosaic/core/formatters/date/formatter.spec.ts
+++ b/packages/mosaic/core/formatters/date/formatter.spec.ts
@@ -12,7 +12,7 @@ import { DateTime, DurationUnit } from 'luxon';
 describe('Date formatter', () => {
     let adapter: LuxonDateAdapter;
     let formatter: DateFormatter<DateTime>;
-    let currentDate: DateTime;
+    let currentDate: any;
 
     const mockAdapterAndFormatterForRelativeTests = () => {
         // @ts-ignore
@@ -41,7 +41,11 @@ describe('Date formatter', () => {
         adapter = d;
         formatter = f;
 
-        currentDate = adapter.createDateTime(2000, 10, 10, 10, 0, 0, 0);
+        currentDate = adapter.today();
+        currentDate.c.hour = 0;
+        currentDate.c.minute = 0;
+        currentDate.c.second = 0;
+        currentDate.c.millisecond = 0;
     }));
 
     const YEAR = 'yyyy';
@@ -132,7 +136,7 @@ describe('Date formatter', () => {
                 });
 
                 it('after tomorrow (other year)', () => {
-                    const date = currentDate.plus({ hours: 49 });
+                    const date = currentDate.plus({ year: 1 });
                     expect(formatter.relativeShortDate(date))
                         .toBe(adapter.format(date, `${DAY}${NBSP}${SHORT_MONTH} ${YEAR}`));
                 });
@@ -140,7 +144,7 @@ describe('Date formatter', () => {
 
             describe('Relative long (relativeLongDate method)', () => {
                 it('before yesterday (other year)', () => {
-                    const date = currentDate.minus({ hours: 49 });
+                    const date = currentDate.minus({ year: 1 });
                     expect(formatter.relativeLongDate(date))
                         .toBe(adapter.format(date, `${DAY_MONTH} ${YEAR}`));
                 });
@@ -199,7 +203,7 @@ describe('Date formatter', () => {
                 });
 
                 it('after tomorrow (other year)', () => {
-                    const date = currentDate.plus({ hours: 49 });
+                    const date = currentDate.plus({ year: 1 });
                     expect(formatter.relativeLongDate(date))
                         .toBe(adapter.format(date, `${DAY_MONTH} ${YEAR}`));
                 });

--- a/packages/mosaic/core/formatters/date/formatter.ts
+++ b/packages/mosaic/core/formatters/date/formatter.ts
@@ -105,11 +105,18 @@ export class DateFormatter<D> {
     relativeDate(date: D, template: FormatterRelativeTemplate): string {
         if (!this.adapter.isDateInstance(date)) { throw new Error(this.invalidDateErrorText); }
 
+        const dayStart: any = this.adapter.today();
+        dayStart.c.hour = 0;
+        dayStart.c.minute = 0;
+        dayStart.c.second = 0;
+        dayStart.c.millisecond = 0;
+
         const isBeforeYesterday = this.adapter.diffNow(date, 'days') <= -2;
         const isYesterday = this.adapter.diffNow(date, 'days') <= -1 && this.adapter.diffNow(date, 'days') > -2;
         const isToday = this.adapter.hasSame(this.adapter.today(), date, 'days');
-        const isTomorrow = this.adapter.diffNow(date, 'days') >= 1 && this.adapter.diffNow(date, 'days') < 2;
-        const isAfterTomorrow = this.adapter.diffNow(date, 'days') > 1;
+        const isTomorrow = this.adapter.compareDateTime(date, dayStart) >= 1 && this.adapter.compareDateTime(date, dayStart) < 2
+            && this.adapter.hasSame(this.adapter.today(), date, 'years');
+        const isAfterTomorrow = this.adapter.compareDateTime(date, dayStart) >= 2 || !this.adapter.hasSame(this.adapter.today(), date, 'years');
 
         const templateVariables = {...this.adapter.config.variables, ...template.variables};
         const variables = this.compileVariables(date, templateVariables);


### PR DESCRIPTION
По предыдущей логике, если сейчас, допустим, 12:00, а переданная date на два дня позже и раньше 12:00 то ` this.adapter.diffNow(date, 'days')` выдаст меньше 2, и дату распознает как isTomorrow.

Сравнивать нужно не с текущим моментом, а с началом дня, что я и попытался сделать костыльным образом, за неимением подходящих методов в адаптере