### PR TITLE
fix(tree): tree toggle padding (UIM-637)

### DIFF
--- a/packages/mosaic/tree/padding.directive.ts
+++ b/packages/mosaic/tree/padding.directive.ts
@@ -72,7 +72,7 @@ export class McTreeNodePadding<T> implements OnInit, OnDestroy {
     }
 
     ngOnInit(): void {
-        this.withIcon = this.tree.treeControl.isExpandable(this.treeNode.data);
+        this.withIcon = this.element.nativeElement.querySelector('i[mctreenodetoggle]:first-child') !== null;
 
         this.setPadding();
     }

--- a/packages/mosaic/tree/padding.directive.ts
+++ b/packages/mosaic/tree/padding.directive.ts
@@ -1,11 +1,11 @@
 import { Directionality } from '@angular/cdk/bidi';
 import { coerceNumberProperty } from '@angular/cdk/coercion';
 import {
+    AfterViewInit,
     Directive,
     ElementRef,
     Input,
     OnDestroy,
-    OnInit,
     Optional,
     Renderer2
 } from '@angular/core';
@@ -14,6 +14,7 @@ import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 
 import { McTreeBase, McTreeNode } from './tree-base';
+import { McTreeOption } from './tree-option.component';
 
 
 /** Regex used to split a string on its CSS units. */
@@ -24,7 +25,7 @@ const cssUnitPattern = /([A-Za-z%]+)$/;
     selector: '[mcTreeNodePadding]',
     exportAs: 'mcTreeNodePadding'
 })
-export class McTreeNodePadding<T> implements OnInit, OnDestroy {
+export class McTreeNodePadding<T> implements OnDestroy, AfterViewInit {
     get level(): number {
         return this._level;
     }
@@ -65,15 +66,15 @@ export class McTreeNodePadding<T> implements OnInit, OnDestroy {
         protected tree: McTreeBase<T>,
         private renderer: Renderer2,
         private element: ElementRef<HTMLElement>,
+        private option: McTreeOption,
         @Optional() private dir: Directionality
     ) {
         this.dir?.change?.pipe(takeUntil(this.destroyed))
             .subscribe(() => this.setPadding());
     }
 
-    ngOnInit(): void {
-        this.withIcon = this.element.nativeElement.querySelector('i[mctreenodetoggle]:first-child') !== null;
-
+    ngAfterViewInit(): void {
+        this.withIcon = !!this.option.toggleElement;
         this.setPadding();
     }
 

--- a/packages/mosaic/tree/tree-option.component.ts
+++ b/packages/mosaic/tree/tree-option.component.ts
@@ -9,11 +9,12 @@ import {
     ElementRef,
     Inject,
     InjectionToken,
-    ChangeDetectionStrategy,
+    
     ViewEncapsulation,
     AfterContentInit,
     NgZone,
-    ContentChild
+    ContentChild,
+    ChangeDetectionStrategy
 } from '@angular/core';
 import { hasModifierKey, TAB } from '@ptsecurity/cdk/keycodes';
 import {
@@ -26,7 +27,7 @@ import { McTooltipTrigger } from '@ptsecurity/mosaic/tooltip';
 import { Subject } from 'rxjs';
 import { take } from 'rxjs/operators';
 
-import { McTreeNodeToggleBaseDirective } from './toggle';
+import { McTreeNodeToggleDirective } from './toggle';
 import { McTreeNode } from './tree-base';
 
 
@@ -79,8 +80,7 @@ export class McTreeOption extends McTreeNode<McTreeOption> implements AfterConte
 
     readonly onBlur = new Subject<McTreeOptionEvent>();
 
-    @ContentChild('mcTreeNodeToggle') toggleElement: McTreeNodeToggleBaseDirective<McTreeOption>;
-
+    @ContentChild(McTreeNodeToggleDirective) toggleElement: McTreeNodeToggleDirective<McTreeOption>;
     @ContentChild(McPseudoCheckbox) pseudoCheckbox: McPseudoCheckbox;
     @ContentChild(McOptionActionComponent) actionButton: McOptionActionComponent;
     @ContentChild(McTooltipTrigger) tooltipTrigger: McTooltipTrigger;

--- a/packages/mosaic/tree/tree-option.component.ts
+++ b/packages/mosaic/tree/tree-option.component.ts
@@ -9,7 +9,6 @@ import {
     ElementRef,
     Inject,
     InjectionToken,
-    
     ViewEncapsulation,
     AfterContentInit,
     NgZone,

--- a/tools/public_api_guard/mosaic/tree.api.md
+++ b/tools/public_api_guard/mosaic/tree.api.md
@@ -6,6 +6,7 @@
 
 import { AfterContentChecked } from '@angular/core';
 import { AfterContentInit } from '@angular/core';
+import { AfterViewInit } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
 import { CanDisable } from '@ptsecurity/mosaic/core';
 import { CanDisableCtor } from '@ptsecurity/mosaic/core';
@@ -304,8 +305,8 @@ export class McTreeNodeOutletContext<T> {
 }
 
 // @public (undocumented)
-export class McTreeNodePadding<T> implements OnInit, OnDestroy {
-    constructor(treeNode: McTreeNode<T>, tree: McTreeBase<T>, renderer: Renderer2, element: ElementRef<HTMLElement>, dir: Directionality);
+export class McTreeNodePadding<T> implements OnDestroy, AfterViewInit {
+    constructor(treeNode: McTreeNode<T>, tree: McTreeBase<T>, renderer: Renderer2, element: ElementRef<HTMLElement>, option: McTreeOption, dir: Directionality);
     // (undocumented)
     baseLeftPadding: number;
     // (undocumented)
@@ -320,9 +321,9 @@ export class McTreeNodePadding<T> implements OnInit, OnDestroy {
     get level(): number;
     set level(value: number);
     // (undocumented)
-    ngOnDestroy(): void;
+    ngAfterViewInit(): void;
     // (undocumented)
-    ngOnInit(): void;
+    ngOnDestroy(): void;
     // (undocumented)
     paddingIndent(): string | null;
     // (undocumented)
@@ -334,7 +335,7 @@ export class McTreeNodePadding<T> implements OnInit, OnDestroy {
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<McTreeNodePadding<any>, "[mcTreeNodePadding]", ["mcTreeNodePadding"], { "indent": "mcTreeNodePaddingIndent"; }, {}, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<McTreeNodePadding<any>, [null, null, null, null, { optional: true; }]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<McTreeNodePadding<any>, [null, null, null, null, null, { optional: true; }]>;
 }
 
 // @public (undocumented)
@@ -437,7 +438,7 @@ export class McTreeOption extends McTreeNode<McTreeOption> implements AfterConte
     // (undocumented)
     toggle(): void;
     // (undocumented)
-    toggleElement: McTreeNodeToggleBaseDirective<McTreeOption>;
+    toggleElement: McTreeNodeToggleDirective<McTreeOption>;
     // (undocumented)
     tooltipTrigger: McTooltipTrigger;
     // (undocumented)


### PR DESCRIPTION
Если опшен содержит дочерние элементы, то отступ убирался, для того чтобы правильно расположить тоггл.
Но тоггл мог находиться не перед контентом, тогда отступ убирать ненужно.