### PR TITLE
feat(table): use tabular styles for body content by default

### DIFF
--- a/packages/mosaic/design-tokens/legacy-2017/tokens/components/table.json5
+++ b/packages/mosaic/design-tokens/legacy-2017/tokens/components/table.json5
@@ -9,7 +9,7 @@
         },
         font: {
             header: { value: 'caption' },
-            body: { value: 'body' }
+            body: { value: 'body-tabular' }
         }
     }
 }

--- a/packages/mosaic/design-tokens/pt-2022/tokens/components/table.json5
+++ b/packages/mosaic/design-tokens/pt-2022/tokens/components/table.json5
@@ -9,7 +9,7 @@
         },
         font: {
             header: { value: 'caption' },
-            body: { value: 'body' }
+            body: { value: 'body-tabular' }
         }
     }
 }


### PR DESCRIPTION
В PR где делали табличные стили забыл это изменение. Оно не исправляет все таблицы, но по дефолту так точно будет лучше.